### PR TITLE
Release libtropic on tag action

### DIFF
--- a/.github/workflows/release_new_version.yml
+++ b/.github/workflows/release_new_version.yml
@@ -1,0 +1,51 @@
+name: Release new libtropic version on tag creation
+on:
+  push:
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+  check_tag_branch:
+    runs-on: ubuntu-22.04
+    outputs:
+      do_release: ${{ steps.check_tag_is_on_master.outputs.DO_RELEASE }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 0  # Ensure full history is available
+
+      - name: Check tag is on master
+        id: check_tag_is_on_master
+        run: |
+            TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref_name }})
+            if git branch -r --contains "$TAG_COMMIT" | grep -q "origin/master"; then
+              echo "DO_RELEASE=true" >> $GITHUB_OUTPUT
+            else
+              echo "DO_RELEASE=false" >> $GITHUB_OUTPUT
+            fi
+
+  create_release:
+    needs: check_tag_branch
+    runs-on: ubuntu-22.04
+    if: ${{ needs.check_tag_branch.outputs.do_release == 'true' }}  # Skip release if tag is not on master
+
+    steps:
+      - name: Get tag 
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Parse changelog for tag version  # Run script creates new file with parsed changelog
+        run: |
+            python3 scripts/parse_changelog.py $TAG_NAME
+
+      - name: Create release
+        uses: actions/create-release@v1.1.4
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          release_name: "libtropic-${{ env.TAG_NAME }}"
+          body_path: CHANGELOG_parsed.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_new_version.yml
+++ b/.github/workflows/release_new_version.yml
@@ -32,12 +32,17 @@ jobs:
     if: ${{ needs.check_tag_branch.outputs.do_release == 'true' }}  # Skip release if tag is not on master
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 0  # Ensure full history is available
+
       - name: Get tag 
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Parse changelog for tag version  # Run script creates new file with parsed changelog
         run: |
-            python3 scripts/parse_changelog.py $TAG_NAME
+            python3 scripts/parse_changelog.py --version $TAG_NAME
 
       - name: Create release
         uses: actions/create-release@v1.1.4

--- a/scripts/parse_changelog.py
+++ b/scripts/parse_changelog.py
@@ -1,0 +1,46 @@
+import argparse
+import re
+import pathlib
+
+CHANGELOG_PATH = pathlib.Path(__file__).parent.parent.joinpath("CHANGELOG.md")
+
+# Regular expressions for searched contents
+VERSION_RE = re.compile(r'^v?(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$')
+
+def CURRENT_CHANGELOG_RE(version: str):
+    return re.compile(
+        r'(?P<current_changelog>##\s+\[' + re.escape(version) + r'\].+?)\s*(?:\n##\s+\[[0-9]+\.[0-9]+\.[0-9]+\]|$)',
+        re.DOTALL
+    )
+
+# Handling of input argument
+def version_type(arg):
+    res = VERSION_RE.search(arg)
+    if not res:
+        raise argparse.ArgumentTypeError("Wrong format of version.")
+    return res.group("version")
+
+if __name__ == "__main__":
+    # Register argument parser, argument and parse
+    parser = argparse.ArgumentParser(
+        description = "Parses CHANGELOG.md and extracts changes for a specific version."
+    )
+
+    parser.add_argument(
+        "-v", "--version",
+        help     = "Specify number of the version.",
+        action   = "store",
+        type     = version_type,
+        required = True
+    )
+
+    args = parser.parse_args()
+
+    # Search for given version in changelog
+    parsed_changelog = CURRENT_CHANGELOG_RE(args.version).search(CHANGELOG_PATH.read_text())
+    if not parsed_changelog:
+        raise ValueError(f"Could not find version '{args.version}' in file '{CHANGELOG_PATH}'.")
+
+    # Write parsed changelog to file
+    out_path = pathlib.Path(CHANGELOG_PATH.parent.joinpath(f"CHANGELOG_parsed.md"))
+    out_path.write_text(parsed_changelog.group("current_changelog"))


### PR DESCRIPTION
Added:
1. `scripts/parse_changelog.py`: Parses the `CHANGELOG.md` file for a specific version and saves the result to `CHANGELOG_parsed.md`. It accepts the version as an input argument.
2. `.github/workflows/release_new_version.yml`: Releases libtropic on a tag creation with format `vN.N.N`, where N is any number. It implements two jobs. First job checks if the tag is on master. The second job is run only if the tag is on master and runs the new Python script. The release is then created from the parsed changelog.