### PR TITLE
Fixed RNG initialization for L432KC

### DIFF
--- a/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
+++ b/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
@@ -62,6 +62,13 @@ lt_ret_t lt_port_init(lt_handle_t *h)
     UNUSED(h);
 
     // RNG
+    rng.Instance = RNG;
+    
+    if (HAL_RNG_DeInit(&rng) != HAL_OK)
+    {
+        return LT_FAIL;
+    }
+
     if (HAL_RNG_Init(&rng) != HAL_OK) {
         return LT_FAIL;
     }


### PR DESCRIPTION
Without this initialization RNG initialization failed.