### PR TITLE
Fix LT_ASSERT value

### DIFF
--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -30,16 +30,16 @@
 #define LT_LOG_SYSTEM(f_, ...) printf("%d\t;SYSTEM;" f_ "\r\n", __LINE__, ##__VA_ARGS__)
 
 // Assertions. Will log as a system message.
-#define LT_ASSERT(expected, value)              \
-{                                               \
-    int _val_ = (value);                        \
-    if (_val_ == expected) {                    \
-        LT_LOG_SYSTEM("ASSERT_OK");             \
-    }                                           \
-    else {                                      \
-        LT_LOG_SYSTEM("ASSERT_FAIL %d", _val_); \
-    };                                          \
-}
+#define LT_ASSERT(expected, value)                  \
+    {                                               \
+        int _val_ = (value);                        \
+        if (_val_ == expected) {                    \
+            LT_LOG_SYSTEM("ASSERT_OK");             \
+        }                                           \
+        else {                                      \
+            LT_LOG_SYSTEM("ASSERT_FAIL %d", _val_); \
+        };                                          \
+    }
 
 #define LT_ASSERT_COND(value, condition, expected_if_true, expected_if_false) \
     if (value == (condition ? expected_if_true : expected_if_false)) {        \

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -31,12 +31,15 @@
 
 // Assertions. Will log as a system message.
 #define LT_ASSERT(expected, value)              \
-    if (value == expected) {                    \
+{                                               \
+    int _val_ = (value);                        \
+    if (_val_ == expected) {                    \
         LT_LOG_SYSTEM("ASSERT_OK");             \
     }                                           \
     else {                                      \
-        LT_LOG_SYSTEM("ASSERT_FAIL %d", value); \
-    };
+        LT_LOG_SYSTEM("ASSERT_FAIL %d", _val_); \
+    };                                          \
+}
 
 #define LT_ASSERT_COND(value, condition, expected_if_true, expected_if_false) \
     if (value == (condition ? expected_if_true : expected_if_false)) {        \


### PR DESCRIPTION
In the macro LT_ASSERT(expected, value), if the value is a function, it is called twice. This is a little problem when the function itself prints something, then it is printed twice, but potentionally could be a bigger problem elsewhere.

The solution is to save value to a variable.