### PR TITLE
feat(libtropic_logging.h): insert assert() into LT_ASSERT*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code formatted with `clang-format` version 16 is now enforced on push to branch
 - Moved logging and assert macros to `libtropic_logging.h` (they were defined twice in
 files `libtropic_examples.h`, `libtropic_functional_tests.h`)
+- Added macro `LT_USE_ASSERT`, based on which `assert()` is inserted into `LT_ASSERT` and `LT_ASSERT_COND`
 
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(LT_HELPERS "Compile helper function" ON)
 # host will be notified by INT pin when response is ready.
 option(LT_USE_INT_PIN "Use INT pin instead of polling for TROPIC01's response" OFF)
 option(LT_SEPARATE_L3_BUFF "Define L3 buffer separately out of the handle" OFF)
+option(LT_USE_ASSERT "Insert assert() into LT_ASSERT/LT_ASSERT_COND" OFF)
 
 # Check if cryptography provider is defined
 if(
@@ -198,4 +199,8 @@ endif()
 
 if(LT_SEPARATE_L3_BUFF)
     target_compile_definitions(tropic PRIVATE LT_SEPARATE_L3_BUFF)
+endif()
+
+if(LT_USE_ASSERT)
+    target_compile_definitions(tropic PUBLIC LT_USE_ASSERT)
 endif()

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,4 +194,7 @@ option(LT_ENABLE_FW_UPDATE "Enable firmware update functions and compile firmwar
 
 # Build libtropic documentation
 -DLT_BUILD_DOCS=1
+
+# Use assert() in macros LT_ASSERT and LT_ASSERT_COND (handy for the Unix port)
+-DLT_USE_ASSERT=1
 ```

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -10,6 +10,9 @@
  */
 
 #include <stdio.h>
+#ifdef LT_USE_ASSERT
+#include <assert.h>
+#endif
 
 // Only info-level loggers and decorators.
 // This has no effect, test runner just simply copies these lines to the log.
@@ -30,6 +33,9 @@
 #define LT_LOG_SYSTEM(f_, ...) printf("%d\t;SYSTEM;" f_ "\r\n", __LINE__, ##__VA_ARGS__)
 
 // Assertions. Will log as a system message.
+#ifdef LT_USE_ASSERT
+#define LT_ASSERT(expected, value) assert(expected == value);
+#else
 #define LT_ASSERT(expected, value)                  \
     {                                               \
         int _val_ = (value);                        \
@@ -40,7 +46,12 @@
             LT_LOG_SYSTEM("ASSERT_FAIL %d", _val_); \
         };                                          \
     }
+#endif
 
+#ifdef LT_USE_ASSERT
+#define LT_ASSERT_COND(value, condition, expected_if_true, expected_if_false) \
+    assert(value == (condition ? expected_if_true : expected_if_false));
+#else
 #define LT_ASSERT_COND(value, condition, expected_if_true, expected_if_false) \
     if (value == (condition ? expected_if_true : expected_if_false)) {        \
         LT_LOG_SYSTEM("ASSERT_OK");                                           \
@@ -48,6 +59,8 @@
     else {                                                                    \
         LT_LOG_SYSTEM("ASSERT_FAIL");                                         \
     }
+#endif
+
 // Used to stop the test. Will log as a system message.
 #define LT_FINISH_TEST() LT_LOG_SYSTEM("TEST_FINISH")
 


### PR DESCRIPTION
When libtropic is running on the Unix port against model, it would be handy if assert() was called from LT_ASSERT and LT_ASSERT_COND, so errors can be checked based on return value of the test program. Without that, the output log would have been parsed and that’s not necessary for testing with Unix port.