### PR TITLE
Remove get_conf_addr, get_confg_desc, shorten name of the configuration table array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Enhanced internal test runner logging and error reporting.
 - Renamed `LT_L2_LAST_RET` to `LT_RET_T_LAST_VALUE` for clarity in `lt_ret_t`.
+- Renamed `config_description_table` to `cfg_desc_table`.
 
 ### Added
 - Macro `LT_CONFIG_OBJ_CNT` for number of objects in the configuration structure.
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Macro `LT_USE_ASSERT`, `assert()` is always inserted.
+- Functions `get_conf_addr()`, `get_conf_desc()`, accessing the configuration table directly is advised instead.
 
 ## [0.1.0]
 

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -186,7 +186,7 @@ static int session_initial(void)
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_read));
     // Print r config
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        printf("\r\n%s, %08" PRIX32, get_conf_desc(i), r_config_read.obj[i]);
+        printf("\r\n%s, %08" PRIX32, cfg_desc_table[i].desc, r_config_read.obj[i]);
     }
     printf("\r\n");
 
@@ -197,7 +197,7 @@ static int session_initial(void)
     read_whole_R_config(&h, &r_config_read);
     // Print r config
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        printf("\r\n%s, %08" PRIX32, get_conf_desc(i), r_config_read.obj[i]);
+        printf("\r\n%s, %08" PRIX32, cfg_desc_table[i].desc, r_config_read.obj[i]);
     }
     printf("\r\n");
 

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -464,21 +464,9 @@ lt_ret_t lt_mac_and_destroy(lt_handle_t *h, mac_and_destroy_slot_t slot, const u
 const char *lt_ret_verbose(lt_ret_t ret);
 
 #ifdef LT_HELPERS
-/**
- * @brief Get the conf desc object from config description table
- *
- * @param i           Index in an array of objects
- * @return uint16_t   String with name of object on a given index
- */
-const char *get_conf_desc(uint8_t i);
 
-/**
- * @brief Get the address of a specific config object from config description table
- *
- * @param  i                               Index in an array of objects
- * @return enum CONFIGURATION_OBJECTS_REGS Address of object on a given index
- */
-enum CONFIGURATION_OBJECTS_REGS get_conf_addr(uint8_t i);
+/** @brief Helper structure, holding string name and address for each configuration object. */
+extern struct lt_config_obj_desc_t cfg_desc_table[LT_CONFIG_OBJ_CNT];
 
 /**
  * @brief This function reads config objects from TROPIC01 and prints them out

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1306,9 +1306,7 @@ const char *lt_ret_verbose(lt_ret_t ret)
 //--------------------------------------------------------------------------------------------------------//
 #ifdef LT_HELPERS
 
-/** @brief This helper structure together with two get* interfaces is meant to be used to simplify looping
- *         through all config addresses and printing them out into log */
-struct lt_config_obj_desc_t config_description_table[LT_CONFIG_OBJ_CNT] = {
+struct lt_config_obj_desc_t cfg_desc_table[LT_CONFIG_OBJ_CNT] = {
     {"CONFIGURATION_OBJECTS_CFG_START_UP                   ", CONFIGURATION_OBJECTS_CFG_START_UP_ADDR},
     {"CONFIGURATION_OBJECTS_CFG_SENSORS                    ", CONFIGURATION_OBJECTS_CFG_SENSORS_ADDR},
     {"CONFIGURATION_OBJECTS_CFG_DEBUG                      ", CONFIGURATION_OBJECTS_CFG_DEBUG_ADDR},
@@ -1337,18 +1335,6 @@ struct lt_config_obj_desc_t config_description_table[LT_CONFIG_OBJ_CNT] = {
     {"CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_UPDATE        ", CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_UPDATE_ADDR},
     {"CONFIGURATION_OBJECTS_CFG_UAP_MAC_AND_DESTROY        ", CONFIGURATION_OBJECTS_CFG_UAP_MAC_AND_DESTROY_ADDR}};
 
-enum CONFIGURATION_OBJECTS_REGS get_conf_addr(uint8_t i)
-{
-    LT_ASSERT(1, (i < LT_CONFIG_OBJ_CNT));
-    return config_description_table[i].addr;
-}
-
-const char *get_conf_desc(uint8_t i)
-{
-    LT_ASSERT(1, (i < LT_CONFIG_OBJ_CNT));
-    return config_description_table[i].desc;
-}
-
 lt_ret_t read_whole_R_config(lt_handle_t *h, struct lt_config_t *config)
 {
     if (!h || !config) {
@@ -1358,7 +1344,7 @@ lt_ret_t read_whole_R_config(lt_handle_t *h, struct lt_config_t *config)
     lt_ret_t ret;
 
     for (uint8_t i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        ret = lt_r_config_read(h, get_conf_addr(i), &config->obj[i]);
+        ret = lt_r_config_read(h, cfg_desc_table[i].addr, &config->obj[i]);
         if (ret != LT_OK) {
             return ret;
         }
@@ -1376,7 +1362,7 @@ lt_ret_t write_whole_R_config(lt_handle_t *h, const struct lt_config_t *config)
     lt_ret_t ret;
 
     for (uint8_t i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        ret = lt_r_config_write(h, get_conf_addr(i), config->obj[i]);
+        ret = lt_r_config_write(h, cfg_desc_table[i].addr, config->obj[i]);
         if (ret != LT_OK) {
             return ret;
         }
@@ -1394,7 +1380,7 @@ lt_ret_t read_whole_I_config(lt_handle_t *h, struct lt_config_t *config)
     lt_ret_t ret;
 
     for (uint8_t i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        ret = lt_i_config_read(h, get_conf_addr(i), &config->obj[i]);
+        ret = lt_i_config_read(h, cfg_desc_table[i].addr, &config->obj[i]);
         if (ret != LT_OK) {
             return ret;
         }

--- a/tests/functional/lt_test_rev_erase_r_config.c
+++ b/tests/functional/lt_test_rev_erase_r_config.c
@@ -35,7 +35,7 @@ void lt_test_rev_erase_r_config(void)
     LT_LOG_INFO("Backing up the whole R config:");
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config_backup.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config_backup.obj[i]);
     }
     LT_LOG_LINE();
 
@@ -45,7 +45,7 @@ void lt_test_rev_erase_r_config(void)
     LT_LOG_INFO("Reading the whole R config");
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was erased");
         LT_ASSERT(1, ((uint32_t)0xFFFFFFFF == r_config.obj[i]));
     }
@@ -57,7 +57,7 @@ void lt_test_rev_erase_r_config(void)
     LT_LOG_INFO("Reading the whole R config");
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was restored");
         LT_ASSERT(1, (r_config_backup.obj[i] == r_config.obj[i]));
     }

--- a/tests/functional/lt_test_rev_read_i_config.c
+++ b/tests/functional/lt_test_rev_read_i_config.c
@@ -35,7 +35,7 @@ void lt_test_rev_read_i_config(void)
     LT_LOG_INFO("Reading the whole I config:");
     LT_ASSERT(LT_OK, read_whole_I_config(&h, &i_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)i_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)i_config.obj[i]);
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_read_r_config.c
+++ b/tests/functional/lt_test_rev_read_r_config.c
@@ -35,7 +35,7 @@ void lt_test_rev_read_r_config(void)
     LT_LOG_INFO("Reading the whole R config:");
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -40,7 +40,7 @@ void lt_test_rev_write_r_config(void)
     LT_LOG_INFO("Backing up the whole R config:");
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config_backup.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config_backup.obj[i]);
     }
     LT_LOG_LINE();
 
@@ -50,7 +50,7 @@ void lt_test_rev_write_r_config(void)
     LT_LOG_INFO("Reading the whole R config");
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was written");
         LT_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
     }
@@ -58,14 +58,14 @@ void lt_test_rev_write_r_config(void)
 
     LT_LOG_INFO("Writing the whole R config again (should fail)");
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_ASSERT(LT_L3_FAIL, lt_r_config_write(&h, get_conf_addr(i), r_config_backup.obj[i]));
+        LT_ASSERT(LT_L3_FAIL, lt_r_config_write(&h, cfg_desc_table[i].addr, r_config_backup.obj[i]));
     }
 
     LT_LOG_INFO("Reading the whole R config");
     memset(r_config.obj, 0, sizeof(r_config.obj));
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was not rewritten");
         LT_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
     }
@@ -80,7 +80,7 @@ void lt_test_rev_write_r_config(void)
     LT_LOG_INFO("Reading the whole R config");
     LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", get_conf_desc(i), (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was restored");
         LT_ASSERT(1, (r_config_backup.obj[i] == r_config.obj[i]));
     }


### PR DESCRIPTION
Reasons:
- `get_conf_addr` and `get_conf_desc` were just wrappers for accessing the configuration table array. To check the input arguments, `LT_ASSERT` was used. But `LT_ASSERT` will be soon changed - it will call a test cleanup hook.
- `get_conf_addr` could easily be changed to return `lt_ret_t`, but in the case of `get_conf_desc`, the result string would have to be saved in an input argument and additional input argument for its length would be needed. Then there would have to be checks about the buffer lengths and so on. Just too much work for almost nothing. Easier is to access the configuration table directly, that way the user is responsible for using the correct index.