### PR TITLE
Add test cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,10 @@ configure_file(
 # a bit of flexibility for a case where one would want to implement more tests in one file etc.
 if(LT_BUILD_TESTS)
     set(SDK_SRCS ${SDK_SRCS}
+        # Special file with stuff common for testing.
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_common.c
+
+        # Files which include test functions definitions.
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_ecc_ecdsa.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_ecc_eddsa.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_ire_read_write_pairing_keys.c

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -11,6 +11,42 @@
 
 #include <stdint.h>
 
+extern void (*lt_test_cleanup_function)(void);
+
+// Assertions. Will log as a system message and call native assert function.
+// Note that parameters are stored to _val_ and _exp_ for a case when there
+// are function calls passed to the macros. Without the helper variables
+// the functions will be called mutliple times -- in the first comparison
+// (if statement), LT_LOG_ERROR and finally in the assert(). This can cause
+// unexpected behaviour.
+#define LT_TEST_ASSERT(expected, value)                                            \
+    {                                                                              \
+        int _val_ = (value);                                                       \
+        int _exp_ = (expected);                                                    \
+        if (_val_ == _exp_) {                                                      \
+            LT_LOG_INFO("ASSERT PASSED!");                                         \
+        }                                                                          \
+        else {                                                                     \
+            LT_LOG_ERROR("ASSERT FAILED! Got: '%d' Expected: '%d'", _val_, _exp_); \
+            if (lt_test_cleanup_function != NULL) lt_test_cleanup_function();      \
+        };                                                                         \
+        assert(_exp_ == _val_);                                                    \
+    }
+
+#define LT_TEST_ASSERT_COND(value, condition, expected_if_true, expected_if_false) \
+    {                                                                              \
+        int _val_ = (value);                                                       \
+        int _exp_ = (condition ? expected_if_true : expected_if_false);            \
+        if (_val_ == _exp_) {                                                      \
+            LT_LOG_INFO("ASSERT PASSED!");                                         \
+        }                                                                          \
+        else {                                                                     \
+            LT_LOG_ERROR("ASSERT FAILED! Got: '%d' Expected: '%d'", _val_, _exp_); \
+            if (lt_test_cleanup_function != NULL) lt_test_cleanup_function();      \
+        }                                                                          \
+        assert(_exp_ == _val_);                                                    \
+    }
+
 // Default factory pairing keys
 extern uint8_t sh0priv[];
 extern uint8_t sh0pub[];

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -56,7 +56,6 @@ extern void (*lt_test_cleanup_function)(void);
 #define LT_FINISH_TEST()                                                    \
     {                                                                       \
         LT_LOG_INFO("TEST FINISHED!");                                      \
-        if (lt_test_cleanup_function != NULL) lt_test_cleanup_function();   \
     }
 
 // Default factory pairing keys

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -25,7 +25,7 @@ void lt_assert_fail_handler(void);
 // are function calls passed to the macros. Without the helper variables
 // the functions will be called mutliple times -- in the first comparison
 // (if statement), LT_LOG_ERROR and finally in the assert(). This can cause
-// unexpected behaviour. 
+// unexpected behaviour.
 #define LT_TEST_ASSERT(expected, value)                                            \
     {                                                                              \
         int _val_ = (value);                                                       \
@@ -55,9 +55,9 @@ void lt_assert_fail_handler(void);
     }
 
 // Used to instruct the test runner that the test finshed and may disconnect (useful in embedded ports).
-#define LT_FINISH_TEST()                                                    \
-    {                                                                       \
-        LT_LOG_INFO("TEST FINISHED!");                                      \
+#define LT_FINISH_TEST()               \
+    {                                  \
+        LT_LOG_INFO("TEST FINISHED!"); \
     }
 
 // Default factory pairing keys

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -10,6 +10,7 @@
  */
 
 #include <stdint.h>
+
 #include "libtropic_common.h"
 
 extern lt_ret_t (*lt_test_cleanup_function)(void);

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -13,12 +13,17 @@
 
 extern void (*lt_test_cleanup_function)(void);
 
-// Assertions. Will log as a system message and call native assert function.
+// Assertions -- special variant for functional tests.
+// Will log as a system message and call native assert function.
+// On error, they will also call a cleanup function, if not NULL. The pointer
+// is usually assigned at the start of a functional test, if the test requires a cleanup
+// on each error (and exit of course) to be truly reversible.
+//
 // Note that parameters are stored to _val_ and _exp_ for a case when there
 // are function calls passed to the macros. Without the helper variables
 // the functions will be called mutliple times -- in the first comparison
 // (if statement), LT_LOG_ERROR and finally in the assert(). This can cause
-// unexpected behaviour.
+// unexpected behaviour. 
 #define LT_TEST_ASSERT(expected, value)                                            \
     {                                                                              \
         int _val_ = (value);                                                       \
@@ -45,6 +50,13 @@ extern void (*lt_test_cleanup_function)(void);
             if (lt_test_cleanup_function != NULL) lt_test_cleanup_function();      \
         }                                                                          \
         assert(_exp_ == _val_);                                                    \
+    }
+
+// Used to stop the test. Will log as a system message and call cleanup if not NULL.
+#define LT_FINISH_TEST()                                                    \
+    {                                                                       \
+        LT_LOG_INFO("TEST FINISHED!");                                      \
+        if (lt_test_cleanup_function != NULL) lt_test_cleanup_function();   \
     }
 
 // Default factory pairing keys

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -10,8 +10,9 @@
  */
 
 #include <stdint.h>
+#include "libtropic_common.h"
 
-extern void (*lt_test_cleanup_function)(void);
+extern lt_ret_t (*lt_test_cleanup_function)(void);
 
 void lt_assert_fail_handler(void);
 

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -13,6 +13,8 @@
 
 extern void (*lt_test_cleanup_function)(void);
 
+void lt_assert_fail_handler(void);
+
 // Assertions -- special variant for functional tests.
 // Will log as a system message and call native assert function.
 // On error, they will also call a cleanup function, if not NULL. The pointer
@@ -33,7 +35,7 @@ extern void (*lt_test_cleanup_function)(void);
         }                                                                          \
         else {                                                                     \
             LT_LOG_ERROR("ASSERT FAILED! Got: '%d' Expected: '%d'", _val_, _exp_); \
-            if (lt_test_cleanup_function != NULL) lt_test_cleanup_function();      \
+            lt_assert_fail_handler();                                              \
         };                                                                         \
         assert(_exp_ == _val_);                                                    \
     }
@@ -47,12 +49,12 @@ extern void (*lt_test_cleanup_function)(void);
         }                                                                          \
         else {                                                                     \
             LT_LOG_ERROR("ASSERT FAILED! Got: '%d' Expected: '%d'", _val_, _exp_); \
-            if (lt_test_cleanup_function != NULL) lt_test_cleanup_function();      \
+            lt_assert_fail_handler();                                              \
         }                                                                          \
         assert(_exp_ == _val_);                                                    \
     }
 
-// Used to stop the test. Will log as a system message and call cleanup if not NULL.
+// Used to instruct the test runner that the test finshed and may disconnect (useful in embedded ports).
 #define LT_FINISH_TEST()                                                    \
     {                                                                       \
         LT_LOG_INFO("TEST FINISHED!");                                      \

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -60,7 +60,4 @@
         assert(_exp_ == _val_);                                                    \
     }
 
-// Used to stop the test. Will log as a system message.
-#define LT_FINISH_TEST() LT_LOG_INFO("TEST FINISHED!")
-
 #endif /* LT_LIBTROPIC_LOGGING_H */

--- a/scripts/test_runner/lt_test_runner/__main__.py
+++ b/scripts/test_runner/lt_test_runner/__main__.py
@@ -83,12 +83,6 @@ async def main() -> lt_test_runner.lt_test_result:
         default = 0
     )
 
-    parser.add_argument(
-        "--ignore-assert-fail",
-        help    = "Do not terminate if assertion fails and continue the test.",
-        action  = "store_true"
-    )
-
     args = parser.parse_args()
     if args.message_timeout < 0:
         parser.error("Message timeout has to be >= 0.")
@@ -129,7 +123,7 @@ async def main() -> lt_test_runner.lt_test_result:
         test_result = lt_test_runner.lt_test_result.TEST_FAILED # The default is failure in case an exception is thrown.
 
         try:
-            test_result = await tr.run(args.firmware, args.message_timeout, args.total_timeout, args.ignore_assert_fail)
+            test_result = await tr.run(args.firmware, args.message_timeout, args.total_timeout)
         except serial.SerialException as e:
             logger.error(f"Platform serial interface communication error: {str(e)}")
             return lt_test_runner.lt_test_result.TEST_FAILED

--- a/scripts/test_runner/lt_test_runner/lt_test_runner.py
+++ b/scripts/test_runner/lt_test_runner/lt_test_runner.py
@@ -121,7 +121,8 @@ class lt_test_runner:
 
                     # Identifying special messages.
                     if "ASSERT FAILED!" in line:
-                        assert_fail_count += 1
+                        assert_fail_count   += 1
+                        reached_assert_flag  = True
                     elif "ASSERT PASSED!" in line:
                         reached_assert_flag = True
                     elif "TEST FINISHED!" in line:

--- a/scripts/test_runner/lt_test_runner/lt_test_runner.py
+++ b/scripts/test_runner/lt_test_runner/lt_test_runner.py
@@ -61,7 +61,7 @@ class lt_test_runner:
         
         self.openocd_launch_params = ["-f", adapter_config_path] + ["-c", f"ftdi vid_pid {adapter_id.vid:#x} {adapter_id.pid:#x}"] + self.platform.get_openocd_launch_params() 
 
-    async def __parse_output(self, message_timeout: int, total_timeout: int, ignore_assert_fail: bool) -> lt_test_result:
+    async def __parse_output(self, message_timeout: int, total_timeout: int) -> lt_test_result:
         err_count = 0
         warn_count = 0
         assert_fail_count = 0
@@ -122,11 +122,6 @@ class lt_test_runner:
                     # Identifying special messages.
                     if "ASSERT FAILED!" in line:
                         assert_fail_count += 1
-                        if not ignore_assert_fail:
-                            logger_runner.info("Received assertion failure, terminating the test.")
-                            break
-                        else:
-                            logger_runner.info("ignore_assert_fail set, ignoring assertion failure.")
                     elif "ASSERT PASSED!" in line:
                         reached_assert_flag = True
                     elif "TEST FINISHED!" in line:
@@ -165,7 +160,7 @@ class lt_test_runner:
         self.platform.openocd_disconnect()
         return self.lt_test_result.TEST_PASSED
 
-    async def run(self, elf_path: Path, message_timeout: int, total_timeout: int, ignore_assert_fail: bool) -> lt_test_result:
+    async def run(self, elf_path: Path, message_timeout: int, total_timeout: int) -> lt_test_result:
         
         if message_timeout == 0:
             # pyserial expects None for no timeout, 0 sets non-blocking mode
@@ -203,4 +198,4 @@ class lt_test_runner:
                 self.platform.openocd_disconnect()
                 return self.lt_test_result.TEST_FAILED
 
-            return await self.__parse_output(message_timeout, total_timeout, ignore_assert_fail)
+            return await self.__parse_output(message_timeout, total_timeout)

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -7,17 +7,20 @@
  */
 
 #include <stdlib.h>
+
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
 
 void (*lt_test_cleanup_function)(void) = NULL;
 
-void lt_assert_fail_handler() {
+void lt_assert_fail_handler()
+{
     if (lt_test_cleanup_function != NULL) {
         LT_LOG_INFO("Post-assert cleanup started.");
         lt_test_cleanup_function();
         LT_LOG_INFO("Post-assert cleanup finished.");
-    } else {
+    }
+    else {
         LT_LOG_INFO("Cleanup function not defined -- skipped post-assert cleaning.");
     }
     LT_FINISH_TEST();

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -8,17 +8,21 @@
 
 #include <stdlib.h>
 
+#include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
 
-void (*lt_test_cleanup_function)(void) = NULL;
+lt_ret_t (*lt_test_cleanup_function)(void) = NULL;
 
 void lt_assert_fail_handler()
 {
-    if (lt_test_cleanup_function != NULL) {
+    if (NULL != lt_test_cleanup_function) {
         LT_LOG_INFO("Post-assert cleanup started.");
-        lt_test_cleanup_function();
-        LT_LOG_INFO("Post-assert cleanup finished.");
+        if (LT_OK == lt_test_cleanup_function()) {
+            LT_LOG_INFO("Post-assert cleanup successful!");
+        } else {
+            LT_LOG_ERROR("Post-assert cleanup failed!");
+        }
     }
     else {
         LT_LOG_INFO("Cleanup function not defined -- skipped post-assert cleaning.");

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -7,5 +7,17 @@
  */
 
 #include <stdlib.h>
+#include "libtropic_functional_tests.h"
 
 void (*lt_test_cleanup_function)(void) = NULL;
+
+void lt_assert_fail_handler() {
+    if (lt_test_cleanup_function != NULL) {
+        LT_LOG_INFO("Cleanup started.");
+        lt_test_cleanup_function();
+        LT_LOG_INFO("Cleanup finished.");
+    } else {
+        LT_LOG_INFO("Cleanup function not defined -- skipped cleaning.");
+    }
+    LT_FINISH_TEST();
+}

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 #include "libtropic_functional_tests.h"
+#include "libtropic_logging.h"
 
 void (*lt_test_cleanup_function)(void) = NULL;
 

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -13,11 +13,11 @@ void (*lt_test_cleanup_function)(void) = NULL;
 
 void lt_assert_fail_handler() {
     if (lt_test_cleanup_function != NULL) {
-        LT_LOG_INFO("Cleanup started.");
+        LT_LOG_INFO("Post-assert cleanup started.");
         lt_test_cleanup_function();
-        LT_LOG_INFO("Cleanup finished.");
+        LT_LOG_INFO("Post-assert cleanup finished.");
     } else {
-        LT_LOG_INFO("Cleanup function not defined -- skipped cleaning.");
+        LT_LOG_INFO("Cleanup function not defined -- skipped post-assert cleaning.");
     }
     LT_FINISH_TEST();
 }

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -20,7 +20,8 @@ void lt_assert_fail_handler()
         LT_LOG_INFO("Post-assert cleanup started.");
         if (LT_OK == lt_test_cleanup_function()) {
             LT_LOG_INFO("Post-assert cleanup successful!");
-        } else {
+        }
+        else {
             LT_LOG_ERROR("Post-assert cleanup failed!");
         }
     }

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -1,0 +1,11 @@
+/**
+ * @file lt_test_common.c
+ * @brief Common variables for functional tests.
+ * @author Tropic Square s.r.o.
+ *
+ * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ */
+
+#include <stdlib.h>
+
+void (*lt_test_cleanup_function)(void) = NULL;

--- a/tests/functional/lt_test_ecc_ecdsa.c
+++ b/tests/functional/lt_test_ecc_ecdsa.c
@@ -32,5 +32,5 @@ int lt_test_ecc_ecdsa(void)
         "-");
 
     LT_LOG("TODO: implement this test");
-    LT_ASSERT(0, 1);
+    LT_TEST_ASSERT(0, 1);
 }

--- a/tests/functional/lt_test_ecc_eddsa.c
+++ b/tests/functional/lt_test_ecc_eddsa.c
@@ -43,11 +43,11 @@ int lt_test_ecc_eddsa(void)
 #endif
 
     LT_LOG("%s", "Initialize handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     // Ping with SH0
     LT_LOG("%s with %d", "verify_chip_and_start_secure_session()", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
 
     // Erase all keys, used in case previous run failed in the middle
     // for(uint16_t i=0; i<32; i++) {
@@ -65,7 +65,7 @@ int lt_test_ecc_eddsa(void)
         uint8_t slot_0_pubkey[64];
         lt_ecc_curve_type_t curve;
         ecc_key_origin_t origin;
-        LT_ASSERT(lt_ecc_key_read(&h, i, slot_0_pubkey, 64, &curve, &origin), LT_OK);
+        LT_TEST_ASSERT(lt_ecc_key_read(&h, i, slot_0_pubkey, 64, &curve, &origin), LT_OK);
 
         LT_LOG("lt_ecc_eddsa_sign() slot       n.%d  ", i);
         uint8_t msg[] = {'a', 'h', 'o', 'j'};
@@ -108,11 +108,11 @@ int lt_test_ecc_eddsa(void)
     }
 
     LT_LOG("%s", "lt_session_abort()");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 
     // Deinit handle
     LT_LOG("%s", "lt_deinit()");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 
     return 0;
 }

--- a/tests/functional/lt_test_ire_read_write_pairing_keys.c
+++ b/tests/functional/lt_test_ire_read_write_pairing_keys.c
@@ -51,20 +51,20 @@ void lt_test_ire_read_write_pairing_keys(void)
     uint8_t zeros[32] = {0};
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     // Read pairing keys (1,2,3 should be empty)
     LT_LOG_INFO("Reading pairing key slot 0:");
-    LT_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, PAIRING_KEY_SLOT_INDEX_0));
     print_bytes(read_key, 32);
     LT_LOG_INFO();
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
         LT_LOG_INFO("Reading pairing key slot %d, asserting LT_L3_PAIRING_KEY_EMPTY", i);
-        LT_ASSERT(LT_L3_PAIRING_KEY_EMPTY, lt_pairing_key_read(&h, read_key, i));
+        LT_TEST_ASSERT(LT_L3_PAIRING_KEY_EMPTY, lt_pairing_key_read(&h, read_key, i));
         LT_LOG_INFO();
     }
     LT_LOG_LINE();
@@ -73,7 +73,7 @@ void lt_test_ire_read_write_pairing_keys(void)
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
         LT_LOG_INFO("Writing to pairing key slot %d:", i);
         print_bytes(pub_keys[i], 32);
-        LT_ASSERT(LT_OK, lt_pairing_key_write(&h, pub_keys[i], i));
+        LT_TEST_ASSERT(LT_OK, lt_pairing_key_write(&h, pub_keys[i], i));
         LT_LOG_INFO();
     }
     LT_LOG_LINE();
@@ -81,10 +81,10 @@ void lt_test_ire_read_write_pairing_keys(void)
     // Read all pairing keys and check value
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
         LT_LOG_INFO("Reading pairing key slot %d:", i);
-        LT_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
+        LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
         LT_LOG_INFO("Comparing contents of written and read key");
-        LT_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
+        LT_TEST_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
         LT_LOG_INFO();
     }
     LT_LOG_LINE();
@@ -92,19 +92,19 @@ void lt_test_ire_read_write_pairing_keys(void)
     // Write pairing key slots again (should fail)
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
         LT_LOG_INFO("Writing zeros to pairing key slot %d, asserting LT_L3_FAIL", i);
-        LT_ASSERT(LT_L3_FAIL, lt_pairing_key_write(&h, zeros, i));
+        LT_TEST_ASSERT(LT_L3_FAIL, lt_pairing_key_write(&h, zeros, i));
         LT_LOG_INFO("Reading pairing key slot %d:", i);
-        LT_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
+        LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
         LT_LOG_INFO("Comparing contents of expected key and read key");
-        LT_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
+        LT_TEST_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
         LT_LOG_INFO();
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Aborting Secure Session");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 }

--- a/tests/functional/lt_test_rev_erase_r_config.c
+++ b/tests/functional/lt_test_rev_erase_r_config.c
@@ -26,46 +26,46 @@ void lt_test_rev_erase_r_config(void)
     struct lt_config_t r_config, r_config_backup;
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Backing up the whole R config:");
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config_backup.obj[i]);
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Erasing R config");
-    LT_ASSERT(LT_OK, lt_r_config_erase(&h));
+    LT_TEST_ASSERT(LT_OK, lt_r_config_erase(&h));
 
     LT_LOG_INFO("Reading the whole R config");
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was erased");
-        LT_ASSERT(1, ((uint32_t)0xFFFFFFFF == r_config.obj[i]));
+        LT_TEST_ASSERT(1, ((uint32_t)0xFFFFFFFF == r_config.obj[i]));
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Restoring the whole R config");
-    LT_ASSERT(LT_OK, write_whole_R_config(&h, &r_config_backup));
+    LT_TEST_ASSERT(LT_OK, write_whole_R_config(&h, &r_config_backup));
 
     LT_LOG_INFO("Reading the whole R config");
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was restored");
-        LT_ASSERT(1, (r_config_backup.obj[i] == r_config.obj[i]));
+        LT_TEST_ASSERT(1, (r_config_backup.obj[i] == r_config.obj[i]));
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Aborting Secure Session");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 }

--- a/tests/functional/lt_test_rev_erase_r_config.c
+++ b/tests/functional/lt_test_rev_erase_r_config.c
@@ -15,7 +15,8 @@
 struct lt_config_t r_config_backup;
 lt_handle_t h = {0};
 
-lt_ret_t lt_test_rev_erase_r_config_cleanup(void) {
+lt_ret_t lt_test_rev_erase_r_config_cleanup(void)
+{
     if (LT_OK != verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0)) {
         return LT_FAIL;
     }
@@ -89,7 +90,8 @@ void lt_test_rev_erase_r_config(void)
     LT_LOG_INFO("Starting post-test cleanup.");
     if (LT_OK != lt_test_rev_erase_r_config_cleanup()) {
         LT_LOG_ERROR("Cleanup failed!");
-    } else {
+    }
+    else {
         LT_LOG_INFO("Cleanup OK!");
     }
 }

--- a/tests/functional/lt_test_rev_erase_r_config.c
+++ b/tests/functional/lt_test_rev_erase_r_config.c
@@ -13,22 +13,62 @@
 
 // Shared with cleanup function.
 struct lt_config_t r_config_backup;
-lt_handle_t h = {0};
+lt_handle_t h;
 
 lt_ret_t lt_test_rev_erase_r_config_cleanup(void)
 {
-    if (LT_OK != verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0)) {
-        return LT_FAIL;
+    lt_ret_t ret;
+    struct lt_config_t r_config;
+
+    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to establish secure session, ret=%s", lt_ret_verbose(ret));
+        return ret;
     }
-    if (LT_OK != write_whole_R_config(&h, &r_config_backup)) {
-        return LT_FAIL;
+
+    LT_LOG_INFO("Erasing R config, so it can be restored");
+    ret = lt_r_config_erase(&h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to erase R config, ret=%s", lt_ret_verbose(ret));
+        return ret;
     }
-    if (LT_OK != lt_session_abort(&h)) {
-        return LT_FAIL;
+
+    LT_LOG_INFO("Writing R config backup");
+    ret = write_whole_R_config(&h, &r_config_backup);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to write R config, ret=%s", lt_ret_verbose(ret));
+        return ret;
     }
-    if (LT_OK != lt_deinit(&h)) {
-        return LT_FAIL;
+
+    LT_LOG_INFO("Reading R config and checking if restored correctly");
+    ret = read_whole_R_config(&h, &r_config);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to read R config, ret=%s", lt_ret_verbose(ret));
+        return ret;
     }
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        if (r_config.obj[i] != r_config_backup.obj[i]) {
+            LT_LOG_ERROR("Slot %d was not correctly restored", i);
+            return LT_FAIL;
+        }
+    }
+
+    LT_LOG_INFO("Aborting secure session");
+    ret = lt_session_abort(&h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to abort secure session, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    LT_LOG_INFO("Deinitializing handle");
+    ret = lt_deinit(&h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to deinitialize handle, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
 }
 
 void lt_test_rev_erase_r_config(void)
@@ -37,13 +77,12 @@ void lt_test_rev_erase_r_config(void)
     LT_LOG_INFO("lt_test_rev_erase_r_config()");
     LT_LOG_INFO("----------------------------------------------");
 
-    lt_handle_t h = {0};
 #if LT_SEPARATE_L3_BUFF
     uint8_t l3_buffer[L3_FRAME_MAX_SIZE] __attribute__((aligned(16))) = {0};
     h.l3.buff = l3_buffer;
     h.l3.buff_len = sizeof(l3_buffer);
 #endif
-    struct lt_config_t r_config, r_config_backup;
+    struct lt_config_t r_config;
 
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
@@ -75,23 +114,9 @@ void lt_test_rev_erase_r_config(void)
     }
     LT_LOG_LINE();
 
-    LT_LOG_INFO("Restoring the whole R config");
-    LT_TEST_ASSERT(LT_OK, write_whole_R_config(&h, &r_config_backup));
-
-    LT_LOG_INFO("Reading the whole R config");
-    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
-    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
-        LT_LOG_INFO("Checking if it was restored");
-        LT_TEST_ASSERT(1, (r_config_backup.obj[i] == r_config.obj[i]));
-    }
-    LT_LOG_LINE();
-
-    LT_LOG_INFO("Starting post-test cleanup.");
-    if (LT_OK != lt_test_rev_erase_r_config_cleanup()) {
-        LT_LOG_ERROR("Cleanup failed!");
-    }
-    else {
-        LT_LOG_INFO("Cleanup OK!");
-    }
+    // Call cleanup function, but don't call it from LT_TEST_ASSERT anymore.
+    lt_test_cleanup_function = NULL;
+    LT_LOG_INFO("Starting post-test cleanup");
+    LT_TEST_ASSERT(LT_OK, lt_test_rev_erase_r_config_cleanup());
+    LT_LOG_INFO("Post-test cleanup was successful");
 }

--- a/tests/functional/lt_test_rev_handshake_req.c
+++ b/tests/functional/lt_test_rev_handshake_req.c
@@ -18,24 +18,24 @@ void lt_test_rev_handshake_req(void)
 
     lt_handle_t h;
     LT_LOG_INFO("Preparing handle.");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Part 1/3: Start and abort Secure Session.");
     LT_LOG_INFO("Starting Secure Session using verify_chip_and_start_secure_session()...");
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
 
     LT_LOG_INFO("Aborting Secure Session using lt_session_abort()...");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 
     LT_LOG_INFO("Part 2/3: Start Secure Session multiple times without aborting.");
     for (int i = 0; i < 3; i++) {
         LT_LOG_INFO("Starting Secure Session (attempt %d)...", i);
-        LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+        LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     }
 
     LT_LOG_INFO("Part 3/3: Abort Secure Session multiple times.");
     for (int i = 0; i < 3; i++) {
         LT_LOG_INFO("Aborting Secure Session using lt_session_abort()...");
-        LT_ASSERT(LT_OK, lt_session_abort(&h));
+        LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
     }
 }

--- a/tests/functional/lt_test_rev_ping.c
+++ b/tests/functional/lt_test_rev_ping.c
@@ -51,23 +51,23 @@ int lt_test_rev_ping(void)
     uint8_t in[PING_LEN] = {0};
 
     LT_LOG("%s", "Initialize handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     // Ping with SH0
     LT_LOG("%s with %d", "verify_chip_and_start_secure_session()", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG("%s", "lt_ping() ");
-    LT_ASSERT(LT_OK, lt_ping(&h, ping_msg, in, PING_LEN));
+    LT_TEST_ASSERT(LT_OK, lt_ping(&h, ping_msg, in, PING_LEN));
     LT_LOG("Asserting %d B of Ping message", PING_LEN);
-    LT_ASSERT(0, memcmp(in, ping_msg, PING_LEN));
+    LT_TEST_ASSERT(0, memcmp(in, ping_msg, PING_LEN));
     LT_LOG_LINE();
     LT_LOG("%s", "lt_session_abort()");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
     memset(in, 0x00, PING_LEN);
 
     // Deinit handle
     LT_LOG("%s", "lt_deinit()");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 
     return 0;
 }

--- a/tests/functional/lt_test_rev_r_mem.c
+++ b/tests/functional/lt_test_rev_r_mem.c
@@ -13,13 +13,55 @@
 #include "libtropic_port.h"
 #include "string.h"
 
+// Shared with cleanup function
+lt_handle_t h;
+
+lt_ret_t lt_test_rev_r_mem_cleanup(void)
+{
+    lt_ret_t ret;
+    uint8_t r_mem_data[R_MEM_DATA_SIZE_MAX];
+    uint16_t read_data_size;
+
+    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to establish secure session, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    LT_LOG_INFO("Erasing all slots...");
+    for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
+        LT_LOG_INFO();
+        LT_LOG_INFO("Erasing slot #%d...", i);
+        ret = lt_r_mem_data_erase(&h, i);
+        if (LT_OK != ret) {
+            LT_LOG_ERROR("Failed to erase slot, ret=%s", lt_ret_verbose(ret));
+            return ret;
+        }
+
+        LT_LOG_INFO("Reading slot #%d (should fail)...", i);
+        ret = lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size);
+        if (LT_L3_R_MEM_DATA_READ_SLOT_EMPTY != ret) {
+            LT_LOG_ERROR("Return value is not LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, ret=%s", lt_ret_verbose(ret));
+            return ret;
+        }
+
+        LT_LOG_INFO("Checking number of read bytes (should be 0)...");
+        if (read_data_size != 0) {
+            LT_LOG_ERROR("Number of read bytes is not zero, val=%d", read_data_size);
+            return LT_FAIL;
+        }
+    }
+
+    return LT_OK;
+}
+
 void lt_test_rev_r_mem(void)
 {
     LT_LOG_INFO("----------------------------------------------");
     LT_LOG_INFO("lt_test_rev_r_mem()");
     LT_LOG_INFO("----------------------------------------------");
 
-    lt_handle_t h = {0};
 #if LT_SEPARATE_L3_BUFF
     uint8_t l3_buffer[L3_FRAME_MAX_SIZE] __attribute__((aligned(16))) = {0};
     h.l3.buff = l3_buffer;
@@ -30,54 +72,57 @@ void lt_test_rev_r_mem(void)
     uint32_t random_data[R_MEM_DATA_SIZE_MAX / sizeof(uint32_t)], random_data_size;
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Checking if all slots are empty...");
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
         LT_LOG_INFO("Reading slot #%d (should fail)...", i);
-        LT_ASSERT(LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
+        LT_TEST_ASSERT(LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
         LT_LOG_INFO("Checking number of read bytes (should be 0)...");
-        LT_ASSERT(1, (read_data_size == 0));
+        LT_TEST_ASSERT(1, (read_data_size == 0));
     }
     LT_LOG_LINE();
+
+    // We might need erasing if fail occurs in the following code
+    lt_test_cleanup_function = &lt_test_rev_r_mem_cleanup;
 
     LT_LOG_INFO("Testing writing all slots entirely...");
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
         LT_LOG_INFO("Generating random data for slot #%d...", i);
-        LT_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
+        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(write_data, random_data, sizeof(write_data));
 
         LT_LOG_INFO("Writing to slot #%d...", i);
-        LT_ASSERT(LT_OK, lt_r_mem_data_write(&h, i, write_data, R_MEM_DATA_SIZE_MAX));
+        LT_TEST_ASSERT(LT_OK, lt_r_mem_data_write(&h, i, write_data, R_MEM_DATA_SIZE_MAX));
 
         LT_LOG_INFO("Reading slot #%d...", i);
-        LT_ASSERT(LT_OK, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
+        LT_TEST_ASSERT(LT_OK, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
         LT_LOG_INFO("Checking number of read bytes...");
-        LT_ASSERT(1, (read_data_size == R_MEM_DATA_SIZE_MAX));
+        LT_TEST_ASSERT(1, (read_data_size == R_MEM_DATA_SIZE_MAX));
 
         LT_LOG_INFO("Checking contents...");
-        LT_ASSERT(0, memcmp(r_mem_data, write_data, R_MEM_DATA_SIZE_MAX));
+        LT_TEST_ASSERT(0, memcmp(r_mem_data, write_data, R_MEM_DATA_SIZE_MAX));
 
         LT_LOG_INFO("Writing zeros to slot #%d (should fail)...", i);
-        LT_ASSERT(LT_L3_R_MEM_DATA_WRITE_WRITE_FAIL, lt_r_mem_data_write(&h, i, zeros, R_MEM_DATA_SIZE_MAX));
+        LT_TEST_ASSERT(LT_L3_R_MEM_DATA_WRITE_WRITE_FAIL, lt_r_mem_data_write(&h, i, zeros, R_MEM_DATA_SIZE_MAX));
 
         LT_LOG_INFO("Reading slot #%d...", i);
         read_data_size = 0;  // Set different value just in case
-        LT_ASSERT(LT_OK, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
+        LT_TEST_ASSERT(LT_OK, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
         LT_LOG_INFO("Checking number of read bytes...");
-        LT_ASSERT(1, (read_data_size == R_MEM_DATA_SIZE_MAX));
+        LT_TEST_ASSERT(1, (read_data_size == R_MEM_DATA_SIZE_MAX));
 
         LT_LOG_INFO("Checking contents (should still contain original data)...");
-        LT_ASSERT(0, memcmp(r_mem_data, write_data, R_MEM_DATA_SIZE_MAX));
+        LT_TEST_ASSERT(0, memcmp(r_mem_data, write_data, R_MEM_DATA_SIZE_MAX));
     }
     LT_LOG_LINE();
 
@@ -85,13 +130,13 @@ void lt_test_rev_r_mem(void)
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
         LT_LOG_INFO("Erasing slot #%d...", i);
-        LT_ASSERT(LT_OK, lt_r_mem_data_erase(&h, i));
+        LT_TEST_ASSERT(LT_OK, lt_r_mem_data_erase(&h, i));
 
         LT_LOG_INFO("Reading slot #%d (should fail)...", i);
-        LT_ASSERT(LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
+        LT_TEST_ASSERT(LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
         LT_LOG_INFO("Checking number of read bytes (should be 0)...");
-        LT_ASSERT(1, (read_data_size == 0));
+        LT_TEST_ASSERT(1, (read_data_size == 0));
     }
     LT_LOG_LINE();
 
@@ -99,46 +144,32 @@ void lt_test_rev_r_mem(void)
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
         LT_LOG_INFO("Generating random data length < %d...", R_MEM_DATA_SIZE_MAX);
-        LT_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
+        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= R_MEM_DATA_SIZE_MAX;
 
         LT_LOG_INFO("Generating %d random bytes for slot #%d...", random_data_size, i);
-        LT_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
+        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(write_data, random_data, random_data_size);
 
         LT_LOG_INFO("Writing to slot #%d...", i);
-        LT_ASSERT_COND(lt_r_mem_data_write(&h, i, write_data, random_data_size), random_data_size != 0, LT_OK,
-                       LT_L3_FAIL);
+        LT_TEST_ASSERT_COND(lt_r_mem_data_write(&h, i, write_data, random_data_size), random_data_size != 0, LT_OK,
+                            LT_L3_FAIL);
 
         LT_LOG_INFO("Reading slot #%d...", i);
-        LT_ASSERT_COND(lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size), random_data_size != 0, LT_OK,
-                       LT_L3_R_MEM_DATA_READ_SLOT_EMPTY);
+        LT_TEST_ASSERT_COND(lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size), random_data_size != 0, LT_OK,
+                            LT_L3_R_MEM_DATA_READ_SLOT_EMPTY);
 
         LT_LOG_INFO("Checking number of read bytes...");
-        LT_ASSERT(1, (read_data_size == random_data_size));
+        LT_TEST_ASSERT(1, (read_data_size == random_data_size));
 
         LT_LOG_INFO("Checking contents...");
-        LT_ASSERT(0, memcmp(r_mem_data, write_data, random_data_size));
+        LT_TEST_ASSERT(0, memcmp(r_mem_data, write_data, random_data_size));
     }
     LT_LOG_LINE();
 
-    LT_LOG_INFO("Erasing all slots...");
-    for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
-        LT_LOG_INFO();
-        LT_LOG_INFO("Erasing slot #%d...", i);
-        LT_ASSERT(LT_OK, lt_r_mem_data_erase(&h, i));
-
-        LT_LOG_INFO("Reading slot #%d (should fail)...", i);
-        LT_ASSERT(LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
-
-        LT_LOG_INFO("Checking number of read bytes (should be 0)...");
-        LT_ASSERT(1, (read_data_size == 0));
-    }
-    LT_LOG_LINE();
-
-    LT_LOG_INFO("Aborting Secure Session");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
-
-    LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    // Call cleanup function, but don't call it from LT_TEST_ASSERT anymore.
+    lt_test_cleanup_function = NULL;
+    LT_LOG_INFO("Starting post-test cleanup");
+    LT_TEST_ASSERT(LT_OK, lt_test_rev_r_mem_cleanup());
+    LT_LOG_INFO("Post-test cleanup was successful");
 }

--- a/tests/functional/lt_test_rev_read_cert_store.c
+++ b/tests/functional/lt_test_rev_read_cert_store.c
@@ -31,10 +31,10 @@ void lt_test_rev_read_cert_store(void)
                                     .buf_len = {CERTS_BUF_LEN, CERTS_BUF_LEN, CERTS_BUF_LEN, CERTS_BUF_LEN}};
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Reading Certificate store");
-    LT_ASSERT(LT_OK, lt_get_info_cert_store(&h, &store));
+    LT_TEST_ASSERT(LT_OK, lt_get_info_cert_store(&h, &store));
     LT_LOG_INFO();
 
     uint8_t *cert;
@@ -42,7 +42,7 @@ void lt_test_rev_read_cert_store(void)
         cert = store.certs[i];
         LT_LOG_INFO("Certificate number: %d", i);
         LT_LOG_INFO("Checking if size of certificate is not zero");
-        LT_ASSERT(1, (store.cert_len[i] != 0));
+        LT_TEST_ASSERT(1, (store.cert_len[i] != 0));
         LT_LOG_INFO("Size in bytes: %d", store.cert_len[i]);
 
         for (int j = 0; j < store.cert_len[i]; j += 16)
@@ -55,5 +55,5 @@ void lt_test_rev_read_cert_store(void)
     LT_LOG_LINE();
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 }

--- a/tests/functional/lt_test_rev_read_chip_id.c
+++ b/tests/functional/lt_test_rev_read_chip_id.c
@@ -454,12 +454,12 @@ void lt_test_rev_read_chip_id(void)
     struct lt_chip_id_t chip_id = {0};
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Reading Chip ID:");
-    LT_ASSERT(LT_OK, lt_get_info_chip_id(&h, &chip_id));
-    LT_ASSERT(LT_OK, print_chip_id(&chip_id));
+    LT_TEST_ASSERT(LT_OK, lt_get_info_chip_id(&h, &chip_id));
+    LT_TEST_ASSERT(LT_OK, print_chip_id(&chip_id));
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 }

--- a/tests/functional/lt_test_rev_read_i_config.c
+++ b/tests/functional/lt_test_rev_read_i_config.c
@@ -26,22 +26,22 @@ void lt_test_rev_read_i_config(void)
     struct lt_config_t i_config;
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Reading the whole I config:");
-    LT_ASSERT(LT_OK, read_whole_I_config(&h, &i_config));
+    LT_TEST_ASSERT(LT_OK, read_whole_I_config(&h, &i_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)i_config.obj[i]);
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Aborting Secure Session");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 }

--- a/tests/functional/lt_test_rev_read_r_config.c
+++ b/tests/functional/lt_test_rev_read_r_config.c
@@ -26,22 +26,22 @@ void lt_test_rev_read_r_config(void)
     struct lt_config_t r_config;
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Reading the whole R config:");
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Aborting Secure Session");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 }

--- a/tests/functional/lt_test_rev_resend_req.c
+++ b/tests/functional/lt_test_rev_resend_req.c
@@ -11,6 +11,7 @@
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_logging.h"
+#include "libtropic_functional_tests.h"
 #include "lt_l1.h"
 #include "lt_l2.h"
 #include "lt_l2_api_structs.h"
@@ -30,13 +31,13 @@ void lt_test_rev_resend_req(void)
 #endif
 
     LT_LOG_INFO("Preparing handle.");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     // Sending dummy Get_Info_Req. We don't need the data, just something to request a resend later.
     // We utilize that Get_Info_Req fits into one frame.
     struct lt_chip_id_t prev_chip_id;
     LT_LOG_INFO("Sending L2 Get_Info_Req...");
-    LT_ASSERT(LT_OK, lt_get_info_chip_id(&h, &prev_chip_id));
+    LT_TEST_ASSERT(LT_OK, lt_get_info_chip_id(&h, &prev_chip_id));
 
     // Requesting a resend.
     LT_LOG_INFO("Asking to resend last response frame...");
@@ -46,7 +47,7 @@ void lt_test_rev_resend_req(void)
     // Setup a request pointer to l2 buffer with response data
     struct lt_l2_get_info_rsp_t *p_l2_resp = (struct lt_l2_get_info_rsp_t *)h.l2.buff;
     // Check incomming l3 length
-    LT_ASSERT(LT_L2_GET_INFO_CHIP_ID_SIZE, p_l2_resp->rsp_len);
+    LT_TEST_ASSERT(LT_L2_GET_INFO_CHIP_ID_SIZE, p_l2_resp->rsp_len);
     // Compare contents.
-    LT_ASSERT(0, memcmp(&prev_chip_id, p_l2_resp->object, LT_L2_GET_INFO_CHIP_ID_SIZE));
+    LT_TEST_ASSERT(0, memcmp(&prev_chip_id, p_l2_resp->object, LT_L2_GET_INFO_CHIP_ID_SIZE));
 }

--- a/tests/functional/lt_test_rev_resend_req.c
+++ b/tests/functional/lt_test_rev_resend_req.c
@@ -10,8 +10,8 @@
 
 #include "libtropic.h"
 #include "libtropic_common.h"
-#include "libtropic_logging.h"
 #include "libtropic_functional_tests.h"
+#include "libtropic_logging.h"
 #include "lt_l1.h"
 #include "lt_l2.h"
 #include "lt_l2_api_structs.h"

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -19,9 +19,6 @@ lt_handle_t h = {0};
 
 lt_ret_t lt_test_rev_write_r_config_cleanup(void)
 {
-    if (LT_OK != lt_init(&h)) {
-        return LT_FAIL;
-    }
     if (LT_OK != verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0)) {
         return LT_FAIL;
     }
@@ -113,9 +110,10 @@ void lt_test_rev_write_r_config(void)
     }
     LT_LOG_LINE();
 
-    LT_LOG_INFO("Aborting Secure Session");
-    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
-
-    LT_LOG_INFO("Deinitializing handle");
-    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
+    LT_LOG_INFO("Starting post-test cleanup.");
+    if (LT_OK != lt_test_rev_write_r_config_cleanup()) {
+        LT_LOG_ERROR("Cleanup failed!");
+    } else {
+        LT_LOG_INFO("Cleanup OK!");
+    }
 }

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -15,8 +15,8 @@
 
 struct lt_config_t r_config_backup;
 
-void lt_test_rev_write_r_config_cleanup(void) {
-
+void lt_test_rev_write_r_config_cleanup(void)
+{
     LT_LOG_INFO("Starting cleanup.");
 
     lt_handle_t h = {0};

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -13,19 +13,12 @@
 #include "libtropic_port.h"
 #include "string.h"
 
+// Shared with cleanup function.
 struct lt_config_t r_config_backup;
+lt_handle_t h = {0};
 
 void lt_test_rev_write_r_config_cleanup(void)
 {
-    LT_LOG_INFO("Starting cleanup.");
-
-    lt_handle_t h = {0};
-#if LT_SEPARATE_L3_BUFF
-    uint8_t l3_buffer[L3_FRAME_MAX_SIZE] __attribute__((aligned(16))) = {0};
-    h.l3.buff = l3_buffer;
-    h.l3.buff_len = sizeof(l3_buffer);
-#endif
-
     if (LT_OK != lt_init(&h)) {
         LT_LOG_ERROR("Cleanup failed!");
         return;

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -28,67 +28,67 @@ void lt_test_rev_write_r_config(void)
     struct lt_config_t r_config_random, r_config, r_config_backup;
 
     LT_LOG_INFO("Initializing handle");
-    LT_ASSERT(LT_OK, lt_init(&h));
+    LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
     LT_LOG_INFO("Creating randomized R config for testing");
-    LT_ASSERT(LT_OK, lt_port_random_bytes(r_config_random.obj, LT_CONFIG_OBJ_CNT));
+    LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(r_config_random.obj, LT_CONFIG_OBJ_CNT));
 
     LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Backing up the whole R config:");
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config_backup.obj[i]);
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Writing the whole R config");
-    LT_ASSERT(LT_OK, write_whole_R_config(&h, &r_config_random));
+    LT_TEST_ASSERT(LT_OK, write_whole_R_config(&h, &r_config_random));
 
     LT_LOG_INFO("Reading the whole R config");
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was written");
-        LT_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
+        LT_TEST_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Writing the whole R config again (should fail)");
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_ASSERT(LT_L3_FAIL, lt_r_config_write(&h, cfg_desc_table[i].addr, r_config_backup.obj[i]));
+        LT_TEST_ASSERT(LT_L3_FAIL, lt_r_config_write(&h, cfg_desc_table[i].addr, r_config_backup.obj[i]));
     }
 
     LT_LOG_INFO("Reading the whole R config");
     memset(r_config.obj, 0, sizeof(r_config.obj));
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was not rewritten");
-        LT_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
+        LT_TEST_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Erasing R config before restoring (needed to be able to write again)");
-    LT_ASSERT(LT_OK, lt_r_config_erase(&h));
+    LT_TEST_ASSERT(LT_OK, lt_r_config_erase(&h));
 
     LT_LOG_INFO("Restoring the whole R config");
-    LT_ASSERT(LT_OK, write_whole_R_config(&h, &r_config_backup));
+    LT_TEST_ASSERT(LT_OK, write_whole_R_config(&h, &r_config_backup));
 
     LT_LOG_INFO("Reading the whole R config");
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
+    LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
         LT_LOG_INFO("Checking if it was restored");
-        LT_ASSERT(1, (r_config_backup.obj[i] == r_config.obj[i]));
+        LT_TEST_ASSERT(1, (r_config_backup.obj[i] == r_config.obj[i]));
     }
     LT_LOG_LINE();
 
     LT_LOG_INFO("Aborting Secure Session");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_ASSERT(LT_OK, lt_deinit(&h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(&h));
 }

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -113,7 +113,8 @@ void lt_test_rev_write_r_config(void)
     LT_LOG_INFO("Starting post-test cleanup.");
     if (LT_OK != lt_test_rev_write_r_config_cleanup()) {
         LT_LOG_ERROR("Cleanup failed!");
-    } else {
+    }
+    else {
         LT_LOG_INFO("Cleanup OK!");
     }
 }

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -17,27 +17,22 @@
 struct lt_config_t r_config_backup;
 lt_handle_t h = {0};
 
-void lt_test_rev_write_r_config_cleanup(void)
+lt_ret_t lt_test_rev_write_r_config_cleanup(void)
 {
     if (LT_OK != lt_init(&h)) {
-        LT_LOG_ERROR("Cleanup failed!");
-        return;
+        return LT_FAIL;
     }
     if (LT_OK != verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0)) {
-        LT_LOG_ERROR("Cleanup failed!");
-        return;
+        return LT_FAIL;
     }
     if (LT_OK != write_whole_R_config(&h, &r_config_backup)) {
-        LT_LOG_ERROR("Cleanup failed!");
-        return;
+        return LT_FAIL;
     }
     if (LT_OK != lt_session_abort(&h)) {
-        LT_LOG_ERROR("Cleanup failed!");
-        return;
+        return LT_FAIL;
     }
     if (LT_OK != lt_deinit(&h)) {
-        LT_LOG_ERROR("Cleanup failed!");
-        return;
+        return LT_FAIL;
     }
 }
 


### PR DESCRIPTION
Some tests need post-assert cleanup to be truly reversible. This PR aims to implement a "hook" functionality, which will allow to specify a function to be called on failed assert and on exit automatically. Also, I've already added cleanup functions to tests on which they are required.