### PR TITLE
Refactor examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `LT_L2_LAST_RET` to `LT_RET_T_LAST_VALUE` for clarity in `lt_ret_t`.
 - Refactored `lt_ex_macandd` example.
 - Refactored `lt_ex_hello_world_separate_API` example.
+- Refactored `lt_ex_hello_world` example.
 - Use `LIBT_DEBUG` instead of `NDEBUG` in `lt_port_{unix_tcp,raspberrypi_wiringpi}.c`.
 - Renamed `config_description_table` to `cfg_desc_table`.
 - Functions `lt_ecc_eddsa_sign()`, `lt_ecc_ecdsa_sign()`, `lt_ecc_eddsa_sig_verify()` and `lt_ecc_ecdsa_sig_verify()` accept zero length of the message to be signed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `lt_ex_macandd` example.
 - Refactored `lt_ex_hello_world_separate_API` example.
 - Refactored `lt_ex_hello_world` example.
+- Refactored `lt_ex_hw_wallet` example.
 - Use `LIBT_DEBUG` instead of `NDEBUG` in `lt_port_{unix_tcp,raspberrypi_wiringpi}.c`.
 - Renamed `config_description_table` to `cfg_desc_table`.
 - Functions `lt_ecc_eddsa_sign()`, `lt_ecc_ecdsa_sign()`, `lt_ecc_eddsa_sig_verify()` and `lt_ecc_ecdsa_sig_verify()` accept zero length of the message to be signed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced internal test runner logging and error reporting.
 - Renamed `LT_L2_LAST_RET` to `LT_RET_T_LAST_VALUE` for clarity in `lt_ret_t`.
 - Refactored `lt_ex_macandd` example.
+- Refactored `lt_ex_hello_world_separate_API` example.
 - Use `LIBT_DEBUG` instead of `NDEBUG` in `lt_port_{unix_tcp,raspberrypi_wiringpi}.c`.
 - Renamed `config_description_table` to `cfg_desc_table`.
 - Functions `lt_ecc_eddsa_sign()`, `lt_ecc_ecdsa_sign()`, `lt_ecc_eddsa_sig_verify()` and `lt_ecc_ecdsa_sig_verify()` accept zero length of the message to be signed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Enhanced internal test runner logging and error reporting.
 - Renamed `LT_L2_LAST_RET` to `LT_RET_T_LAST_VALUE` for clarity in `lt_ret_t`.
+- Refactored `lt_ex_macandd` example.
 - Use `LIBT_DEBUG` instead of `NDEBUG` in `lt_port_{unix_tcp,raspberrypi_wiringpi}.c`.
 - Renamed `config_description_table` to `cfg_desc_table`.
 - Functions `lt_ecc_eddsa_sign()`, `lt_ecc_ecdsa_sign()`, `lt_ecc_eddsa_sig_verify()` and `lt_ecc_ecdsa_sig_verify()` accept zero length of the message to be signed.

--- a/examples/lt_ex_hello_world.c
+++ b/examples/lt_ex_hello_world.c
@@ -13,8 +13,8 @@
 
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "This is Hello World message from TROPIC01!!"
-/** @brief Length of the Ping message. */
-#define PING_MSG_LEN 43
+/** @brief Size of the Ping message, including '\0'. */
+#define PING_MSG_SIZE 44
 
 int lt_ex_hello_world(void)
 {
@@ -46,10 +46,10 @@ int lt_ex_hello_world(void)
     }
     LT_LOG_LINE();
 
-    uint8_t recv_buf[PING_MSG_LEN];
+    uint8_t recv_buf[PING_MSG_SIZE];
     LT_LOG_INFO("Sending Ping command with message:");
     LT_LOG_INFO("\t\"%s\"", PING_MSG);
-    ret = lt_ping(&h, (const uint8_t*)PING_MSG, recv_buf, PING_MSG_LEN);
+    ret = lt_ping(&h, (const uint8_t*)PING_MSG, recv_buf, PING_MSG_SIZE);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Ping command failed, ret=%s", lt_ret_verbose(ret));
         return -1;

--- a/examples/lt_ex_hello_world.c
+++ b/examples/lt_ex_hello_world.c
@@ -34,6 +34,7 @@ int lt_ex_hello_world(void)
     ret = lt_init(&h);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
 
@@ -42,6 +43,7 @@ int lt_ex_hello_world(void)
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_0,
                      lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
     LT_LOG_LINE();
@@ -52,6 +54,8 @@ int lt_ex_hello_world(void)
     ret = lt_ping(&h, (const uint8_t*)PING_MSG, recv_buf, PING_MSG_SIZE);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Ping command failed, ret=%s", lt_ret_verbose(ret));
+        lt_session_abort(&h);
+        lt_deinit(&h);
         return -1;
     }
     LT_LOG_LINE();
@@ -64,6 +68,7 @@ int lt_ex_hello_world(void)
     ret = lt_session_abort(&h);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to abort Secure Session, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
 

--- a/examples/lt_ex_hello_world.c
+++ b/examples/lt_ex_hello_world.c
@@ -13,7 +13,9 @@
 #include "libtropic_logging.h"
 #include "string.h"
 
+/** @brief Message to send with Ping L3 command. */
 #define PING_MSG "This is Hello World message from TROPIC01!!"
+/** @brief Length of the Ping message. */
 #define PING_MSG_LEN 43
 
 int lt_ex_hello_world(void)

--- a/examples/lt_ex_hello_world.c
+++ b/examples/lt_ex_hello_world.c
@@ -6,12 +6,10 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_examples.h"
 #include "libtropic_logging.h"
-#include "string.h"
 
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "This is Hello World message from TROPIC01!!"

--- a/examples/lt_ex_hello_world.c
+++ b/examples/lt_ex_hello_world.c
@@ -1,6 +1,6 @@
 /**
  * @file lt_ex_hello_world.c
- * @brief Example usage of TROPIC01 chip in a generic *hardware wallet* project.
+ * @brief Establishes Secure Session and executes Ping L3 command.
  * @author Tropic Square s.r.o.
  *
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
@@ -13,61 +13,66 @@
 #include "libtropic_logging.h"
 #include "string.h"
 
-/**
- * @name Hello World
- * @note We recommend reading TROPIC01's datasheet before diving into this example!
- * @par
- */
+#define PING_MSG "This is Hello World message from TROPIC01!!"
+#define PING_MSG_LEN 43
 
-/**
- * @brief Session with H0 pairing keys
- *
- * @param h           Device's handle
- * @return            0 if success, otherwise -1
- */
-static int session_H0(void)
+int lt_ex_hello_world(void)
 {
+    LT_LOG_INFO("======================================");
+    LT_LOG_INFO("==== TROPIC01 Hello World Example ====");
+    LT_LOG_INFO("======================================");
+
     lt_handle_t h = {0};
 #if LT_SEPARATE_L3_BUFF
     uint8_t l3_buffer[L3_PACKET_MAX_SIZE] __attribute__((aligned(16))) = {0};
     h.l3.buff = l3_buffer;
     h.l3.buff_len = sizeof(l3_buffer);
 #endif
+    lt_ret_t ret;
 
-    lt_init(&h);
-
-    LT_LOG("%s", "Establish session with H0");
-
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
-
-    uint8_t in[100] = {0};
-    uint8_t out[100] = {0};
-    memcpy(out, "This is Hello World message from TROPIC01!!", 43);
-    LT_LOG("%s", "lt_ping() ");
-    LT_ASSERT(LT_OK, lt_ping(&h, out, in, 43));
-    LT_LOG("\t\tMessage: %s", in);
-
-    lt_deinit(&h);
-
-    return 0;
-}
-
-int lt_ex_hello_world(void)
-{
-    LT_LOG("");
-    LT_LOG("\t=======================================================================");
-    LT_LOG("\t=====  TROPIC01 Hello World                                         ===");
-    LT_LOG("\t=======================================================================");
-
-    LT_LOG_LINE();
-    LT_LOG("\t Session with H0 keys:");
-    if (session_H0() == -1) {
-        LT_LOG("Error during session_H0()");
+    LT_LOG_INFO("Initializing handle");
+    ret = lt_init(&h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
     }
 
+    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_0,
+                     lt_ret_verbose(ret));
+        return -1;
+    }
     LT_LOG_LINE();
 
-    LT_LOG("\t End of execution, no errors.");
+    uint8_t recv_buf[PING_MSG_LEN];
+    LT_LOG_INFO("Sending Ping command with message:");
+    LT_LOG_INFO("\t\"%s\"", PING_MSG);
+    ret = lt_ping(&h, (const uint8_t*)PING_MSG, recv_buf, PING_MSG_LEN);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Ping command failed, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_LINE();
+
+    LT_LOG_INFO("Message received from TROPIC01:");
+    LT_LOG_INFO("\t\"%s\"", recv_buf);
+    LT_LOG_LINE();
+
+    LT_LOG_INFO("Aborting Secure Session");
+    ret = lt_session_abort(&h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to abort Secure Session, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+
+    LT_LOG_INFO("Deinitializing handle");
+    ret = lt_deinit(&h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to deinitialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
     return 0;
 }

--- a/examples/lt_ex_hello_world_separate_API.c
+++ b/examples/lt_ex_hello_world_separate_API.c
@@ -16,8 +16,8 @@
 #define CERTS_BUF_LEN 700
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "This is Hello World message from TROPIC01!!"
-/** @brief Length of the Ping message. */
-#define PING_MSG_LEN 43
+/** @brief Size of the Ping message, including '\0'. */
+#define PING_MSG_SIZE 44
 
 int lt_ex_hello_world_separate_API(void)
 {
@@ -104,10 +104,10 @@ int lt_ex_hello_world_separate_API(void)
 
     // Now we can use lt_ping() to send a message to TROPIC01 and receive a response, this is done with separate API
     // calls
-    uint8_t recv_buf[PING_MSG_LEN];
+    uint8_t recv_buf[PING_MSG_SIZE];
     LT_LOG_INFO("Executing lt_out__ping() with message:");
     LT_LOG_INFO("\t\"%s\"", PING_MSG);
-    ret = lt_out__ping(&h, (const uint8_t*)PING_MSG, PING_MSG_LEN);
+    ret = lt_out__ping(&h, (const uint8_t*)PING_MSG, PING_MSG_SIZE);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_out__ping failed, ret=%s", lt_ret_verbose(ret));
         return -1;
@@ -127,7 +127,7 @@ int lt_ex_hello_world_separate_API(void)
     }
 
     LT_LOG_INFO("Executing lt_in__ping()...");
-    ret = lt_in__ping(&h, recv_buf, PING_MSG_LEN);
+    ret = lt_in__ping(&h, recv_buf, PING_MSG_SIZE);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_in__ping failed, ret=%s", lt_ret_verbose(ret));
         return -1;

--- a/examples/lt_ex_hello_world_separate_API.c
+++ b/examples/lt_ex_hello_world_separate_API.c
@@ -37,6 +37,7 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_init(&h);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
 
@@ -47,6 +48,7 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_get_info_cert_store(&h, &store);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to get Certificate Store, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
 
@@ -56,6 +58,7 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_get_st_pub(&store, stpub, 32);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to get stpub key, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
     LT_LOG_LINE();
@@ -70,6 +73,7 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_out__session_start(&h, PAIRING_KEY_SLOT_INDEX_0, &state);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_out__session_start() failed, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
 
@@ -80,12 +84,14 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_l2_send(&h.l2);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_l2_send() failed, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
     LT_LOG_INFO("Executing lt_l2_receive()...");
     ret = lt_l2_receive(&h.l2);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_l2_receive() failed, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
 
@@ -98,6 +104,7 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_in__session_start(&h, stpub, PAIRING_KEY_SLOT_INDEX_0, sh0priv, sh0pub, &state);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_in__session_start failed, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
     LT_LOG_LINE();
@@ -110,6 +117,8 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_out__ping(&h, (const uint8_t*)PING_MSG, PING_MSG_SIZE);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_out__ping failed, ret=%s", lt_ret_verbose(ret));
+        lt_session_abort(&h);
+        lt_deinit(&h);
         return -1;
     }
 
@@ -117,12 +126,16 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_l2_send_encrypted_cmd(&h.l2, h.l3.buff, h.l3.buff_len);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_l2_send_encrypted_cmd failed, ret=%s", lt_ret_verbose(ret));
+        lt_session_abort(&h);
+        lt_deinit(&h);
         return -1;
     }
     LT_LOG_INFO("Executing lt_l2_recv_encrypted_res()...");
     ret = lt_l2_recv_encrypted_res(&h.l2, h.l3.buff, h.l3.buff_len);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_l2_recv_encrypted_res failed, ret=%s", lt_ret_verbose(ret));
+        lt_session_abort(&h);
+        lt_deinit(&h);
         return -1;
     }
 
@@ -130,6 +143,8 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_in__ping(&h, recv_buf, PING_MSG_SIZE);
     if (LT_OK != ret) {
         LT_LOG_ERROR("lt_in__ping failed, ret=%s", lt_ret_verbose(ret));
+        lt_session_abort(&h);
+        lt_deinit(&h);
         return -1;
     }
 
@@ -141,6 +156,7 @@ int lt_ex_hello_world_separate_API(void)
     ret = lt_session_abort(&h);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to abort Secure Session, ret=%s", lt_ret_verbose(ret));
+        lt_deinit(&h);
         return -1;
     }
 

--- a/examples/lt_ex_hello_world_separate_API.c
+++ b/examples/lt_ex_hello_world_separate_API.c
@@ -12,8 +12,6 @@
 #include "lt_l2.h"
 #include "lt_l3.h"
 
-/** @brief Length of the buffers for certificates. */
-#define CERTS_BUF_LEN 700
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "This is Hello World message from TROPIC01!!"
 /** @brief Size of the Ping message, including '\0'. */
@@ -42,9 +40,12 @@ int lt_ex_hello_world_separate_API(void)
     }
 
     LT_LOG_INFO("Getting Certificate Store from TROPIC01");
-    uint8_t cert1[CERTS_BUF_LEN], cert2[CERTS_BUF_LEN], cert3[CERTS_BUF_LEN], cert4[CERTS_BUF_LEN];
-    struct lt_cert_store_t store = {.certs = {cert1, cert2, cert3, cert4},
-                                    .buf_len = {CERTS_BUF_LEN, CERTS_BUF_LEN, CERTS_BUF_LEN, CERTS_BUF_LEN}};
+    uint8_t cert1[LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE], cert2[LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE],
+        cert3[LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE], cert4[LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE];
+    struct lt_cert_store_t store
+        = {.certs = {cert1, cert2, cert3, cert4},
+           .buf_len = {LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE, LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE,
+                       LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE, LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE}};
     ret = lt_get_info_cert_store(&h, &store);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to get Certificate Store, ret=%s", lt_ret_verbose(ret));

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -13,24 +13,6 @@
 #include "libtropic_logging.h"
 #include "string.h"
 
-/**
- * @name CONCEPT: Generic Hardware Wallet
- * @note We recommend reading TROPIC01's datasheet before diving into this example!
- * @par
-    This code aims to show an example usage of TROPIC01 chip in a generic *hardware wallet* project.
-
-    It is not focused on final application's usage, even though there is a few
-    hints in session3() function.
-
-    Instead of that, this code mainly walks you through a different stages during a chip's lifecycle:
-    - Initial power up during PCB manufacturing
-    - Attestation key uploading
-    - Final product usage
-
-    Example shows how content of config objects might be used to set different access rights and how chip behaves during
- the device's lifecycle.
-*/
-
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "Ping message for TROPIC01"
 /** @brief Size of the Ping message, including '\0'. */
@@ -41,7 +23,7 @@ uint8_t attestation_key[32]
     = {0x22, 0x57, 0xa8, 0x2f, 0x85, 0x8f, 0x13, 0x32, 0xfa, 0x0f, 0xf6, 0x0c, 0x76, 0x29, 0x42, 0x70,
        0xa9, 0x58, 0x9d, 0xfd, 0x47, 0xa5, 0x23, 0x78, 0x18, 0x4d, 0x2d, 0x38, 0xf0, 0xa7, 0xc4, 0x01};
 
-/** @brief  User Conﬁguration Objects - values set here reflect the concept of a generic hardware wallet */
+/** @brief User Conﬁguration Objects - values set here reflect the concept of a generic hardware wallet */
 struct lt_config_t example_config = {
     .obj
     = {//-------CONFIGURATION_OBJECTS_CFG_START_UP------------------------------------

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -23,128 +23,255 @@ uint8_t attestation_key[32]
     = {0x22, 0x57, 0xa8, 0x2f, 0x85, 0x8f, 0x13, 0x32, 0xfa, 0x0f, 0xf6, 0x0c, 0x76, 0x29, 0x42, 0x70,
        0xa9, 0x58, 0x9d, 0xfd, 0x47, 0xa5, 0x23, 0x78, 0x18, 0x4d, 0x2d, 0x38, 0xf0, 0xa7, 0xc4, 0x01};
 
-/** @brief User Conﬁguration Objects - values set here reflect the concept of a generic hardware wallet */
-struct lt_config_t example_config = {
-    .obj
-    = {//-------CONFIGURATION_OBJECTS_CFG_START_UP------------------------------------
-       // Enable checks on boot
-       (CONFIGURATION_OBJECTS_CFG_START_UP_MBIST_DIS_MASK | CONFIGURATION_OBJECTS_CFG_START_UP_RNGTEST_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_START_UP_MAINTENANCE_ENA_MASK
-        | CONFIGURATION_OBJECTS_CFG_START_UP_CPU_FW_VERIFY_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_START_UP_SPECT_FW_VERIFY_DIS_MASK),
-       //-------CONFIGURATION_OBJECTS_CFG_SENSORS-------------------------------------
-       // Enable all sensors
-       (CONFIGURATION_OBJECTS_CFG_SENSORS_PTRNG0_TEST_DIS_MASK | CONFIGURATION_OBJECTS_CFG_SENSORS_PTRNG1_TEST_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_OSCILLATOR_MON_DIS_MASK | CONFIGURATION_OBJECTS_CFG_SENSORS_SHIELD_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_VOLTAGE_MON_DIS_MASK | CONFIGURATION_OBJECTS_CFG_SENSORS_GLITCH_DET_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_TEMP_SENS_DIS_MASK | CONFIGURATION_OBJECTS_CFG_SENSORS_LASER_DET_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_EM_PULSE_DET_DIS_MASK | CONFIGURATION_OBJECTS_CFG_SENSORS_CPU_ALERT_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_PIN_VERIF_BIT_FLIP_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_SCB_BIT_FLIP_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_CPB_BIT_FLIP_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_ECC_BIT_FLIP_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_R_MEM_BIT_FLIP_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_EKDB_BIT_FLIP_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_I_MEM_BIT_FLIP_DIS_MASK
-        | CONFIGURATION_OBJECTS_CFG_SENSORS_PLATFORM_BIT_FLIP_DIS_MASK),
-       //------- CONFIGURATION_OBJECTS_CFG_DEBUG -------------------------------------
-       // Enable TROPIC01's fw log
-       (CONFIGURATION_OBJECTS_CFG_DEBUG_FW_LOG_EN_MASK),
-       //-------CONFIGURATION_OBJECTS_CFG_SLEEP_MODE----------------------------------
-       // Enable sleep mode only
-       (CONFIGURATION_OBJECTS_CFG_SLEEP_MODE_SLEEP_MODE_EN_MASK),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_PAIRING_KEY_WRITE ---------------------
-       // No session can write pairing keys
-       0,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_PAIRING_KEY_READ ----------------------
-       // All sessions can read pairing keys
-       (TO_PAIRING_KEY_SH0(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                           | SESSION_SH3_HAS_ACCESS)
-        | TO_PAIRING_KEY_SH1(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                             | SESSION_SH3_HAS_ACCESS)
-        | TO_PAIRING_KEY_SH2(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                             | SESSION_SH3_HAS_ACCESS)
-        | TO_PAIRING_KEY_SH3(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                             | SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_PAIRING_KEY_INVALIDATE ----------------
-       // Pairing key SH0PUB can be invalidated only from session SH0PUB
-       // H3 session can invalidate pairing key H1 H2 and H3
-       (TO_PAIRING_KEY_SH0(SESSION_SH0_HAS_ACCESS) | TO_PAIRING_KEY_SH1(SESSION_SH3_HAS_ACCESS)
-        | TO_PAIRING_KEY_SH2(SESSION_SH3_HAS_ACCESS) | TO_PAIRING_KEY_SH3(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_R_CONFIG_WRITE_ERASE ------------------
-       // Reset value, not used currently
-       0xFFFFFFFF,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_R_CONFIG_READ -------------------------
-       // Reset value, not used currently
-       0xFFFFFFFF,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_I_CONFIG_WRITE ------------------------
-       // Reset value, not used currently
-       0xFFFFFFFF,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_I_CONFIG_READ -------------------------
-       // Reset value, not used currently
-       0xFFFFFFFF,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_PING ----------------------------------
-       // Ping command is available for all session keys
-       (SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_WRITE ----------------------
-       // Reset value, not used currently
-       0xFFFFFFFF,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_READ -----------------------
-       // Reset value, not used currently
-       0xFFFFFFFF,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_ERASE ----------------------
-       // Reset value, not used currently
-       0xFFFFFFFF,
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_RANDOM_VALUE_GET ----------------------
-       (SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_GENERATE ----------------------
-       // No session can generate key in ecc key slot 0-7
-       // H3 can generate key in slots 8-31
-       (TO_ECC_KEY_SLOT_0_7(0) | TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_STORE -------------------------
-       // H1 can store key into ecc key slot 0-7
-       // H3 can store key into ecc key slot 8-31
-       (TO_ECC_KEY_SLOT_0_7(SESSION_SH1_HAS_ACCESS) | TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_READ --------------------------
-       // All keys can read pubkey
-       (TO_ECC_KEY_SLOT_0_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                            | SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_8_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                               | SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_16_23(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                                | SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_24_31(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
-                                | SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_ERASE -------------------------
-       // H1 key can erase keys in slot 0-7
-       // H3 key can erase key in slot  8-31
-       (TO_ECC_KEY_SLOT_0_7(SESSION_SH1_HAS_ACCESS) | TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_ECDSA_SIGN ----------------------------
-       // H3 can sign with all ECDSA key slots
-       (TO_ECC_KEY_SLOT_0_7(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_EDDSA_SIGN ----------------------------
-       // H3 can sign with all ECC key slots
-       (TO_ECC_KEY_SLOT_0_7(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS)
-        | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_INIT -------------------------
-       // H3 can init all counters
-       (TO_LT_MCOUNTER_0_3(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_4_7(SESSION_SH3_HAS_ACCESS)
-        | TO_LT_MCOUNTER_8_11(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_12_15(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_GET --------------------------
-       // H3 can get all counters
-       (TO_LT_MCOUNTER_0_3(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_4_7(SESSION_SH3_HAS_ACCESS)
-        | TO_LT_MCOUNTER_8_11(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_12_15(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_UPDATE -----------------------
-       // H3 can update all counters
-       (TO_LT_MCOUNTER_0_3(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_4_7(SESSION_SH3_HAS_ACCESS)
-        | TO_LT_MCOUNTER_8_11(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_12_15(SESSION_SH3_HAS_ACCESS)),
-       //------- CONFIGURATION_OBJECTS_TODO -----------------------
-       // All slots can use MAC-and-destroy
-       0xFFFFFFFF}};
+/**
+ * @brief Creates an HW wallet example config from the virgin R config.
+ *
+ * @param r_config R config to modify
+ */
+static void create_example_r_config(struct lt_config_t *r_config)
+{
+    //-------CFG_START_UP------------------------------------
+    // Enable MBIST and RNGTEST (DIS in their names stands for disable, so writing 0 enables them)
+    r_config->obj[0] &= ~(BOOTLOADER_CO_CFG_START_UP_MBIST_DIS_MASK | BOOTLOADER_CO_CFG_START_UP_RNGTEST_DIS_MASK);
+
+    //-------CFG_SENSORS-------------------------------------
+    // Enable all sensors (DIS in their names stands for disable, so writing 0 enables them)
+    r_config->obj[1] &= ~(
+        BOOTLOADER_CO_CFG_SENSORS_PTRNG0_TEST_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_PTRNG1_TEST_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_OSCILLATOR_MON_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_SHIELD_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_VOLTAGE_MON_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_GLITCH_DET_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_TEMP_SENS_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_LASER_DET_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_EM_PULSE_DET_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_CPU_ALERT_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_PIN_VERIF_BIT_FLIP_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_SCB_BIT_FLIP_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_CPB_BIT_FLIP_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_ECC_BIT_FLIP_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_R_MEM_BIT_FLIP_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_EKDB_BIT_FLIP_DIS_MASK
+        | BOOTLOADER_CO_CFG_SENSORS_I_MEM_BIT_FLIP_DIS_MASK | BOOTLOADER_CO_CFG_SENSORS_PLATFORM_BIT_FLIP_DIS_MASK);
+
+    //-------CFG_DEBUG---------------------------------------
+    // Disable FW logging
+    r_config->obj[2] &= ~BOOTLOADER_CO_CFG_DEBUG_FW_LOG_EN_MASK;
+
+    //-------CONFIGURATION_OBJECTS_CFG_GPO-----------------------------------------
+    // Keep at reset value
+
+    //-------CONFIGURATION_OBJECTS_CFG_SLEEP_MODE----------------------------------
+    // Enable sleep mode
+    r_config->obj[4] |= APPLICATION_CO_CFG_SLEEP_MODE_SLEEP_MODE_EN_MASK;
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_PAIRING_KEY_WRITE ---------------------
+    // Disable writing pairing keys for all slots
+    r_config->obj[5] &= ~TO_PAIRING_KEY_SH0(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[5] &= ~TO_PAIRING_KEY_SH1(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[5] &= ~TO_PAIRING_KEY_SH2(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[5] &= ~TO_PAIRING_KEY_SH3(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_PAIRING_KEY_READ ----------------------
+    // All sessions can read pairing keys
+    r_config->obj[6] |= TO_PAIRING_KEY_SH0(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                           | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[6] |= TO_PAIRING_KEY_SH1(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                           | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[6] |= TO_PAIRING_KEY_SH2(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                           | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[6] |= TO_PAIRING_KEY_SH3(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                           | SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_PAIRING_KEY_INVALIDATE ----------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[7] &= ~TO_PAIRING_KEY_SH0(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[7] &= ~TO_PAIRING_KEY_SH1(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[7] &= ~TO_PAIRING_KEY_SH2(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[7] &= ~TO_PAIRING_KEY_SH3(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                            | SESSION_SH3_HAS_ACCESS);
+    // 2. Pairing key SH0PUB can be invalidated only from session with SH0PUB
+    r_config->obj[7] |= TO_PAIRING_KEY_SH0(SESSION_SH0_HAS_ACCESS);
+    // 3. Pairing keys SH1PUB, SH2PUB and SH3PUB can be invalidated only from session with SH3PUB
+    r_config->obj[7] |= TO_PAIRING_KEY_SH1(SESSION_SH3_HAS_ACCESS);
+    r_config->obj[7] |= TO_PAIRING_KEY_SH2(SESSION_SH3_HAS_ACCESS);
+    r_config->obj[7] |= TO_PAIRING_KEY_SH3(SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_R_CONFIG_WRITE_ERASE ------------------
+    // Keep at reset value, not used currently
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_R_CONFIG_READ -------------------------
+    // Keep at reset value, not used currently
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_I_CONFIG_WRITE ------------------------
+    // Keep at reset value, not used currently
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_I_CONFIG_READ -------------------------
+    // Keep at reset value, not used currently
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_PING ----------------------------------
+    // Enable for all pairing keys
+    r_config->obj[12]
+        |= (SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_WRITE ----------------------
+    // Reset value, not used currently
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_READ -----------------------
+    // Reset value, not used currently
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_ERASE ----------------------
+    // Reset value, not used currently
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_RANDOM_VALUE_GET ----------------------
+    // Enable for all pairing keys
+    r_config->obj[16]
+        |= (SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_GENERATE ----------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[17] &= ~TO_ECC_KEY_SLOT_0_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[17] &= ~TO_ECC_KEY_SLOT_8_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[17] &= ~TO_ECC_KEY_SLOT_16_23(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[17] &= ~TO_ECC_KEY_SLOT_24_31(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    // 2. Only session with SH3PUB can generate keys in slots 8-31
+    r_config->obj[17] |= (TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS)
+                          | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS));
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_STORE -------------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[18] &= ~TO_ECC_KEY_SLOT_0_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[18] &= ~TO_ECC_KEY_SLOT_8_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[18] &= ~TO_ECC_KEY_SLOT_16_23(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[18] &= ~TO_ECC_KEY_SLOT_24_31(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    // 2. Session with SH1PUB can store key into ECC key slot 0-7
+    r_config->obj[18] |= TO_ECC_KEY_SLOT_0_7(SESSION_SH1_HAS_ACCESS);
+    // 3. Session with SH3PUB can store key into ECC key slot 8-31
+    r_config->obj[18] |= TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS)
+                         | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_READ --------------------------
+    // Enable for all pairing keys
+    r_config->obj[19] |= TO_ECC_KEY_SLOT_0_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                             | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[19] |= TO_ECC_KEY_SLOT_8_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[19] |= TO_ECC_KEY_SLOT_16_23(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[19] |= TO_ECC_KEY_SLOT_24_31(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_ERASE -------------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[20] &= ~TO_ECC_KEY_SLOT_0_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[20] &= ~TO_ECC_KEY_SLOT_8_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[20] &= ~TO_ECC_KEY_SLOT_16_23(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[20] &= ~TO_ECC_KEY_SLOT_24_31(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    // 2. Session with SH1PUB can erase ECC key slots 0-7
+    r_config->obj[20] |= TO_ECC_KEY_SLOT_0_7(SESSION_SH1_HAS_ACCESS);
+    // 3. Session with SH3PUB can erase ECC key slots 8-31
+    r_config->obj[20] |= TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS)
+                         | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS);
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_ECDSA_SIGN ----------------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[21] &= ~TO_ECC_KEY_SLOT_0_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[21] &= ~TO_ECC_KEY_SLOT_8_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[21] &= ~TO_ECC_KEY_SLOT_16_23(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[21] &= ~TO_ECC_KEY_SLOT_24_31(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    // 2. Session with SH3PUB can sign with all ECC key slots
+    r_config->obj[21]
+        |= (TO_ECC_KEY_SLOT_0_7(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS)
+            | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS));
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_EDDSA_SIGN ----------------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[22] &= ~TO_ECC_KEY_SLOT_0_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[22] &= ~TO_ECC_KEY_SLOT_8_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[22] &= ~TO_ECC_KEY_SLOT_16_23(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[22] &= ~TO_ECC_KEY_SLOT_24_31(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                                | SESSION_SH3_HAS_ACCESS);
+    // 2. Session with SH3PUB can sign with all ECC key slots
+    r_config->obj[22]
+        |= (TO_ECC_KEY_SLOT_0_7(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_8_15(SESSION_SH3_HAS_ACCESS)
+            | TO_ECC_KEY_SLOT_16_23(SESSION_SH3_HAS_ACCESS) | TO_ECC_KEY_SLOT_24_31(SESSION_SH3_HAS_ACCESS));
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_INIT -------------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[23] &= ~TO_LT_MCOUNTER_0_3(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                             | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[23] &= ~TO_LT_MCOUNTER_4_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                             | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[23] &= ~TO_LT_MCOUNTER_8_11(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[23] &= ~TO_LT_MCOUNTER_12_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    // 2. Session with SH3PUB can init all mcounters
+    r_config->obj[23] |= (TO_LT_MCOUNTER_0_3(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_4_7(SESSION_SH3_HAS_ACCESS)
+                          | TO_LT_MCOUNTER_8_11(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_12_15(SESSION_SH3_HAS_ACCESS));
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_GET --------------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[24] &= ~TO_LT_MCOUNTER_0_3(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                             | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[24] &= ~TO_LT_MCOUNTER_4_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                             | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[24] &= ~TO_LT_MCOUNTER_8_11(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[24] &= ~TO_LT_MCOUNTER_12_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    // 2. Session with SH3PUB can get all mcounters
+    r_config->obj[24] |= (TO_LT_MCOUNTER_0_3(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_4_7(SESSION_SH3_HAS_ACCESS)
+                          | TO_LT_MCOUNTER_8_11(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_12_15(SESSION_SH3_HAS_ACCESS));
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_UPDATE -----------------------
+    // 1. Disable all, then enable only specific ones
+    r_config->obj[25] &= ~TO_LT_MCOUNTER_0_3(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                             | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[25] &= ~TO_LT_MCOUNTER_4_7(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                             | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[25] &= ~TO_LT_MCOUNTER_8_11(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                              | SESSION_SH3_HAS_ACCESS);
+    r_config->obj[25] &= ~TO_LT_MCOUNTER_12_15(SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS
+                                               | SESSION_SH3_HAS_ACCESS);
+    // 2. Session with SH3PUB can update all mcounters
+    r_config->obj[25] |= (TO_LT_MCOUNTER_0_3(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_4_7(SESSION_SH3_HAS_ACCESS)
+                          | TO_LT_MCOUNTER_8_11(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_12_15(SESSION_SH3_HAS_ACCESS));
+
+    //------- CONFIGURATION_OBJECTS_CFG_UAP_MAC_AND_DESTROY_ADDR -----------------------
+    // Enable for all pairing key slots
+    r_config->obj[26]
+        |= ((SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS)
+            << APPLICATION_CO_CFG_UAP_MAC_AND_DESTROY_MACANDD_0_31_POS);
+    r_config->obj[26]
+        |= ((SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS)
+            << APPLICATION_CO_CFG_UAP_MAC_AND_DESTROY_MACANDD_32_63_POS);
+    r_config->obj[26]
+        |= ((SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS)
+            << APPLICATION_CO_CFG_UAP_MAC_AND_DESTROY_MACANDD_64_95_POS);
+    r_config->obj[26]
+        |= ((SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS)
+            << APPLICATION_CO_CFG_UAP_MAC_AND_DESTROY_MACANDD_96_127_POS);
+}
 
 /**
  * @brief Initial session, when chip is powered for the first time during manufacturing.
@@ -184,8 +311,11 @@ static int session_initial(lt_handle_t *h)
         LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
     }
 
+    LT_LOG_INFO("Creating an example config from the read R config...");
+    create_example_r_config(&r_config);
+
     LT_LOG_INFO("Writing the whole R config with the example config...");
-    ret = write_whole_R_config(h, &example_config);
+    ret = write_whole_R_config(h, &r_config);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to write R config, ret=%s", lt_ret_verbose(ret));
         return -1;

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -20,7 +20,7 @@
     This code aims to show an example usage of TROPIC01 chip in a generic *hardware wallet* project.
 
     It is not focused on final application's usage, even though there is a few
-    hints in session_H3() function.
+    hints in session3() function.
 
     Instead of that, this code mainly walks you through a different stages during a chip's lifecycle:
     - Initial power up during PCB manufacturing
@@ -31,8 +31,18 @@
  the device's lifecycle.
 */
 
+/** @brief Message to send with Ping L3 command. */
+#define PING_MSG "Ping message for TROPIC01"
+/** @brief Size of the Ping message, including '\0'. */
+#define PING_MSG_SIZE 26
+
+/** @brief Attestation key for ECC slot 0. */
+uint8_t attestation_key[32]
+    = {0x22, 0x57, 0xa8, 0x2f, 0x85, 0x8f, 0x13, 0x32, 0xfa, 0x0f, 0xf6, 0x0c, 0x76, 0x29, 0x42, 0x70,
+       0xa9, 0x58, 0x9d, 0xfd, 0x47, 0xa5, 0x23, 0x78, 0x18, 0x4d, 0x2d, 0x38, 0xf0, 0xa7, 0xc4, 0x01};
+
 /** @brief  User Conﬁguration Objects - values set here reflect the concept of a generic hardware wallet */
-struct lt_config_t config = {
+struct lt_config_t example_config = {
     .obj
     = {//-------CONFIGURATION_OBJECTS_CFG_START_UP------------------------------------
        // Enable checks on boot
@@ -40,9 +50,6 @@ struct lt_config_t config = {
         | CONFIGURATION_OBJECTS_CFG_START_UP_MAINTENANCE_ENA_MASK
         | CONFIGURATION_OBJECTS_CFG_START_UP_CPU_FW_VERIFY_DIS_MASK
         | CONFIGURATION_OBJECTS_CFG_START_UP_SPECT_FW_VERIFY_DIS_MASK),
-       //-------CONFIGURATION_OBJECTS_CFG_SLEEP_MODE----------------------------------
-       // Enable sleep mode only
-       (CONFIGURATION_OBJECTS_CFG_SLEEP_MODE_SLEEP_MODE_EN_MASK),
        //-------CONFIGURATION_OBJECTS_CFG_SENSORS-------------------------------------
        // Enable all sensors
        (CONFIGURATION_OBJECTS_CFG_SENSORS_PTRNG0_TEST_DIS_MASK | CONFIGURATION_OBJECTS_CFG_SENSORS_PTRNG1_TEST_DIS_MASK
@@ -61,6 +68,9 @@ struct lt_config_t config = {
        //------- CONFIGURATION_OBJECTS_CFG_DEBUG -------------------------------------
        // Enable TROPIC01's fw log
        (CONFIGURATION_OBJECTS_CFG_DEBUG_FW_LOG_EN_MASK),
+       //-------CONFIGURATION_OBJECTS_CFG_SLEEP_MODE----------------------------------
+       // Enable sleep mode only
+       (CONFIGURATION_OBJECTS_CFG_SLEEP_MODE_SLEEP_MODE_EN_MASK),
        //------- CONFIGURATION_OBJECTS_CFG_UAP_PAIRING_KEY_WRITE ---------------------
        // No session can write pairing keys
        0,
@@ -81,28 +91,28 @@ struct lt_config_t config = {
         | TO_PAIRING_KEY_SH2(SESSION_SH3_HAS_ACCESS) | TO_PAIRING_KEY_SH3(SESSION_SH3_HAS_ACCESS)),
        //------- CONFIGURATION_OBJECTS_CFG_UAP_R_CONFIG_WRITE_ERASE ------------------
        // Reset value, not used currently
-       0x000000ff,
+       0xFFFFFFFF,
        //------- CONFIGURATION_OBJECTS_CFG_UAP_R_CONFIG_READ -------------------------
        // Reset value, not used currently
-       0x0000ffff,
+       0xFFFFFFFF,
        //------- CONFIGURATION_OBJECTS_CFG_UAP_I_CONFIG_WRITE ------------------------
        // Reset value, not used currently
-       0x0000ffff,
+       0xFFFFFFFF,
        //------- CONFIGURATION_OBJECTS_CFG_UAP_I_CONFIG_READ -------------------------
        // Reset value, not used currently
-       0x0000ffff,
+       0xFFFFFFFF,
        //------- CONFIGURATION_OBJECTS_CFG_UAP_PING ----------------------------------
        // Ping command is available for all session keys
        (SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS),
        //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_WRITE ----------------------
        // Reset value, not used currently
-       0xffffffff,
+       0xFFFFFFFF,
        //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_READ -----------------------
        // Reset value, not used currently
-       0xffffffff,
+       0xFFFFFFFF,
        //------- CONFIGURATION_OBJECTS_CFG_UAP_R_MEM_DATA_ERASE ----------------------
        // Reset value, not used currently
-       0xffffffff,
+       0xFFFFFFFF,
        //------- CONFIGURATION_OBJECTS_CFG_UAP_RANDOM_VALUE_GET ----------------------
        (SESSION_SH0_HAS_ACCESS | SESSION_SH1_HAS_ACCESS | SESSION_SH2_HAS_ACCESS | SESSION_SH3_HAS_ACCESS),
        //------- CONFIGURATION_OBJECTS_CFG_UAP_ECC_KEY_GENERATE ----------------------
@@ -152,353 +162,531 @@ struct lt_config_t config = {
         | TO_LT_MCOUNTER_8_11(SESSION_SH3_HAS_ACCESS) | TO_LT_MCOUNTER_12_15(SESSION_SH3_HAS_ACCESS)),
        //------- CONFIGURATION_OBJECTS_TODO -----------------------
        // All slots can use MAC-and-destroy
-       (0xffffffff)}};
+       0xFFFFFFFF}};
 
 /**
  * @brief Initial session, when chip is powered for the first time during manufacturing.
- *        This function writes chip's configuration into r config area.
+ *        This function writes chip's configuration into R config.
  *
- * @param h           Device's handle
- * @return            0 if success, otherwise -1
+ * @param h  Device's handle
+ * @return   0 if success, -1 otherwise
  */
-static int session_initial(void)
+static int session_initial(lt_handle_t *h)
 {
-    lt_handle_t h = {0};
-#if LT_SEPARATE_L3_BUFF
-    uint8_t l3_buffer[L3_PACKET_MAX_SIZE] __attribute__((aligned(16))) = {0};
-    h.l3.buff = l3_buffer;
-    h.l3.buff_len = sizeof(l3_buffer);
-#endif
+    lt_ret_t ret;
+    struct lt_config_t r_config;
+    uint8_t *pub_keys[] = {sh0pub, sh1pub, sh2pub, sh3pub};
 
-    lt_init(&h);
-
-    // Establish secure handshake with default H0 pairing keys
-    LT_LOG("%s", "Creating session with initial factory keys H0");
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
-
-    LT_LOG("%s", "R CONFIG read:");
-    struct lt_config_t r_config_read;
-    LT_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_read));
-    // Print r config
-    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        printf("\r\n%s, %08" PRIX32, cfg_desc_table[i].desc, r_config_read.obj[i]);
+    LT_LOG_INFO("Initializing handle");
+    ret = lt_init(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
     }
-    printf("\r\n");
 
-    LT_LOG("%s", "Writing whole R config");
-    LT_ASSERT(LT_OK, write_whole_R_config(&h, &config));
-
-    LT_LOG("%s", "Reading R CONFIG again");
-    read_whole_R_config(&h, &r_config_read);
-    // Print r config
-    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        printf("\r\n%s, %08" PRIX32, cfg_desc_table[i].desc, r_config_read.obj[i]);
+    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    ret = verify_chip_and_start_secure_session(h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_0,
+                     lt_ret_verbose(ret));
+        return -1;
     }
-    printf("\r\n");
 
-    // Writing pairing keys 1-3
-    LT_LOG("%s", "Writing pairing key H1");
-    LT_ASSERT(LT_OK, lt_pairing_key_write(&h, sh1pub, PAIRING_KEY_SLOT_INDEX_1));
-    LT_LOG("%s", "Writing pairing key H2");
-    LT_ASSERT(LT_OK, lt_pairing_key_write(&h, sh2pub, PAIRING_KEY_SLOT_INDEX_2));
-    LT_LOG("%s", "Writing pairing key H3");
-    LT_ASSERT(LT_OK, lt_pairing_key_write(&h, sh3pub, PAIRING_KEY_SLOT_INDEX_3));
-    LT_LOG("%s", "Invalidating SH0PUB pairing key");
-    LT_ASSERT(LT_OK, lt_pairing_key_invalidate(&h, PAIRING_KEY_SLOT_INDEX_0));
+    LT_LOG_INFO("Reading the whole R config:");
+    ret = read_whole_R_config(h, &r_config);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to read R config, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+    }
 
-    LT_LOG("%s", "Closing session H0");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_LOG_INFO("Writing the whole R config with the example config...");
+    ret = write_whole_R_config(h, &example_config);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to write R config, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "Rebooting TROPIC01");
-    LT_ASSERT(LT_OK, lt_reboot(&h, LT_MODE_APP));
+    LT_LOG_INFO("Reading the whole R config again:");
+    ret = read_whole_R_config(h, &r_config);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to read R config, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+    }
 
-    lt_deinit(&h);
+    // Write pairing keys into slots 1,2,3
+    for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
+        LT_LOG_INFO("Writing to pairing key slot %d...", i);
+        ret = lt_pairing_key_write(h, pub_keys[i], i);
+        if (LT_OK != ret) {
+            LT_LOG_ERROR("Failed to write pairing key, ret=%s", lt_ret_verbose(ret));
+            return -1;
+        }
+        LT_LOG_INFO("\tOK");
+    }
+
+    LT_LOG_INFO("Invalidating pairing key slot %d...", PAIRING_KEY_SLOT_INDEX_0);
+    ret = lt_pairing_key_invalidate(h, PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to invalidate pairing key slot, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
+
+    LT_LOG_INFO("Aborting Secure Session");
+    ret = lt_session_abort(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to abort Secure Session, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+
+    LT_LOG_INFO("Rebooting TROPIC01 to apply changes...");
+    ret = lt_reboot(h, LT_MODE_APP);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to reboot, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
+
+    LT_LOG_INFO("Deinitializing handle");
+    ret = lt_deinit(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to deinitialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
     return 0;
 }
 
 /**
- * @brief Session with H0 pairing keys
+ * @brief Session with pairing key slot 0
  *
- * @param h           Device's handle
- * @return            0 if success, otherwise -1
+ * @param h  Device's handle
+ * @return   0 if success, -1 otherwise
  */
-static int session_H0(void)
+static int session0(lt_handle_t *h)
 {
-    lt_handle_t h = {0};
-#if LT_SEPARATE_L3_BUFF
-    uint8_t l3_buffer[L3_PACKET_MAX_SIZE] __attribute__((aligned(16))) = {0};
-    h.l3.buff = l3_buffer;
-    h.l3.buff_len = sizeof(l3_buffer);
-#endif
+    lt_ret_t ret;
 
-    lt_init(&h);
+    LT_LOG_INFO("Initializing handle");
+    ret = lt_init(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    /* Establish secure handshake with default H0 pairing keys should fail, because this key was invalidated during
-     * session_initial() */
-    LT_LOG("%s", "Establish session with H0 must fail");
-    LT_ASSERT(LT_L2_HSK_ERR, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
+    LT_LOG_INFO("Starting Secure Session with key %d (should fail)", PAIRING_KEY_SLOT_INDEX_0);
+    ret = verify_chip_and_start_secure_session(h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_L2_HSK_ERR != ret) {
+        LT_LOG_ERROR("Return value is not LT_L2_HSK_ERR, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    lt_deinit(&h);
+    LT_LOG_INFO("Deinitializing handle");
+    ret = lt_deinit(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to deinitialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
     return 0;
 }
 
 /**
- * @brief Session with H1 pairing keys
+ * @brief Session with pairing key slot 1
  *
- * @param h           Device's handle
- * @return            0 if success, otherwise -1
+ * @param h  Device's handle
+ * @return   0 if success, -1 otherwise
  */
-static int session_H1(void)
+static int session1(lt_handle_t *h)
 {
-    lt_handle_t h = {0};
-#if LT_SEPARATE_L3_BUFF
-    uint8_t l3_buffer[L3_PACKET_MAX_SIZE] __attribute__((aligned(16))) = {0};
-    h.l3.buff = l3_buffer;
-    h.l3.buff_len = sizeof(l3_buffer);
-#endif
+    lt_ret_t ret;
 
-    lt_init(&h);
+    LT_LOG_INFO("Initializing handle");
+    ret = lt_init(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    /* Establish secure handshake with default H1 pairing keys */
-    LT_LOG("%s", "Creating session with H1 keys");
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh1priv, sh1pub, PAIRING_KEY_SLOT_INDEX_1));
+    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_1);
+    ret = verify_chip_and_start_secure_session(h, sh1priv, sh1pub, PAIRING_KEY_SLOT_INDEX_1);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_1,
+                     lt_ret_verbose(ret));
+        return -1;
+    }
 
-    uint8_t in[100];
-    uint8_t out[100];
-    LT_LOG("%s", "lt_ping() ");
-    LT_ASSERT(LT_OK, lt_ping(&h, out, in, 100));
+    uint8_t recv_buf[PING_MSG_SIZE];
+    LT_LOG_INFO("Sending Ping command with message:");
+    LT_LOG_INFO("\t\"%s\"", PING_MSG);
+    ret = lt_ping(h, (const uint8_t *)PING_MSG, recv_buf, PING_MSG_SIZE);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Ping command failed, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    // LT_LOG("%s", "Macand: ");
-    // uint8_t data_in[32] = {0};
-    // uint8_t data_out[32] = {0};
-    // memset(data_out, 0xab, 32);
-    // LT_ASSERT(LT_OK, lt_mac_and_destroy(&h, MAC_AND_DESTROY_SLOT_0, data_out, data_in));
+    LT_LOG_INFO("Message received from TROPIC01:");
+    LT_LOG_INFO("\t\"%s\"", recv_buf);
 
-    uint8_t attestation_key[32]
-        = {0x22, 0x57, 0xa8, 0x2f, 0x85, 0x8f, 0x13, 0x32, 0xfa, 0x0f, 0xf6, 0x0c, 0x76, 0x29, 0x42, 0x70,
-           0xa9, 0x58, 0x9d, 0xfd, 0x47, 0xa5, 0x23, 0x78, 0x18, 0x4d, 0x2d, 0x38, 0xf0, 0xa7, 0xc4, 0x01};
-    LT_LOG("%s", "Storing attestation key into slot 0");
-    LT_ASSERT(LT_OK, lt_ecc_key_store(&h, ECC_SLOT_0, CURVE_ED25519, attestation_key));
+    LT_LOG_INFO("Storing attestation key into ECC slot %d...", ECC_SLOT_0);
+    ret = lt_ecc_key_store(h, ECC_SLOT_0, CURVE_ED25519, attestation_key);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to store ECC key to slot %d, ret=%s", ECC_SLOT_0, lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    uint8_t dummykey[32];
-    LT_LOG("%s", "Pairing key write into slot 0 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_0));
-    LT_LOG("%s", "Pairing key write into slot 1 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_1));
-    LT_LOG("%s", "Pairing key write into slot 2 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_2));
-    LT_LOG("%s", "Pairing key write into slot 3 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_3));
+    uint8_t dummy_key[32] = {0};
+    LT_LOG_INFO("Writing all pairing key slots (should fail):");
+    for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
+        LT_LOG_INFO("\tWriting pairing key slot %d...", i);
+        ret = lt_pairing_key_write(h, dummy_key, i);
+        if (LT_L3_UNAUTHORIZED != ret) {
+            LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+            return -1;
+        }
+        LT_LOG_INFO("\t\tOK");
+    }
 
-    LT_LOG("%s", "Aborting session H1");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_LOG_INFO("Aborting Secure Session");
+    ret = lt_session_abort(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to abort Secure Session, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    lt_deinit(&h);
+    LT_LOG_INFO("Deinitializing handle");
+    ret = lt_deinit(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to deinitialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    return LT_OK;
+    return 0;
 }
 
 /**
- * @brief Session with H2 pairing keys
+ * @brief Session with pairing key slot 2
  *
- * @param h           Device's handle
- * @return            0 if success, otherwise -1
+ * @param h  Device's handle
+ * @return   0 if success, -1 otherwise
  */
-static int session_H2(void)
+static int session2(lt_handle_t *h)
 {
-    lt_handle_t h = {0};
-#if LT_SEPARATE_L3_BUFF
-    uint8_t l3_buffer[L3_PACKET_MAX_SIZE] __attribute__((aligned(16))) = {0};
-    h.l3.buff = l3_buffer;
-    h.l3.buff_len = sizeof(l3_buffer);
-#endif
+    lt_ret_t ret;
 
-    lt_init(&h);
+    LT_LOG_INFO("Initializing handle");
+    ret = lt_init(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    LT_LOG("%s", "Creating session with H2 keys");
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh2priv, sh2pub, PAIRING_KEY_SLOT_INDEX_2));
+    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_2);
+    ret = verify_chip_and_start_secure_session(h, sh2priv, sh2pub, PAIRING_KEY_SLOT_INDEX_2);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_2,
+                     lt_ret_verbose(ret));
+        return -1;
+    }
 
-    uint8_t in[100];
-    uint8_t out[100];
-    LT_LOG("%s", "lt_ping() ");
-    LT_ASSERT(LT_OK, lt_ping(&h, out, in, 100));
+    uint8_t recv_buf[PING_MSG_SIZE];
+    LT_LOG_INFO("Sending Ping command with message:");
+    LT_LOG_INFO("\t\"%s\"", PING_MSG);
+    ret = lt_ping(h, (const uint8_t *)PING_MSG, recv_buf, PING_MSG_SIZE);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Ping command failed, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    // LT_LOG("%s", "Macand: ");
-    // uint8_t data_in[32] = {0};
-    // uint8_t data_out[32] = {0};
-    // memset(data_out, 0xab, 32);
-    // LT_ASSERT(LT_OK, lt_mac_and_destroy(&h, MAC_AND_DESTROY_SLOT_0, data_out, data_in));
+    LT_LOG_INFO("Message received from TROPIC01:");
+    LT_LOG_INFO("\t\"%s\"", recv_buf);
 
-    uint8_t dummykey[32];
-    LT_LOG("%s", "ECC key store into slot 1 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_ecc_key_store(&h, ECC_SLOT_0, CURVE_ED25519, dummykey));
+    uint8_t dummy_key[32];
+    LT_LOG_INFO("Trying to store key into ECC slot %d (should fail)", ECC_SLOT_0);
+    ret = lt_ecc_key_store(h, ECC_SLOT_0, CURVE_ED25519, dummy_key);
+    if (LT_L3_UNAUTHORIZED != ret) {
+        LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "Pairing key write into slot 0 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_0));
-    LT_LOG("%s", "Pairing key write into slot 1 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_1));
-    LT_LOG("%s", "Pairing key write into slot 2 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_2));
-    LT_LOG("%s", "Pairing key write into slot 3 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_3));
+    LT_LOG_INFO("Writing all pairing key slots (should fail):");
+    for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
+        LT_LOG_INFO("\tWriting pairing key slot %d...", i);
+        ret = lt_pairing_key_write(h, dummy_key, i);
+        if (LT_L3_UNAUTHORIZED != ret) {
+            LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+            return -1;
+        }
+        LT_LOG_INFO("\t\tOK");
+    }
 
     uint32_t mcounter_value = 0x000000ff;
-    LT_LOG("%s", "Initializing mcounter 0 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_mcounter_init(&h, 0, mcounter_value));
-    LT_LOG("%s", "Mcounter 0 update must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_mcounter_update(&h, 0));
-    LT_LOG("%s", "Mcounter get must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_mcounter_get(&h, 0, &mcounter_value));
+    LT_LOG_INFO("Initializing mcounter 0 (should fail)...");
+    ret = lt_mcounter_init(h, 0, mcounter_value);
+    if (LT_L3_UNAUTHORIZED != ret) {
+        LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    // TODO Unauthorized sign with attestation key
+    LT_LOG_INFO("Updating mcounter 0 (should fail)...");
+    ret = lt_mcounter_update(h, 0);
+    if (LT_L3_UNAUTHORIZED != ret) {
+        LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "Aborting session H2");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    LT_LOG_INFO("Getting mcounter 0 (should fail)...");
+    ret = lt_mcounter_get(h, 0, &mcounter_value);
+    if (LT_L3_UNAUTHORIZED != ret) {
+        LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    lt_deinit(&h);
+    // TODO: Unauthorized sign with attestation key
 
-    return LT_OK;
+    LT_LOG_INFO("Aborting Secure Session");
+    ret = lt_session_abort(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to abort Secure Session, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+
+    LT_LOG_INFO("Deinitializing handle");
+    ret = lt_deinit(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to deinitialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+
+    return 0;
 }
 
 /**
- * @brief Session with H3 pairing keys
+ * @brief Session with pairing key slot 3
  *
- * @param h           Device's handle
- * @return            0 if success, otherwise -1
+ * @param h  Device's handle
+ * @return   0 if success, -1 otherwise
  */
-static int session_H3(void)
+static int session3(lt_handle_t *h)
 {
-    lt_handle_t h = {0};
-#if LT_SEPARATE_L3_BUFF
-    uint8_t l3_buffer[L3_PACKET_MAX_SIZE] __attribute__((aligned(16))) = {0};
-    h.l3.buff = l3_buffer;
-    h.l3.buff_len = sizeof(l3_buffer);
-#endif
+    lt_ret_t ret;
 
-    lt_init(&h);
+    LT_LOG_INFO("Initializing handle");
+    ret = lt_init(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to initialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    LT_LOG("%s", "Creating session with H3 keys");
-    LT_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh3priv, sh3pub, PAIRING_KEY_SLOT_INDEX_3));
+    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_3);
+    ret = verify_chip_and_start_secure_session(h, sh3priv, sh3pub, PAIRING_KEY_SLOT_INDEX_3);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_3,
+                     lt_ret_verbose(ret));
+        return -1;
+    }
 
-    // Following commands must NOT pass, check if they return LT_L3_UNAUTHORIZED
+    uint8_t recv_buf[PING_MSG_SIZE];
+    LT_LOG_INFO("Sending Ping command with message:");
+    LT_LOG_INFO("\t\"%s\"", PING_MSG);
+    ret = lt_ping(h, (const uint8_t *)PING_MSG, recv_buf, PING_MSG_SIZE);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Ping command failed, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
 
-    LT_LOG("%s", "lt_ping() ");
-    uint8_t in[100];
-    uint8_t out[100];
-    LT_ASSERT(LT_OK, lt_ping(&h, out, in, 100));
+    LT_LOG_INFO("Message received from TROPIC01:");
+    LT_LOG_INFO("\t\"%s\"", recv_buf);
 
-    // LT_LOG("%s", "Macand: ");
-    // uint8_t data_in[32] = {0};
-    // uint8_t data_out[32] = {0};
-    // memset(data_out, 0xab, 32);
-    // LT_ASSERT(LT_OK, lt_mac_and_destroy(&h, MAC_AND_DESTROY_SLOT_0, data_out, data_in));
-
-    // Sign with attestation key which was updated through session keys H1
-    LT_LOG("%s", "lt_ecc_eddsa_sign() ");
+    LT_LOG_INFO("Signing with attestation key which was updated through pairing key slot 1");
     uint8_t msg[] = {'a', 'h', 'o', 'j'};
     uint8_t rs[64];
-    LT_ASSERT(LT_OK, lt_ecc_eddsa_sign(&h, ECC_SLOT_0, msg, 4, rs));
+    ret = lt_ecc_eddsa_sign(h, ECC_SLOT_0, msg, 4, rs);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to sign, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "lt_ecc_key_read() ");
+    LT_LOG_INFO("Reading ECC key slot %d...", ECC_SLOT_0);
     uint8_t slot_0_pubkey[64];
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
-    LT_ASSERT(LT_OK, lt_ecc_key_read(&h, ECC_SLOT_0, slot_0_pubkey, &curve, &origin));
+    ret = lt_ecc_key_read(h, ECC_SLOT_0, slot_0_pubkey, &curve, &origin);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to read ECC slot, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "lt_ecc_eddsa_sig_verify() ");
-    LT_ASSERT(LT_OK, lt_ecc_eddsa_sig_verify(msg, 4, slot_0_pubkey, rs));
+    LT_LOG_INFO("Verifying with lt_ecc_eddsa_sig_verify()...");
+    ret = lt_ecc_eddsa_sig_verify(msg, 4, slot_0_pubkey, rs);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to verify, ret%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    // TODO generate key
-    LT_LOG("%s", "lt_ecc_key_generate() in ECC_SLOT_8");
-    LT_ASSERT(LT_OK, lt_ecc_key_generate(&h, ECC_SLOT_8, CURVE_ED25519));
-    LT_LOG("%s", "lt_ecc_key_generate() in ECC_SLOT_16");
-    LT_ASSERT(LT_OK, lt_ecc_key_generate(&h, ECC_SLOT_16, CURVE_ED25519));
-    LT_LOG("%s", "lt_ecc_key_generate() in ECC_SLOT_24");
-    LT_ASSERT(LT_OK, lt_ecc_key_generate(&h, ECC_SLOT_24, CURVE_ED25519));
+    LT_LOG_INFO("Generating ECC key in slot %d...", ECC_SLOT_8);
+    ret = lt_ecc_key_generate(h, ECC_SLOT_8, CURVE_ED25519);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to generate ECC key, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "lt_random_value_get() RANDOM_VALUE_GET_LEN_MAX == 255");
+    LT_LOG_INFO("Generating ECC key in slot %d...", ECC_SLOT_16);
+    ret = lt_ecc_key_generate(h, ECC_SLOT_16, CURVE_ED25519);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to generate ECC key, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
+
+    LT_LOG_INFO("Generating ECC key in slot %d...", ECC_SLOT_24);
+    ret = lt_ecc_key_generate(h, ECC_SLOT_24, CURVE_ED25519);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to generate ECC key, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
+
+    LT_LOG_INFO("Getting %d random bytes...", RANDOM_VALUE_GET_LEN_MAX);
     uint8_t buff[RANDOM_VALUE_GET_LEN_MAX];
-    LT_ASSERT(LT_OK, lt_random_value_get(&h, buff, RANDOM_VALUE_GET_LEN_MAX));
-
-    // TODO write r mem data
-    LT_LOG("%s", "lt_r_mem_data_erase() slot 0 ");
-    LT_ASSERT(LT_OK, lt_r_mem_data_erase(&h, 0));
-    // TODO read r mem data
+    ret = lt_random_value_get(h, buff, RANDOM_VALUE_GET_LEN_MAX);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to get random bytes, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
     uint32_t mcounter_value = 0x000000ff;
-    LT_LOG_VALUE("mcounter_value %08" PRIX32, mcounter_value);
-    LT_LOG("%s", "Initializing mcounter 0 ");
-    LT_ASSERT(LT_OK, lt_mcounter_init(&h, 0, mcounter_value));
-    LT_LOG("%s", "Mcounter 0 update");
-    LT_ASSERT(LT_OK, lt_mcounter_update(&h, 0));
-    LT_LOG("%s", "Mcounter get ");
-    LT_ASSERT(LT_OK, lt_mcounter_get(&h, 0, &mcounter_value));
-    LT_LOG_VALUE("mcounter_value %08" PRIX32, mcounter_value);
+    LT_LOG_INFO("Initializing mcounter 0...");
+    ret = lt_mcounter_init(h, 0, mcounter_value);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to initialize mcounter, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    uint8_t dummykey[32];
-    LT_LOG("%s", "ECC key store into slot 1 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_ecc_key_store(&h, ECC_SLOT_0, CURVE_ED25519, dummykey));
+    LT_LOG_INFO("Updating mcounter 0...");
+    ret = lt_mcounter_update(h, 0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to update mcounter, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "Pairing key write into slot 0 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_0));
-    LT_LOG("%s", "Pairing key write into slot 1 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_1));
-    LT_LOG("%s", "Pairing key write into slot 2 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_2));
-    LT_LOG("%s", "Pairing key write into slot 3 must fail");
-    LT_ASSERT(LT_L3_UNAUTHORIZED, lt_pairing_key_write(&h, dummykey, PAIRING_KEY_SLOT_INDEX_3));
+    LT_LOG_INFO("Getting mcounter 0...");
+    ret = lt_mcounter_get(h, 0, &mcounter_value);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to get mcounter, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    LT_LOG("%s", "Aborting session H3");
-    LT_ASSERT(LT_OK, lt_session_abort(&h));
+    uint8_t dummy_key[32];
+    LT_LOG_INFO("Trying to store key into ECC slot %d (should fail)", ECC_SLOT_0);
+    ret = lt_ecc_key_store(h, ECC_SLOT_0, CURVE_ED25519, dummy_key);
+    if (LT_L3_UNAUTHORIZED != ret) {
+        LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+    LT_LOG_INFO("\tOK");
 
-    lt_deinit(&h);
+    LT_LOG_INFO("Writing all pairing key slots (should fail):");
+    for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
+        LT_LOG_INFO("\tWriting pairing key slot %d...", i);
+        ret = lt_pairing_key_write(h, dummy_key, i);
+        if (LT_L3_UNAUTHORIZED != ret) {
+            LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
+            return -1;
+        }
+        LT_LOG_INFO("\t\tOK");
+    }
 
-    return LT_OK;
+    LT_LOG_INFO("Aborting Secure Session");
+    ret = lt_session_abort(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to abort Secure Session, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+
+    LT_LOG_INFO("Deinitializing handle");
+    ret = lt_deinit(h);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to deinitialize handle, ret=%s", lt_ret_verbose(ret));
+        return -1;
+    }
+
+    return 0;
 }
 
 int lt_ex_hardware_wallet(void)
 {
-    LT_LOG("");
-    LT_LOG("\t=======================================================================");
-    LT_LOG("\t=====  TROPIC01 example 1 - Hardware Wallet                         ===");
-    LT_LOG("\t=======================================================================");
+    LT_LOG_INFO("==========================================");
+    LT_LOG_INFO("==== TROPIC01 Hardware Wallet Example ====");
+    LT_LOG_INFO("==========================================");
+
+    lt_handle_t h = {0};
+#if LT_SEPARATE_L3_BUFF
+    uint8_t l3_buffer[L3_FRAME_MAX_SIZE] __attribute__((aligned(16))) = {0};
+    h.l3.buff = l3_buffer;
+    h.l3.buff_len = sizeof(l3_buffer);
+#endif
 
     LT_LOG_LINE();
-    LT_LOG("\t Session initial:");
-    if (session_initial() == -1) {
-        LT_LOG("Error during session_initial()");
-        return -1;
-    }
-
-    LT_LOG_LINE();
-    LT_LOG("\t Session H0:");
-    if (session_H0() == -1) {
-        LT_LOG("Error during session_H0()");
-        return -1;
-    }
-    LT_LOG_LINE();
-    LT_LOG("\t Session H1:");
-    if (session_H1() == -1) {
-        LT_LOG("Error during session_H1()");
-        return -1;
-    }
-    LT_LOG_LINE();
-    LT_LOG("\t Session H2:");
-    if (session_H2() == -1) {
-        LT_LOG("Error during session_H2()");
-        return -1;
-    }
-    LT_LOG_LINE();
-    LT_LOG("\t Session H3:");
-    if (session_H3() == -1) {
-        LT_LOG("Error during session_H3()");
+    LT_LOG_INFO("Initial session with pairing key slot 0");
+    if (session_initial(&h) == -1) {
+        if (h.l3.session == SESSION_ON) lt_session_abort(&h);
+        lt_deinit(&h);
         return -1;
     }
     LT_LOG_LINE();
 
-    LT_LOG("\t End of execution, no errors.");
+    LT_LOG_INFO("Session with pairing key slot 0");
+    if (session0(&h) == -1) {
+        if (h.l3.session == SESSION_ON) lt_session_abort(&h);
+        lt_deinit(&h);
+        return -1;
+    }
+    LT_LOG_LINE();
+
+    LT_LOG_INFO("Session with pairing key slot 1");
+    if (session1(&h) == -1) {
+        if (h.l3.session == SESSION_ON) lt_session_abort(&h);
+        lt_deinit(&h);
+        return -1;
+    }
+    LT_LOG_LINE();
+
+    LT_LOG_INFO("Session with pairing key slot 2");
+    if (session2(&h) == -1) {
+        if (h.l3.session == SESSION_ON) lt_session_abort(&h);
+        lt_deinit(&h);
+        return -1;
+    }
+    LT_LOG_LINE();
+
+    LT_LOG_INFO("Session with pairing key slot 3");
+    if (session3(&h) == -1) {
+        if (h.l3.session == SESSION_ON) lt_session_abort(&h);
+        lt_deinit(&h);
+        return -1;
+    }
 
     return 0;
 }

--- a/examples/lt_ex_macandd.c
+++ b/examples/lt_ex_macandd.c
@@ -2,7 +2,7 @@
  * @file lt_ex_macandd.c
  * @brief Example usage of TROPIC01 flagship feature - 'Mac And Destroy' PIN verification engine.
  * @author Tropic Square s.r.o.
- * 
+ *
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
@@ -182,7 +182,7 @@ static lt_ret_t lt_PIN_set(lt_handle_t *h, const uint8_t *PIN, const uint8_t PIN
             goto exit;
         }
         LT_LOG_INFO("\tOK");
-        
+
         // Now the slot is initialized again by calling M&D sequence again with 'u'
         LT_LOG_INFO("Doing M&D sequence again to initialize a slot...");
         ret = lt_mac_and_destroy(h, i, u, garbage);
@@ -367,7 +367,8 @@ static lt_ret_t lt_PIN_check(lt_handle_t *h, const uint8_t *PIN, const uint8_t P
     nvm.i = MACANDD_ROUNDS;
 
     // Store NVM data for future use
-    LT_LOG_INFO("Writing M&D data into R_Mem User slot %d for future use (erase, then write)...", R_MEM_DATA_SLOT_MACANDD);
+    LT_LOG_INFO("Writing M&D data into R_Mem User slot %d for future use (erase, then write)...",
+                R_MEM_DATA_SLOT_MACANDD);
     ret = lt_r_mem_data_erase(h, R_MEM_DATA_SLOT_MACANDD);
     if (ret != LT_OK) {
         LT_LOG_ERROR("Failed to erase User slot, ret=%s", lt_ret_verbose(ret));
@@ -468,7 +469,7 @@ int lt_ex_macandd(void)
 
     LT_LOG_INFO("Doing Final PIN attempt with correct PIN, slots are reinitialized again...");
     ret = lt_PIN_check(&h, pin, 4, additional_data, additional_data_size, secret);
-    if(LT_OK != ret) {
+    if (LT_OK != ret) {
         LT_LOG_ERROR("Attempt with correct PIN failed, ret=%s", lt_ret_verbose(ret));
         lt_session_abort(&h);
         lt_deinit(&h);

--- a/include/libtropic_examples.h
+++ b/include/libtropic_examples.h
@@ -57,11 +57,22 @@ int lt_ex_hello_world(void);
 int lt_ex_hello_world_separate_API(void);
 
 /**
- * @brief Example function, Hardware Wallet
- * @details Pairing keys SH1-3 are set and SH0 is invalidated. TODO explain more
- * WARNING: This example ireversively writes into chip!
+ * @brief Example usage of TROPIC01 chip in a generic *hardware wallet* project.
  *
- * @return int
+ * It is not focused on final application's usage, even though there is a few hints in session3() function.
+ * Instead of that, this code mainly walks you through a different stages during a chip's lifecycle:
+ *  - Initial power up during PCB manufacturing
+ *  - Attestation key uploading
+ *  - Final product usage
+
+ * Example shows how content of config objects might be used to set different access rights and how chip behaves during
+ * the device's lifecycle.
+ *
+ * @note We recommend reading TROPIC01's datasheet before diving into this example!
+ * @warning We strongly recommend running this example against the TROPIC01 model only, as it does irreversible
+ operations!
+ *
+ * @return 0 on success, -1 otherwise
  */
 int lt_ex_hardware_wallet(void);
 

--- a/include/libtropic_examples.h
+++ b/include/libtropic_examples.h
@@ -11,25 +11,22 @@
 
 #include <stdint.h>
 
-// Default factory pairing keys
 extern uint8_t sh0priv[];
 extern uint8_t sh0pub[];
-// Keys with acces to write attestation key in slot 1
+
 extern uint8_t sh1priv[];
 extern uint8_t sh1pub[];
-// Keys with access only to read serial number
+
 extern uint8_t sh2priv[];
 extern uint8_t sh2pub[];
-// Keys for application
+
 extern uint8_t sh3priv[];
 extern uint8_t sh3pub[];
 
 /**
- * @brief Example function, Hello World
- *
- *  Verifies chip's certificate, establishes secure channel and executes Ping l3 command.
- *  TODO explain more
- * @return int
+ * @brief Establishes Secure Session and executes Ping L3 command.
+ * @note We recommend reading TROPIC01's datasheet before diving into this example!
+ * @return -1 on fail, 0 otherwise
  */
 int lt_ex_hello_world(void);
 

--- a/include/libtropic_examples.h
+++ b/include/libtropic_examples.h
@@ -36,9 +36,26 @@ int lt_ex_hello_world(void);
 /**
  * @brief Example function, Hello World with separate API
  *
- *  Verifies chip's certificate, establishes secure channel and executes Ping l3 command.
- *  TODO explain more
+ * Verifies chip's certificate, establishes secure channel and executes Ping l3 command.
+ * TODO explain more
  * @return int
+ */
+
+/**
+ * @brief Establishes Secure Session and executes Ping L3 command using separated API.
+ *
+ * This example shows how to use separated API calls with TROPIC01. Separate calls are named lt_out__* and
+ * lt_in__* and they provide splitting of the commands/results, which might be used for example for communication over a
+ * tunnel. Let's say we want to speak with TROPIC01 from a server, then lt_out__* part is done on the server, then
+ * encrypted payload is transferred over tunnel to the point where SPI is wired to TROPIC01. L2 communication is
+ * executed, encrypted result is transferred back to the server, where lt_in__* function is used to decrypt the
+ * response.
+ *
+ * To have a better understanding have a look into lt_ex_hello_world.c, both examples shows similar procedure.
+ *
+ * This might be used for example in production, where we want to establish a secure channel between HSM and TROPIC01 on
+ * PCB.
+ * @return -1 on fail, 0 otherwise
  */
 int lt_ex_hello_world_separate_API(void);
 

--- a/include/libtropic_examples.h
+++ b/include/libtropic_examples.h
@@ -72,7 +72,7 @@ int lt_ex_fw_update(void);
  * memory slot.
  *
  * @note We recommend reading TROPIC01's datasheet before diving into this example!
- * 
+ *
  * @return 0 on success, -1 otherwise
  */
 int lt_ex_macandd(void);

--- a/include/libtropic_examples.h
+++ b/include/libtropic_examples.h
@@ -59,8 +59,21 @@ int lt_ex_hardware_wallet(void);
 int lt_ex_fw_update(void);
 
 /**
- * @brief Example usage of 'Mac And Destroy' pin verification scheme
+ * @brief Example usage of TROPIC01 flagship feature - 'Mac And Destroy' PIN verification engine.
  *
+ * Value MACANDD_ROUNDS represents a number of possible PIN gueses, this value also affects size of lt_macandd_nvm_t
+ * struct. Technically TROPIC01 is capable to have this set to 128, therefore provide 128 Mac And Destroy tries, which
+ * would require roughly 128*32 bytes in non volatile memory for storing data related to M&D tries.
+ *
+ * In this example TROPIC01's R memory is used as a storage for data during power cycle.
+ * For a sake of simplicity, only one R memory slot is used as a storage, which means 444B of storage are available.
+ *
+ * Therefore MACANDD_ROUNDS is here limited to 12 -> biggest possible number of tries which fits into 444B one R
+ * memory slot.
+ *
+ * @note We recommend reading TROPIC01's datasheet before diving into this example!
+ * 
+ * @return 0 on success, -1 otherwise
  */
 int lt_ex_macandd(void);
 

--- a/include/libtropic_examples.h
+++ b/include/libtropic_examples.h
@@ -90,8 +90,9 @@ int lt_ex_fw_update(void);
  * struct. Technically TROPIC01 is capable to have this set to 128, therefore provide 128 Mac And Destroy tries, which
  * would require roughly 128*32 bytes in non volatile memory for storing data related to M&D tries.
  *
- * In this example TROPIC01's R memory is used as a storage for data during power cycle.
- * For a sake of simplicity, only one R memory slot is used as a storage, which means 444B of storage are available.
+ * In this example TROPIC01's R memory is used as a storage for data during power cycle (specifically, the last slot is
+ * used). For a sake of simplicity, only one R memory slot is used as a storage, which means 444B of storage are
+ * available.
  *
  * Therefore MACANDD_ROUNDS is here limited to 12 -> biggest possible number of tries which fits into 444B one R
  * memory slot.


### PR DESCRIPTION
- [x] refactored all examples (not functionality, only error checking etc.)
  - FIX: `lt_ex_hw_wallet` uses old API of `lt_ecc_key_read` and `lt_ecc_eddsa_sign`
- [x] refactored compilation - only `LT_BUILD_EXAMPLES` is used for compiling examples, which results in generating executable for each example, which is then flashed to the target board.
- [ ] ~~mention all this in documentation and add missing info about examples~~ Will be solved in another PR