### PR TITLE
WIP: Refactor typedef usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,24 +2,48 @@
 
 We love contributions! To make contributing simple for both sides, please:
 
-- Open an issue
-- Describe how you would like to contribute and discuss details with us
-- Make sure your code is properly formatted with `clang-format` version 16 - more info in `docs/contributors.md`, or simply install clang-format version 16 run `clang-format -i -- filename_c_or_h`
-- Make sure your commit messages follow [Conventional Commits guidelines](https://www.conventionalcommits.org/en/v1.0.0/#specification)
-- Create pull request
+- Open an issue and describe how you would like to contribute and discuss details with us.
+- Create a branch and do the changes:
+    - Make sure your commit messages follow our guidelines -- [see below](#commit-messages).
+    - Make sure to follow specifics in our coding style -- [see below](#coding-style).
+    - Make sure your code is properly formatted with `clang-format` version >16! Otherwise the PR check will fail and cannot be merged.
+        - install clang-format
+        - run `clang-format -i -- path_to_c_or_h_source_file`.
+    - Make sure the branch passes tests against model -- otherwise, again, the PR check will fail.
+        - Guide about testing against the model is in the [`tests/model_based_project/README.md`](tests/model_based_project/README.md).
+- Create pull request.
 
-### Commit messages:
+## Coding style
+### Structures and enums
+In the public API (`include/`) we define structured types and enumerations using typedef. We do NOT omit
+structure (enum) name, to keep possibility to declare using struct/enum keywords. Example:
 
+```c
+typedef struct my_struct {
+    ...
+} my_struct;
+
+typedef enum my_enum {
+    ...
+} my_enum;
 ```
-# The Tropic Square commit message shall look like so:
 
+Anywhere else [we do not use typedefs](https://www.kernel.org/doc/html/latest/process/coding-style.html#typedefs).
+
+## Commit messages
+Our commit message format is inspired by [Conventional Commits guidelines](https://www.conventionalcommits.org/en/v1.0.0/#specification).
+
+The commit messages should look like following:
+```
 < type >[ optional scope ]: < description >
 [ optional JIRA REF ]
 [ optional body ]
 [ optional footer ( s ) ]
+```
 
-# The meaning of individual ﬁelds is following:
+Where the meaning of individual ﬁelds is:
 
+```
 <type> - Type of commit. Can be one of following:
     - feat     - A new feature.
     - build    - A change to build or compile scripts.

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -62,12 +62,12 @@
 //--------------------------------------------------------------------------------------------------------------------//
 
 /** @brief Generic L3 command and result frame */
-struct __attribute__((packed)) lt_l3_gen_frame_t {
+typedef struct lt_l3_gen_frame_t {
     /** @brief RES_SIZE or CMD_SIZE value */
     uint16_t cmd_size;
     /** @brief Command or result data including ID and TAG */
     uint8_t data[L3_FRAME_MAX_SIZE - L3_RES_SIZE_SIZE];
-};
+} __attribute__((packed)) lt_l3_gen_frame_t ;
 
 // clang-format off
 STATIC_ASSERT(
@@ -82,12 +82,12 @@ STATIC_ASSERT(
 //--------------------------------------------------------------------------------------------------------------------//
 
 #define UART_DEV_MAX_LEN 32
-typedef struct {
+typedef struct lt_uart_def_unix_t {
     char device[UART_DEV_MAX_LEN];  // = "/dev/ttyACM0";
     uint32_t baud_rate;             // = 115200;
 } lt_uart_def_unix_t;
 
-typedef struct {
+typedef struct lt_l2_state_t {
     void *device;
     uint8_t mode;
     uint8_t buff[1 + L2_MAX_FRAME_SIZE];
@@ -98,7 +98,7 @@ typedef struct {
 #define LT_SIZE_OF_L3_BUFF L3_FRAME_MAX_SIZE
 #endif
 
-typedef struct {
+typedef struct lt_l3_state_t {
     uint32_t session;
     uint8_t encryption_IV[12];
     uint8_t decryption_IV[12];
@@ -136,7 +136,7 @@ typedef struct lt_handle_t {
  * @brief Enum return type.
  * @note Specific values are given for easier lookup of values.
  */
-typedef enum {
+typedef enum lt_ret_t {
     /** @brief Operation was successful */
     LT_OK = 0,
     /** @brief Operation was not succesfull */
@@ -241,7 +241,7 @@ typedef enum {
 #define LT_L2_GET_INFO_REQ_CERT_SIZE_TOTAL 3840
 #define LT_L2_GET_INFO_REQ_CERT_SIZE_SINGLE 700
 
-typedef enum {
+typedef enum lt_cert_kind_t {
     LT_CERT_KIND_DEVICE = 0,
     LT_CERT_KIND_XXXX = 1,
     LT_CERT_KIND_TROPIC01 = 2,
@@ -254,11 +254,11 @@ typedef enum {
 /**
  * @brief Certificate store contents
  */
-struct lt_cert_store_t {
+typedef struct lt_cert_store_t {
     uint8_t *certs[LT_NUM_CERTIFICATES];    /** Certificates */
     uint16_t buf_len[LT_NUM_CERTIFICATES];  /** Length of buffers for certificates */
     uint16_t cert_len[LT_NUM_CERTIFICATES]; /** Lenght of certificates (from Cert store header) */
-};
+} lt_cert_store_t;
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief Maximal size of returned CHIP ID */
@@ -270,7 +270,7 @@ struct lt_cert_store_t {
  *
  * @details This structure contains fields for parsing the chip's serial number data.
  */
-struct lt_ser_num_t {
+typedef struct lt_ser_num_t {
     uint8_t sn;          /**< 8 bits for serial number */
     uint8_t fab_data[3]; /**< 12 bits fab ID, 12 bits part number ID */
     uint16_t fab_date;   /**< 16 bits for fabrication date */
@@ -278,7 +278,7 @@ struct lt_ser_num_t {
     uint8_t wafer_id;    /**< 8 bits for wafer ID */
     uint16_t x_coord;    /**< 16 bits for x-coordinate */
     uint16_t y_coord;    /**< 16 bits for y-coordinate */
-} __attribute__((packed));
+} __attribute__((packed)) lt_ser_num_t;
 
 // clang-format off
 STATIC_ASSERT(
@@ -301,7 +301,7 @@ STATIC_ASSERT(
 /**
  * @brief Data in this struct comes from BP (batch package) yml file. CHIP_INFO is read into this struct.
  */
-struct lt_chip_id_t {
+typedef struct lt_chip_id_t {
     /**
      * @brief CHIP_ID structure versioning (32 bits), defined by Tropic Square in BP.
      * @details Example encoding: v1.2.3.4 = 0x01,0x02,0x03,0x04
@@ -398,7 +398,7 @@ struct lt_chip_id_t {
      * @brief Padding (192 bits).
      */
     uint8_t rfu_4[24];
-} __attribute__((packed));
+} __attribute__((packed)) lt_chip_id_t;
 
 // clang-format off
 STATIC_ASSERT(
@@ -442,7 +442,7 @@ STATIC_ASSERT(
 #define LT_L2_GET_INFO_FW_HEADER_SIZE 20
 
 /** @brief BANK ID */
-typedef enum {
+typedef enum bank_id_t {
     FW_BANK_FW1 = 1,      // Firmware bank 1.
     FW_BANK_FW2 = 2,      // Firmware bank 2
     FW_BANK_SPECT1 = 17,  // SPECT bank 1.
@@ -451,7 +451,7 @@ typedef enum {
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief Pairing key indexes corresponds to S_HiPub */
-typedef enum {
+typedef enum pkey_index_t {
     PAIRING_KEY_SLOT_INDEX_0,
     PAIRING_KEY_SLOT_INDEX_1,
     PAIRING_KEY_SLOT_INDEX_2,
@@ -487,7 +487,7 @@ typedef struct {
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief ECC key slot indexes */
-typedef enum {
+typedef enum pairing_key_slot_t {
     SH0PUB = 0,
     SH1PUB,
     SH2PUB,
@@ -496,7 +496,7 @@ typedef enum {
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief CONFIGURATION_OBJECTS_REGISTERS memory map */
-enum CONFIGURATION_OBJECTS_REGS {
+typedef enum CONFIGURATION_OBJECTS_REGS {
     CONFIGURATION_OBJECTS_CFG_START_UP_ADDR = 0X0,
     CONFIGURATION_OBJECTS_CFG_SENSORS_ADDR = 0X8,
     CONFIGURATION_OBJECTS_CFG_DEBUG_ADDR = 0X10,
@@ -523,7 +523,7 @@ enum CONFIGURATION_OBJECTS_REGS {
     CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_GET_ADDR = 0X154,
     CONFIGURATION_OBJECTS_CFG_UAP_MCOUNTER_UPDATE_ADDR = 0X158,
     CONFIGURATION_OBJECTS_CFG_UAP_MAC_AND_DESTROY_ADDR = 0X160
-};
+} CONFIGURATION_OBJECTS_REGS ;
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief Maximal size of one data slot in bytes */
@@ -537,7 +537,7 @@ enum CONFIGURATION_OBJECTS_REGS {
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief ECC key slot indexes */
-typedef enum {
+typedef enum ecc_slot_t {
     ECC_SLOT_0 = 0,
     ECC_SLOT_1,
     ECC_SLOT_2,
@@ -573,14 +573,14 @@ typedef enum {
 } ecc_slot_t;
 
 /** @brief ECC key type */
-typedef enum { CURVE_P256 = 1, CURVE_ED25519 } lt_ecc_curve_type_t;
+typedef enum lt_ecc_curve_type_t { CURVE_P256 = 1, CURVE_ED25519 } lt_ecc_curve_type_t;
 
 /** @brief ECC key origin */
-typedef enum { CURVE_GENERATED = 1, CURVE_STORED } ecc_key_origin_t;
+typedef enum ecc_key_origin_t { CURVE_GENERATED = 1, CURVE_STORED } ecc_key_origin_t;
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief Use to choose one from 16 counters */
-enum lt_mcounter_index_t {
+typedef enum lt_mcounter_index_t {
     MCOUNTER_INDEX_0 = 0,
     MCOUNTER_INDEX_1 = 1,
     MCOUNTER_INDEX_2 = 2,
@@ -597,7 +597,7 @@ enum lt_mcounter_index_t {
     MCOUNTER_INDEX_13 = 13,
     MCOUNTER_INDEX_14 = 14,
     MCOUNTER_INDEX_15 = 15
-};
+} lt_mcounter_index_t;
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief Maximal size of returned MAC-and-Destroy data */
@@ -606,7 +606,7 @@ enum lt_mcounter_index_t {
 #define MACANDD_ROUNDS_MAX 128
 
 /** @brief Mac-and-Destroy slot indexes */
-typedef enum {
+typedef enum mac_and_destroy_slot_t {
     MAC_AND_DESTROY_SLOT_0 = 0,
     MAC_AND_DESTROY_SLOT_1,
     MAC_AND_DESTROY_SLOT_2,
@@ -780,17 +780,17 @@ typedef enum {
 
 /** @brief This structure is used in this example to simplify looping
  *         through all config addresses and printing out them into debug */
-struct lt_config_obj_desc_t {
+typedef struct lt_config_obj_desc_t {
     char desc[60];
     enum CONFIGURATION_OBJECTS_REGS addr;
-};
+} lt_config_obj_desc_t;
 
 /** @brief Number of configuration objects in lt_config_t */
 #define LT_CONFIG_OBJ_CNT 26
 
 /** @brief Structure to hold all configuration objects */
-struct lt_config_t {
+typedef struct lt_config_t {
     uint32_t obj[LT_CONFIG_OBJ_CNT];
-};
+} lt_config_t;
 
 #endif

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -11,13 +11,6 @@
 #include "libtropic_macros.h"
 #include "stdint.h"
 
-/** Alias for unsigned 8 bit integer */
-typedef uint8_t u8;
-/** Alias for unsigned 16 bit integer */
-typedef uint16_t u16;
-/** Alias for unsigned 32 bit integer */
-typedef uint32_t u32;
-
 // This macro is used to change static functions into exported one, when compiling unit tests.
 // It allows to unit test static functions.
 #ifndef TEST

--- a/src/lt_l2_api_structs.h
+++ b/src/lt_l2_api_structs.h
@@ -53,19 +53,19 @@
  * FW.
  */
 struct lt_l2_get_info_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
     /**
      * @brief
      * The Identifier of the requested object.
      */
-    u8 object_id;
+    uint8_t object_id;
     /**
      * @brief
      * The index of the 128 Byte long block to request
      */
-    u8 block_index;
-    u8 crc[2]; /**< Checksum */
+    uint8_t block_index;
+    uint8_t crc[2]; /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -90,15 +90,15 @@ STATIC_ASSERT(
  * FW.
  */
 struct lt_l2_get_info_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
     /**
      * @brief
      * The data content of the requested object block.
      */
-    u8 object[128];
-    u8 crc[2]; /**< Checksum */
+    uint8_t object[128];
+    uint8_t crc[2]; /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -136,21 +136,21 @@ STATIC_ASSERT(
  * Channel Mode).
  */
 struct lt_l2_handshake_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
     /**
      * @brief
      * The Host MCU's Ephemeral X25519 public key. A little endian encoding of the x-coordinate from the public
      * Curve25519 point.
      */
-    u8 e_hpub[32]; /**< Ephemeral Key of Host MCU. */
+    uint8_t e_hpub[32]; /**< Ephemeral Key of Host MCU. */
     /**
      * @brief
      * The index of the Pairing Key slot to establish a Secure Channel Session with (TROPIC01 fetches $S_{HiPub}$ from
      * the Pairing Key slot specified in this field).
      */
-    u8 pkey_index; /**< Pairing Key slot */
-    u8 crc[2];     /**< Checksum */
+    uint8_t pkey_index; /**< Pairing Key slot */
+    uint8_t crc[2];     /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -172,20 +172,20 @@ STATIC_ASSERT(
  * Channel Mode).
  */
 struct lt_l2_handshake_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
     /**
      * @brief
      * TROPIC01's X25519 Ephemeral key.
      */
-    u8 e_tpub[32]; /**< Ephemeral Key of TROPIC01. */
+    uint8_t e_tpub[32]; /**< Ephemeral Key of TROPIC01. */
     /**
      * @brief
      * The Secure Channel Handshake Authentication Tag.
      */
-    u8 t_tauth[16]; /**< Authentication Tag */
-    u8 crc[2];      /**< Checksum */
+    uint8_t t_tauth[16]; /**< Authentication Tag */
+    uint8_t crc[2];      /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -218,11 +218,11 @@ STATIC_ASSERT(
  * Request to execute an L3 Command.
  */
 struct lt_l2_encrypted_cmd_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
     /** Contains a chunk of encrypted command */
     uint8_t l3_chunk[255];
-    u8 crc[2]; /**< Checksum */
+    uint8_t crc[2]; /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -242,16 +242,16 @@ STATIC_ASSERT(
  * Request to execute an L3 Command.
  */
 struct lt_l2_encrypted_cmd_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
     /**
      * @brief
      * The size of the RES_CIPHERTEXT L3 Field in bytes.
      */
     /** Contains a chunk of encrypted command */
     uint8_t l3_chunk[255];
-    u8 crc[2]; /**< Checksum */
+    uint8_t crc[2]; /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -280,9 +280,9 @@ STATIC_ASSERT(
  * Request to abort current Secure Channel Session and execution of L3 command (TROPIC01 moves to Idle Mode).
  */
 struct lt_l2_encrypted_session_abt_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
-    u8 crc[2];  /**< Checksum */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
+    uint8_t crc[2];  /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -301,10 +301,10 @@ STATIC_ASSERT(
  * Request to abort current Secure Channel Session and execution of L3 command (TROPIC01 moves to Idle Mode).
  */
 struct lt_l2_encrypted_session_abt_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
-    u8 crc[2];      /**< Checksum */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
+    uint8_t crc[2];      /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -332,9 +332,9 @@ STATIC_ASSERT(
  * Request for TROPIC01 to resend the last L2 Response.
  */
 struct lt_l2_resend_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
-    u8 crc[2];  /**< Checksum */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
+    uint8_t crc[2];  /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -353,10 +353,10 @@ STATIC_ASSERT(
  * Request for TROPIC01 to resend the last L2 Response.
  */
 struct lt_l2_resend_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
-    u8 crc[2];      /**< Checksum */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
+    uint8_t crc[2];      /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -388,14 +388,14 @@ STATIC_ASSERT(
  * Request for TROPIC01 to go to Sleep Mode or Deep Sleep Mode.
  */
 struct lt_l2_sleep_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
     /**
      * @brief
      * The type of Sleep mode TROPIC01 moves to.
      */
-    u8 sleep_kind; /**< Sleep Kind */
-    u8 crc[2];     /**< Checksum */
+    uint8_t sleep_kind; /**< Sleep Kind */
+    uint8_t crc[2];     /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -415,10 +415,10 @@ STATIC_ASSERT(
  * Request for TROPIC01 to go to Sleep Mode or Deep Sleep Mode.
  */
 struct lt_l2_sleep_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
-    u8 crc[2];      /**< Checksum */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
+    uint8_t crc[2];      /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -450,10 +450,10 @@ STATIC_ASSERT(
  * Request for TROPIC01 to reset.
  */
 struct lt_l2_startup_req_t {
-    u8 req_id;     /**< Request ID byte */
-    u8 req_len;    /**< Length byte */
-    u8 startup_id; /**< The request ID */
-    u8 crc[2];     /**< Checksum */
+    uint8_t req_id;     /**< Request ID byte */
+    uint8_t req_len;    /**< Length byte */
+    uint8_t startup_id; /**< The request ID */
+    uint8_t crc[2];     /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -473,10 +473,10 @@ STATIC_ASSERT(
  * Request for TROPIC01 to reset.
  */
 struct lt_l2_startup_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
-    u8 crc[2];      /**< Checksum */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
+    uint8_t crc[2];      /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -519,12 +519,12 @@ STATIC_ASSERT(
  * NOTE: Write only to the correctly erased bank (see Mutable_FW_Erase_Req).
  */
 struct lt_l2_mutable_fw_update_req_t {
-    u8 req_id;    /**< Request ID byte */
-    u8 req_len;   /**< Length byte */
-    u8 bank_id;   /**< The Identifier of the bank to write in. */
-    u16 offset;   /**< The offset of the specific bank to write the chunk */
-    u8 data[248]; /**< The binary data to write. Data size should be a multiple of 4. */
-    u8 crc[2];    /**< Checksum */
+    uint8_t req_id;    /**< Request ID byte */
+    uint8_t req_len;   /**< Length byte */
+    uint8_t bank_id;   /**< The Identifier of the bank to write in. */
+    uint16_t offset;   /**< The offset of the specific bank to write the chunk */
+    uint8_t data[248]; /**< The binary data to write. Data size should be a multiple of 4. */
+    uint8_t crc[2];    /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -549,10 +549,10 @@ STATIC_ASSERT(
  * NOTE: Write only to the correctly erased bank (see Mutable_FW_Erase_Req).
  */
 struct lt_l2_mutable_fw_update_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
-    u8 crc[2];      /**< Checksum */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
+    uint8_t crc[2];      /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -589,10 +589,10 @@ STATIC_ASSERT(
  * Supported only in Start-up mode (i.e. after Startup_Req with MAINTENANCE_REBOOT).
  */
 struct lt_l2_mutable_fw_erase_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
-    u8 bank_id; /**< The Identifier of the bank to erase. The same choices as above. */
-    u8 crc[2];  /**< Checksum */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
+    uint8_t bank_id; /**< The Identifier of the bank to erase. The same choices as above. */
+    uint8_t crc[2];  /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -613,10 +613,10 @@ STATIC_ASSERT(
  * Supported only in Start-up mode (i.e. after Startup_Req with MAINTENANCE_REBOOT).
  */
 struct lt_l2_mutable_fw_erase_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
-    u8 crc[2];      /**< Checksum */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
+    uint8_t crc[2];      /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -644,9 +644,9 @@ STATIC_ASSERT(
  * Get log from FW running on RISCV CPU.
  */
 struct lt_l2_get_log_req_t {
-    u8 req_id;  /**< Request ID byte */
-    u8 req_len; /**< Length byte */
-    u8 crc[2];  /**< Checksum */
+    uint8_t req_id;  /**< Request ID byte */
+    uint8_t req_len; /**< Length byte */
+    uint8_t crc[2];  /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off
@@ -665,15 +665,15 @@ STATIC_ASSERT(
  * Get log from FW running on RISCV CPU.
  */
 struct lt_l2_get_log_rsp_t {
-    u8 chip_status; /**< CHIP_STATUS byte */
-    u8 status;      /**< L2 status byte */
-    u8 rsp_len;     /**< Length of incoming data */
+    uint8_t chip_status; /**< CHIP_STATUS byte */
+    uint8_t status;      /**< L2 status byte */
+    uint8_t rsp_len;     /**< Length of incoming data */
     /**
      * @brief
      * Log message of RISCV FW.
      */
-    u8 log_msg[255]; /**< Log message */
-    u8 crc[2];       /**< Checksum */
+    uint8_t log_msg[255]; /**< Log message */
+    uint8_t crc[2];       /**< Checksum */
 } __attribute__((packed));
 
 // clang-format off

--- a/src/lt_l3_api_structs.h
+++ b/src/lt_l3_api_structs.h
@@ -33,14 +33,14 @@
  * A dummy command to check the Secure Channel Session communication.
  */
 struct lt_l3_ping_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The input data
      */
-    u8 data_in[4096]; /**< Data in */
-    u8 tag[16];       /**< L3 tag */
+    uint8_t data_in[4096]; /**< Data in */
+    uint8_t tag[16];       /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -60,14 +60,14 @@ STATIC_ASSERT(
  * A dummy command to check the Secure Channel Session communication.
  */
 struct lt_l3_ping_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The output data (loopback of the DATA_IN L3 Field).
      */
-    u8 data_out[4096]; /**< Data out */
-    u8 tag[16];        /**< L3 tag */
+    uint8_t data_out[4096]; /**< Data out */
+    uint8_t tag[16];        /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -103,24 +103,24 @@ STATIC_ASSERT(
  * Command to write the X25519 public key to a Pairing Key slot.
  */
 struct lt_l3_pairing_key_write_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The Pairing Key slot. Valid values are 0 - 3.
      */
-    u16 slot; /**< Slot to write in */
+    uint16_t slot; /**< Slot to write in */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding; /**< Padding */
+    uint8_t padding; /**< Padding */
     /**
      * @brief
      * The X25519 public key to be written in the Pairing Key slot specified in the SLOT field.
      */
-    u8 s_hipub[32]; /**< Public Key */
-    u8 tag[16];     /**< L3 tag */
+    uint8_t s_hipub[32]; /**< Public Key */
+    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -142,9 +142,9 @@ STATIC_ASSERT(
  * Command to write the X25519 public key to a Pairing Key slot.
  */
 struct lt_l3_pairing_key_write_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -179,14 +179,14 @@ STATIC_ASSERT(
  * Command to read the X25519 public key from a Pairing Key slot.
  */
 struct lt_l3_pairing_key_read_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The Pairing Key slot. Valid values are 0 - 3.
      */
-    u16 slot;   /**< Slot to Read */
-    u8 tag[16]; /**< L3 tag */
+    uint16_t slot;   /**< Slot to Read */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -206,19 +206,19 @@ STATIC_ASSERT(
  * Command to read the X25519 public key from a Pairing Key slot.
  */
 struct lt_l3_pairing_key_read_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The X25519 public key to be written in the Pairing Key slot specified in the SLOT field.
      */
-    u8 s_hipub[32]; /**< Public Key */
-    u8 tag[16];     /**< L3 tag */
+    uint8_t s_hipub[32]; /**< Public Key */
+    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -255,14 +255,14 @@ STATIC_ASSERT(
  * Command to invalidate the X25519 public key in a Pairing Key slot.
  */
 struct lt_l3_pairing_key_invalidate_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The Pairing Key slot. Valid values are 0 - 3.
      */
-    u16 slot;   /**< Slot to Invalidate */
-    u8 tag[16]; /**< L3 tag */
+    uint16_t slot;   /**< Slot to Invalidate */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -282,9 +282,9 @@ STATIC_ASSERT(
  * Command to invalidate the X25519 public key in a Pairing Key slot.
  */
 struct lt_l3_pairing_key_invalidate_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -311,24 +311,24 @@ STATIC_ASSERT(
  * Command to write a single CO to R-Config.
  */
 struct lt_l3_r_config_write_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The CO address offset for TROPIC01 to compute the actual CO address.
      */
-    u16 address; /**< Configuration object address */
+    uint16_t address; /**< Configuration object address */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding; /**< Padding */
+    uint8_t padding; /**< Padding */
     /**
      * @brief
      * The CO value to write in the computed address.
      */
-    u32 value;  /**< Configuration object value */
-    u8 tag[16]; /**< L3 tag */
+    uint32_t value;  /**< Configuration object value */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -350,9 +350,9 @@ STATIC_ASSERT(
  * Command to write a single CO to R-Config.
  */
 struct lt_l3_r_config_write_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -379,14 +379,14 @@ STATIC_ASSERT(
  * Command to read a single CO from R-Config.
  */
 struct lt_l3_r_config_read_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The CO address offset for TROPIC01 to compute the actual CO address.
      */
-    u16 address; /**< Configuration object address */
-    u8 tag[16];  /**< L3 tag */
+    uint16_t address; /**< Configuration object address */
+    uint8_t tag[16];  /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -406,19 +406,19 @@ STATIC_ASSERT(
  * Command to read a single CO from R-Config.
  */
 struct lt_l3_r_config_read_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The CO value TROPIC01 read from the computed address.
      */
-    u32 value;  /**< Configuration object value */
-    u8 tag[16]; /**< L3 tag */
+    uint32_t value;  /**< Configuration object value */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -447,9 +447,9 @@ STATIC_ASSERT(
  * Command to erase the whole R-Config (convert the bits of all CO to 1).
  */
 struct lt_l3_r_config_erase_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -468,9 +468,9 @@ STATIC_ASSERT(
  * Command to erase the whole R-Config (convert the bits of all CO to 1).
  */
 struct lt_l3_r_config_erase_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -497,19 +497,19 @@ STATIC_ASSERT(
  * Command to write a single bit of CO (from I-Config) from 1 to 0.
  */
 struct lt_l3_i_config_write_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The CO address offset for TROPIC01 to compute the actual CO address.
      */
-    u16 address; /**< Configuration object address */
+    uint16_t address; /**< Configuration object address */
     /**
      * @brief
      * The bit to write from 1 to 0. Valid values are 0-31.
      */
-    u8 bit_index; /**< Bit to write. */
-    u8 tag[16];   /**< L3 tag */
+    uint8_t bit_index; /**< Bit to write. */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -530,9 +530,9 @@ STATIC_ASSERT(
  * Command to write a single bit of CO (from I-Config) from 1 to 0.
  */
 struct lt_l3_i_config_write_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -559,14 +559,14 @@ STATIC_ASSERT(
  * Command to read a single CO from I-Config.
  */
 struct lt_l3_i_config_read_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The CO address offset for TROPIC01 to compute the actual CO address.
      */
-    u16 address; /**< Configuration object address */
-    u8 tag[16];  /**< L3 tag */
+    uint16_t address; /**< Configuration object address */
+    uint8_t tag[16];  /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -586,19 +586,19 @@ STATIC_ASSERT(
  * Command to read a single CO from I-Config.
  */
 struct lt_l3_i_config_read_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The CO value TROPIC01 read from the computed address.
      */
-    u32 value;  /**< Configuration object value */
-    u8 tag[16]; /**< L3 tag */
+    uint32_t value;  /**< Configuration object value */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -631,24 +631,24 @@ STATIC_ASSERT(
  * Command to write general purpose data in a slot from the User Data partition in R-Memory.
  */
 struct lt_l3_r_mem_data_write_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot of the User Data partition. Valid values are 0 - 511.
      */
-    u16 udata_slot; /**< Slot to write */
+    uint16_t udata_slot; /**< Slot to write */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding; /**< Padding */
+    uint8_t padding; /**< Padding */
     /**
      * @brief
      * The data stream to be written in the slot specified in the UDATA_SLOT L3 field.
      */
-    u8 data[444]; /**< Data to write */
-    u8 tag[16];   /**< L3 tag */
+    uint8_t data[444]; /**< Data to write */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -670,9 +670,9 @@ STATIC_ASSERT(
  * Command to write general purpose data in a slot from the User Data partition in R-Memory.
  */
 struct lt_l3_r_mem_data_write_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -700,14 +700,14 @@ STATIC_ASSERT(
  * Command to read the general purpose data from a slot of the User Data partition in R-Memory.
  */
 struct lt_l3_r_mem_data_read_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot of the User Data partition. Valid values are 0 - 511.
      */
-    u16 udata_slot; /**< Slot to read */
-    u8 tag[16];     /**< L3 tag */
+    uint16_t udata_slot; /**< Slot to read */
+    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -727,19 +727,19 @@ STATIC_ASSERT(
  * Command to read the general purpose data from a slot of the User Data partition in R-Memory.
  */
 struct lt_l3_r_mem_data_read_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The data stream read from the slot specified in the UDATA_SLOT L3 field.
      */
-    u8 data[444]; /**< Data to read */
-    u8 tag[16];   /**< L3 tag */
+    uint8_t data[444]; /**< Data to read */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -768,14 +768,14 @@ STATIC_ASSERT(
  * Command to erase a slot from the User Data partition in R-Memory.
  */
 struct lt_l3_r_mem_data_erase_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot of the User Data partition. Valid values are 0 - 511.
      */
-    u16 udata_slot; /**< Slot to erase */
-    u8 tag[16];     /**< L3 tag */
+    uint16_t udata_slot; /**< Slot to erase */
+    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -795,9 +795,9 @@ STATIC_ASSERT(
  * Command to erase a slot from the User Data partition in R-Memory.
  */
 struct lt_l3_r_mem_data_erase_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -824,14 +824,14 @@ STATIC_ASSERT(
  * Command to get random numbers generated by TRNG2.
  */
 struct lt_l3_random_value_get_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The number of random bytes to get.
      */
-    u8 n_bytes; /**< Number of bytes to get. */
-    u8 tag[16]; /**< L3 tag */
+    uint8_t n_bytes; /**< Number of bytes to get. */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -851,19 +851,19 @@ STATIC_ASSERT(
  * Command to get random numbers generated by TRNG2.
  */
 struct lt_l3_random_value_get_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The random data from TRNG2 in the number of bytes specified in the N_BYTES L3 Field.
      */
-    u8 random_data[255]; /**< Random data */
-    u8 tag[16];          /**< L3 tag */
+    uint8_t random_data[255]; /**< Random data */
+    uint8_t tag[16];          /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -896,19 +896,19 @@ STATIC_ASSERT(
  * Command to generate an ECC Key and store the key in a slot from the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_generate_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot to write the generated key. Valid values are 0 - 31.
      */
-    u16 slot; /**< ECC Key slot */
+    uint16_t slot; /**< ECC Key slot */
     /**
      * @brief
      * The Elliptic Curve the key is generated from.
      */
-    u8 curve;   /**< Elliptic Curve */
-    u8 tag[16]; /**< L3 tag */
+    uint8_t curve;   /**< Elliptic Curve */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -929,9 +929,9 @@ STATIC_ASSERT(
  * Command to generate an ECC Key and store the key in a slot from the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_generate_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -962,29 +962,29 @@ STATIC_ASSERT(
  * Command to store an ECC Key in a slot from the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_store_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot to write the K L3 Field. Valid values are 0 - 31.
      */
-    u16 slot; /**< ECC Key slot */
+    uint16_t slot; /**< ECC Key slot */
     /**
      * @brief
      * The Elliptic Curve the key is generated from.
      */
-    u8 curve; /**< The type of Elliptic Curve the K L3 Field belongs to. */
+    uint8_t curve; /**< The type of Elliptic Curve the K L3 Field belongs to. */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[12]; /**< Padding */
+    uint8_t padding[12]; /**< Padding */
     /**
      * @brief
      * The ECC Key to store. The key must be a member of the field given by the curve specified in the CURVE L3 Field.
      */
-    u8 k[32];   /**< Key to store */
-    u8 tag[16]; /**< L3 tag */
+    uint8_t k[32];   /**< Key to store */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1007,9 +1007,9 @@ STATIC_ASSERT(
  * Command to store an ECC Key in a slot from the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_store_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1044,14 +1044,14 @@ STATIC_ASSERT(
  * Command to read the public ECC Key from a slot of the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_read_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot to read the public ECC Key from. Valid values are 0 - 31.
      */
-    u16 slot;   /**< ECC Key slot */
-    u8 tag[16]; /**< L3 tag */
+    uint16_t slot;   /**< ECC Key slot */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1071,29 +1071,29 @@ STATIC_ASSERT(
  * Command to read the public ECC Key from a slot of the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_read_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The type of Elliptic Curve public key returned.
      */
-    u8 curve; /**< Elliptic Curve */
+    uint8_t curve; /**< Elliptic Curve */
     /**
      * @brief
      * The origin of the key.
      */
-    u8 origin; /**< Origin of the key. */
+    uint8_t origin; /**< Origin of the key. */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[13]; /**< Padding */
+    uint8_t padding[13]; /**< Padding */
     /**
      * @brief
      * The public key from the ECC Key slot as specified in the SLOT L3 Field.
      */
-    u8 pub_key[64]; /**< Public Key */
-    u8 tag[16];     /**< L3 tag */
+    uint8_t pub_key[64]; /**< Public Key */
+    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1124,14 +1124,14 @@ STATIC_ASSERT(
  * Command to erase an ECC Key from a slot in the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_erase_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot to erase. Valid values are 0 - 31.
      */
-    u16 slot;   /**< ECC Key slot */
-    u8 tag[16]; /**< L3 tag */
+    uint16_t slot;   /**< ECC Key slot */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1151,9 +1151,9 @@ STATIC_ASSERT(
  * Command to erase an ECC Key from a slot in the ECC Keys partition in R-Memory.
  */
 struct lt_l3_ecc_key_erase_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1180,24 +1180,24 @@ STATIC_ASSERT(
  * Command to sign a message hash with an ECDSA algorithm.
  */
 struct lt_l3_ecdsa_sign_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot (from the ECC Keys partition in R-Memory) to read the key for ECDSA signing.
      */
-    u16 slot; /**< ECC Key slot */
+    uint16_t slot; /**< ECC Key slot */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[13]; /**< Padding */
+    uint8_t padding[13]; /**< Padding */
     /**
      * @brief
      * The hash of the message to sign (max size of 32 bytes).
      */
-    u8 msg_hash[32]; /**< Hash of the Message to sign. */
-    u8 tag[16];      /**< L3 tag */
+    uint8_t msg_hash[32]; /**< Hash of the Message to sign. */
+    uint8_t tag[16];      /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1219,24 +1219,24 @@ STATIC_ASSERT(
  * Command to sign a message hash with an ECDSA algorithm.
  */
 struct lt_l3_ecdsa_sign_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[15]; /**< Padding */
+    uint8_t padding[15]; /**< Padding */
     /**
      * @brief
      * ECDSA signature - The R part
      */
-    u8 r[32]; /**< ECDSA Signature - R part */
+    uint8_t r[32]; /**< ECDSA Signature - R part */
     /**
      * @brief
      * ECDSA signature - The S part
      */
-    u8 s[32];   /**< ECDSA Signature - S part */
-    u8 tag[16]; /**< L3 tag */
+    uint8_t s[32];   /**< ECDSA Signature - S part */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1270,24 +1270,24 @@ STATIC_ASSERT(
  * Command to sign a message with an EdDSA algorithm.
  */
 struct lt_l3_eddsa_sign_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot (from the ECC Keys partition in R-Memory) to read the key for EdDSA signing.
      */
-    u16 slot; /**< ECC Key slot */
+    uint16_t slot; /**< ECC Key slot */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[13]; /**< Padding */
+    uint8_t padding[13]; /**< Padding */
     /**
      * @brief
      * The message to sign (max size of 4096 bytes).
      */
-    u8 msg[4096]; /**< Message to sign. */
-    u8 tag[16];   /**< L3 tag */
+    uint8_t msg[4096]; /**< Message to sign. */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1309,24 +1309,24 @@ STATIC_ASSERT(
  * Command to sign a message with an EdDSA algorithm.
  */
 struct lt_l3_eddsa_sign_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[15]; /**< Padding */
+    uint8_t padding[15]; /**< Padding */
     /**
      * @brief
      * EdDSA signature - The R part
      */
-    u8 r[32]; /**< EDDSA Signature - R part */
+    uint8_t r[32]; /**< EDDSA Signature - R part */
     /**
      * @brief
      * EdDSA signature - The S part
      */
-    u8 s[32];   /**< EDDSA Signature - S part */
-    u8 tag[16]; /**< L3 tag */
+    uint8_t s[32];   /**< EDDSA Signature - S part */
+    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1356,24 +1356,24 @@ STATIC_ASSERT(
  * Command to initialize the Monotonic Counter.
  */
 struct lt_l3_mcounter_init_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The index of the Monotonic Counter to initialize. Valid values are 0 - 15.
      */
-    u16 mcounter_index; /**< Index of Monotonic Counter */
+    uint16_t mcounter_index; /**< Index of Monotonic Counter */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding; /**< Padding */
+    uint8_t padding; /**< Padding */
     /**
      * @brief
      * The initialization value of the Monotonic Counter.
      */
-    u32 mcounter_val; /**< Initialization value. */
-    u8 tag[16];       /**< L3 tag */
+    uint32_t mcounter_val; /**< Initialization value. */
+    uint8_t tag[16];       /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1395,9 +1395,9 @@ STATIC_ASSERT(
  * Command to initialize the Monotonic Counter.
  */
 struct lt_l3_mcounter_init_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1424,14 +1424,14 @@ STATIC_ASSERT(
  * Command to update the Monotonic Counter (decrement by 1).
  */
 struct lt_l3_mcounter_update_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The index of the Monotonic Counter to update. Valid values are 0 - 15.
      */
-    u16 mcounter_index; /**< Index of Monotonic Counter */
-    u8 tag[16];         /**< L3 tag */
+    uint16_t mcounter_index; /**< Index of Monotonic Counter */
+    uint8_t tag[16];         /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1451,9 +1451,9 @@ STATIC_ASSERT(
  * Command to update the Monotonic Counter (decrement by 1).
  */
 struct lt_l3_mcounter_update_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1480,14 +1480,14 @@ STATIC_ASSERT(
  * Command to get the value of the Monotonic Counter.
  */
 struct lt_l3_mcounter_get_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The index of the Monotonic Counter to get the value of. Valid index values are 0 - 15.
      */
-    u16 mcounter_index; /**< Index of Monotonic Counter */
-    u8 tag[16];         /**< L3 tag */
+    uint16_t mcounter_index; /**< Index of Monotonic Counter */
+    uint8_t tag[16];         /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1507,19 +1507,19 @@ STATIC_ASSERT(
  * Command to get the value of the Monotonic Counter.
  */
 struct lt_l3_mcounter_get_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The value of the Monotonic Counter specified by the MCOUNTER_INDEX L3 Field.
      */
-    u32 mcounter_val; /**< Initialization value. */
-    u8 tag[16];       /**< L3 tag */
+    uint32_t mcounter_val; /**< Initialization value. */
+    uint8_t tag[16];       /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1548,25 +1548,25 @@ STATIC_ASSERT(
  * Command to execute the MAC-and-Destroy sequence.
  */
 struct lt_l3_mac_and_destroy_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
     /**
      * @brief
      * The slot (from the MAC-and-Destroy data partition in R-Memory) to execute the MAC_And_Destroy sequence. Valid
      * values are 0 - 127.
      */
-    u16 slot; /**< Mac-and-Destroy slot */
+    uint16_t slot; /**< Mac-and-Destroy slot */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding; /**< Padding */
+    uint8_t padding; /**< Padding */
     /**
      * @brief
      * The data input for the MAC-and-Destroy sequence.
      */
-    u8 data_in[32]; /**< Input data */
-    u8 tag[16];     /**< L3 tag */
+    uint8_t data_in[32]; /**< Input data */
+    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1588,19 +1588,19 @@ STATIC_ASSERT(
  * Command to execute the MAC-and-Destroy sequence.
  */
 struct lt_l3_mac_and_destroy_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The data output from the MAC-and-Destroy sequence.
      */
-    u8 data_out[32]; /**< Output data */
-    u8 tag[16];      /**< L3 tag */
+    uint8_t data_out[32]; /**< Output data */
+    uint8_t tag[16];      /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1629,9 +1629,9 @@ STATIC_ASSERT(
  * Command to obtain the unique per-chip identifier.
  */
 struct lt_l3_serial_code_get_cmd_t {
-    u16 cmd_size; /**< L3 command size */
-    u8 cmd_id;    /**< Command Identifier */
-    u8 tag[16];   /**< L3 tag */
+    uint16_t cmd_size; /**< L3 command size */
+    uint8_t cmd_id;    /**< Command Identifier */
+    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1650,19 +1650,19 @@ STATIC_ASSERT(
  * Command to obtain the unique per-chip identifier.
  */
 struct lt_l3_serial_code_get_res_t {
-    u16 res_size; /**< L3 result size */
-    u8 result;    /**< Result status indication */
+    uint16_t res_size; /**< L3 result size */
+    uint8_t result;    /**< Result status indication */
     /**
      * @brief
      * The padding by dummy data.
      */
-    u8 padding[3]; /**< Padding */
+    uint8_t padding[3]; /**< Padding */
     /**
      * @brief
      * The unique per-chip identifier.
      */
-    u8 serial_code[32]; /**< Serial code */
-    u8 tag[16];         /**< L3 tag */
+    uint8_t serial_code[32]; /**< Serial code */
+    uint8_t tag[16];         /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off


### PR DESCRIPTION
In this PR I refactor usage of `typedef` keyword:
- In the public API, the typedef is used with every struct/enum.
- I removed u8/u16/u32 typedefs.