### PR TITLE
Refactor ECC_Key_Read API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Macro `LT_USE_ASSERT`, `assert()` is always inserted.
 - Functions `get_conf_addr()`, `get_conf_desc()`, accessing the configuration table directly is advised instead.
+- Removed `keylen` parameter from `lt_ecc_key_read()` and `lt_in__ecc_key_read()`.
 
 ## [0.1.0]
 

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -410,7 +410,7 @@ static int session_H3(void)
     uint8_t slot_0_pubkey[64];
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
-    LT_ASSERT(LT_OK, lt_ecc_key_read(&h, ECC_SLOT_0, slot_0_pubkey, 64, &curve, &origin));
+    LT_ASSERT(LT_OK, lt_ecc_key_read(&h, ECC_SLOT_0, slot_0_pubkey, &curve, &origin));
 
     LT_LOG("%s", "lt_ecc_eddsa_sig_verify() ");
     LT_ASSERT(LT_OK, lt_ecc_eddsa_sig_verify(msg, 4, slot_0_pubkey, rs));

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -350,18 +350,17 @@ lt_ret_t lt_ecc_key_generate(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc
 lt_ret_t lt_ecc_key_store(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_curve_type_t curve, const uint8_t *key);
 
 /**
- * @brief Read ECC public key corresponding to a private key in device's slot
+ * @brief Read ECC public key corresponding to a private key in device's slot.
  *
  * @param h           Device's handle
  * @param ecc_slot    Slot number ECC_SLOT_0 - ECC_SLOT_31
- * @param key         Buffer for retrieving a key
- * @param keylen      Length of the key's buffer
+ * @param key         Buffer for retrieving a key (length of the key is given by *curve*)
  * @param curve       Will be filled by curve byte
  * @param origin      Will be filled by origin byte
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_ecc_key_read(lt_handle_t *h, const ecc_slot_t ecc_slot, uint8_t *key, const uint8_t keylen,
-                         lt_ecc_curve_type_t *curve, ecc_key_origin_t *origin);
+lt_ret_t lt_ecc_key_read(lt_handle_t *h, const ecc_slot_t ecc_slot, uint8_t *key, lt_ecc_curve_type_t *curve,
+                         ecc_key_origin_t *origin);
 
 /**
  * @brief Erase ECC key from device's slot

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -354,7 +354,8 @@ lt_ret_t lt_ecc_key_store(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_cu
  *
  * @param h           Device's handle
  * @param ecc_slot    Slot number ECC_SLOT_0 - ECC_SLOT_31
- * @param key         Buffer for retrieving a key (length of the key is given by *curve*)
+ * @param key         Buffer for retrieving a key; length depends on the type of key in the slot (32B for Ed25519, 64B
+ * for P256), according to *curve*
  * @param curve       Will be filled by curve byte
  * @param origin      Will be filled by origin byte
  * @return            LT_OK if success, otherwise returns other error code.

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -339,12 +339,12 @@ lt_ret_t lt_random_get(lt_handle_t *h, uint8_t *buff, const uint16_t len);
 lt_ret_t lt_ecc_key_generate(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_curve_type_t curve);
 
 /**
- * @brief Store ECC key in the device's ECC key slot
+ * @brief Store ECC key in the device's ECC key slot.
  *
  * @param h           Device's handle
  * @param slot        Slot number ecc_slot_t
  * @param curve       Type of ECC curve. Use L3_ECC_KEY_GENERATE_CURVE_ED25519 or L3_ECC_KEY_GENERATE_CURVE_P256
- * @param key         Key to store
+ * @param key         Key to store (only the first 32 bytes are stored)
  * @return            LT_OK if success, otherwise returns other error code.
  */
 lt_ret_t lt_ecc_key_store(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_curve_type_t curve, const uint8_t *key);

--- a/include/lt_l3.h
+++ b/include/lt_l3.h
@@ -371,14 +371,12 @@ lt_ret_t lt_out__ecc_key_read(lt_handle_t *h, const ecc_slot_t slot);
  * the top of this file.
  *
  * @param h           Device's handle
- * @param key         Buffer to receive ECC public key
- * @param keylen      Length of the key's buffer, must be at least 64 bytes
+ * @param key         Buffer to receive ECC public key (length of the key is given by *curve*)
  * @param curve       Will be filled by curve type
  * @param origin      Will be filled by origin type
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_in__ecc_key_read(lt_handle_t *h, uint8_t *key, const uint8_t keylen, lt_ecc_curve_type_t *curve,
-                             ecc_key_origin_t *origin);
+lt_ret_t lt_in__ecc_key_read(lt_handle_t *h, uint8_t *key, lt_ecc_curve_type_t *curve, ecc_key_origin_t *origin);
 
 /**
  * @brief Encodes 'ECC key erase' command payload. Used for separate l3 communication, for more information read info at

--- a/include/lt_l3.h
+++ b/include/lt_l3.h
@@ -371,7 +371,8 @@ lt_ret_t lt_out__ecc_key_read(lt_handle_t *h, const ecc_slot_t slot);
  * the top of this file.
  *
  * @param h           Device's handle
- * @param key         Buffer to receive ECC public key (length of the key is given by *curve*)
+ * @param key         Buffer for retrieving a key; length depends on the type of key in the slot (32B for Ed25519, 64B
+ * for P256), according to *curve*
  * @param curve       Will be filled by curve type
  * @param origin      Will be filled by origin type
  * @return            LT_OK if success, otherwise returns other error code.

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1017,17 +1017,14 @@ lt_ret_t lt_ecc_key_store(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_cu
     return lt_in__ecc_key_store(h);
 }
 
-lt_ret_t lt_ecc_key_read(lt_handle_t *h, const ecc_slot_t ecc_slot, uint8_t *key, const uint8_t keylen,
-                         lt_ecc_curve_type_t *curve, ecc_key_origin_t *origin)
+lt_ret_t lt_ecc_key_read(lt_handle_t *h, const ecc_slot_t ecc_slot, uint8_t *key, lt_ecc_curve_type_t *curve,
+                         ecc_key_origin_t *origin)
 {
     if (!h || ecc_slot < ECC_SLOT_0 || ecc_slot > ECC_SLOT_31 || !key || !curve || !origin) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
         return LT_HOST_NO_SESSION;
-    }
-    if (keylen < 64) {
-        return LT_PARAM_ERR;
     }
 
     lt_ret_t ret = lt_out__ecc_key_read(h, ecc_slot);
@@ -1045,7 +1042,7 @@ lt_ret_t lt_ecc_key_read(lt_handle_t *h, const ecc_slot_t ecc_slot, uint8_t *key
         return ret;
     }
 
-    return lt_in__ecc_key_read(h, key, keylen, curve, origin);
+    return lt_in__ecc_key_read(h, key, curve, origin);
 }
 
 lt_ret_t lt_ecc_key_erase(lt_handle_t *h, const ecc_slot_t ecc_slot)

--- a/src/lt_l3.c
+++ b/src/lt_l3.c
@@ -915,10 +915,9 @@ lt_ret_t lt_out__ecc_key_read(lt_handle_t *h, const ecc_slot_t slot)
     return lt_l3_encrypt_request(&h->l3);
 }
 
-lt_ret_t lt_in__ecc_key_read(lt_handle_t *h, uint8_t *key, const uint8_t keylen, lt_ecc_curve_type_t *curve,
-                             ecc_key_origin_t *origin)
+lt_ret_t lt_in__ecc_key_read(lt_handle_t *h, uint8_t *key, lt_ecc_curve_type_t *curve, ecc_key_origin_t *origin)
 {
-    if (!h || !key || !curve || !origin || (keylen < 64)) {
+    if (!h || !key || !curve || !origin) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {

--- a/tests/functional/lt_test_ecc_eddsa.c
+++ b/tests/functional/lt_test_ecc_eddsa.c
@@ -65,7 +65,7 @@ int lt_test_ecc_eddsa(void)
         uint8_t slot_0_pubkey[64];
         lt_ecc_curve_type_t curve;
         ecc_key_origin_t origin;
-        LT_TEST_ASSERT(lt_ecc_key_read(&h, i, slot_0_pubkey, 64, &curve, &origin), LT_OK);
+        LT_TEST_ASSERT(lt_ecc_key_read(&h, i, slot_0_pubkey, &curve, &origin), LT_OK);
 
         LT_LOG("lt_ecc_eddsa_sign() slot       n.%d  ", i);
         uint8_t msg[] = {'a', 'h', 'o', 'j'};
@@ -91,7 +91,7 @@ int lt_test_ecc_eddsa(void)
         uint8_t slot_0_pubkey[64];
         lt_ecc_curve_type_t curve;
         ecc_key_origin_t origin;
-        LT_LOG_RESULT("%s", lt_ret_verbose(lt_ecc_key_read(&h, i, slot_0_pubkey, 64, &curve, &origin)));
+        LT_LOG_RESULT("%s", lt_ret_verbose(lt_ecc_key_read(&h, i, slot_0_pubkey, &curve, &origin)));
 
         LT_LOG("lt_ecc_eddsa_sign() slot       n.%d  ", i);
         uint8_t msg[] = {'a', 'h', 'o', 'j'};


### PR DESCRIPTION
Removed `keylen` parameter because the length of the key can be determined by the `curve` parameter - for P256, length is 64B and for ED25519, it is 32B. This should make the function usage more deterministic.