### PR TITLE
Refactor lt test ire read write pairing keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ endif()
 set(LIBTROPIC_TEST_LIST
     lt_test_ecc_ecdsa
     lt_test_ecc_eddsa
-    lt_test_ire_read_write_pairing_keys
+    lt_test_ire_pairing_key_slots
     lt_test_rev_ping
     lt_test_rev_r_mem
     lt_test_rev_erase_r_config
@@ -197,7 +197,7 @@ if(LT_BUILD_TESTS)
         # Files which include test functions definitions.
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_ecc_ecdsa.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_ecc_eddsa.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_ire_read_write_pairing_keys.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_ire_pairing_key_slots.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_rev_ping.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_rev_r_mem.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/functional/lt_test_rev_erase_r_config.c

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -90,7 +90,7 @@ int lt_test_ecc_eddsa(void);
 int lt_test_ecc_ecdsa(void);
 
 /**
- * @brief Test Pairing_Key_Read and Pairing_Key_Write on all slots.
+ * @brief Test Pairing_Key_Read, Pairing_Key_Write and Pairing_Key_Invalidate on all slots.
  *
  * Test steps:
  *  1. Start Secure Session with pairing key slot 0 and read it.
@@ -98,8 +98,10 @@ int lt_test_ecc_ecdsa(void);
  *  3. Write pairing key slots 1,2,3.
  *  4. Read all pairing key slots and check for expected value.
  *  5. Write zeros to all pairing key slots and check for failure.
+ *  6. Invalidate all pairing key slots.
+ *  7. Read all pairing key slots and check for failure.
  */
-void lt_test_ire_read_write_pairing_keys(void);
+void lt_test_ire_pairing_key_slots(void);
 
 /**
  * @brief Test Ping L3 command with random data of random length <= PING_LEN_MAX.

--- a/tests/functional/lt_test_ire_pairing_key_slots.c
+++ b/tests/functional/lt_test_ire_pairing_key_slots.c
@@ -1,6 +1,6 @@
 /**
- * @file lt_test_ire_read_write_pairing_keys.c
- * @brief Test Pairing_Key_Read and Pairing_Key_Write on all slots.
+ * @file lt_test_ire_pairing_key_slots.c
+ * @brief Test Pairing_Key_Read, Pairing_Key_Write and Pairing_Key_Invalidate on all slots.
  * @author Tropic Square s.r.o.
  *
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
@@ -34,10 +34,10 @@ static void print_bytes(uint8_t *data, uint16_t len)
     }
 }
 
-void lt_test_ire_read_write_pairing_keys(void)
+void lt_test_ire_pairing_key_slots(void)
 {
     LT_LOG_INFO("----------------------------------------------");
-    LT_LOG_INFO("lt_test_ire_read_write_pairing_keys()");
+    LT_LOG_INFO("lt_test_ire_pairing_key_slots()");
     LT_LOG_INFO("----------------------------------------------");
 
     lt_handle_t h = {0};
@@ -83,7 +83,7 @@ void lt_test_ire_read_write_pairing_keys(void)
         LT_LOG_INFO("Reading pairing key slot %d...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
-        
+
         LT_LOG_INFO("Comparing contents of written and read key...");
         LT_TEST_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
         LT_LOG_INFO();
@@ -94,11 +94,11 @@ void lt_test_ire_read_write_pairing_keys(void)
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
         LT_LOG_INFO("Writing to pairing key slot %d (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_FAIL, lt_pairing_key_write(&h, zeros, i));
-        
+
         LT_LOG_INFO("Reading pairing key slot %d...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
-        
+
         LT_LOG_INFO("Comparing contents of expected key and read key...");
         LT_TEST_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
         LT_LOG_INFO();
@@ -108,7 +108,7 @@ void lt_test_ire_read_write_pairing_keys(void)
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
         LT_LOG_INFO("Invalidating pairing key slot %d...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_invalidate(&h, i));
-        
+
         LT_LOG_INFO("Reading pairing key slot %d (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_PAIRING_KEY_INVALID, lt_pairing_key_read(&h, read_key, i));
     }

--- a/tests/functional/lt_test_ire_read_write_pairing_keys.c
+++ b/tests/functional/lt_test_ire_read_write_pairing_keys.c
@@ -58,12 +58,12 @@ void lt_test_ire_read_write_pairing_keys(void)
     LT_LOG_LINE();
 
     // Read pairing keys (1,2,3 should be empty)
-    LT_LOG_INFO("Reading pairing key slot 0:");
+    LT_LOG_INFO("Reading pairing key slot 0...");
     LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, PAIRING_KEY_SLOT_INDEX_0));
     print_bytes(read_key, 32);
     LT_LOG_INFO();
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Reading pairing key slot %d, asserting LT_L3_PAIRING_KEY_EMPTY", i);
+        LT_LOG_INFO("Reading pairing key slot %d (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_PAIRING_KEY_EMPTY, lt_pairing_key_read(&h, read_key, i));
         LT_LOG_INFO();
     }
@@ -71,7 +71,7 @@ void lt_test_ire_read_write_pairing_keys(void)
 
     // Write pairing keys into slot 1,2,3
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Writing to pairing key slot %d:", i);
+        LT_LOG_INFO("Writing to pairing key slot %d...", i);
         print_bytes(pub_keys[i], 32);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_write(&h, pub_keys[i], i));
         LT_LOG_INFO();
@@ -80,10 +80,11 @@ void lt_test_ire_read_write_pairing_keys(void)
 
     // Read all pairing keys and check value
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Reading pairing key slot %d:", i);
+        LT_LOG_INFO("Reading pairing key slot %d...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
-        LT_LOG_INFO("Comparing contents of written and read key");
+        
+        LT_LOG_INFO("Comparing contents of written and read key...");
         LT_TEST_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
         LT_LOG_INFO();
     }
@@ -91,12 +92,14 @@ void lt_test_ire_read_write_pairing_keys(void)
 
     // Write pairing key slots again (should fail)
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Writing zeros to pairing key slot %d, asserting LT_L3_FAIL", i);
+        LT_LOG_INFO("Writing to pairing key slot %d (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_FAIL, lt_pairing_key_write(&h, zeros, i));
-        LT_LOG_INFO("Reading pairing key slot %d:", i);
+        
+        LT_LOG_INFO("Reading pairing key slot %d...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
-        LT_LOG_INFO("Comparing contents of expected key and read key");
+        
+        LT_LOG_INFO("Comparing contents of expected key and read key...");
         LT_TEST_ASSERT(0, memcmp(pub_keys[i], read_key, 32));
         LT_LOG_INFO();
     }

--- a/tests/functional/lt_test_ire_read_write_pairing_keys.c
+++ b/tests/functional/lt_test_ire_read_write_pairing_keys.c
@@ -105,6 +105,15 @@ void lt_test_ire_read_write_pairing_keys(void)
     }
     LT_LOG_LINE();
 
+    for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
+        LT_LOG_INFO("Invalidating pairing key slot %d...", i);
+        LT_TEST_ASSERT(LT_OK, lt_pairing_key_invalidate(&h, i));
+        
+        LT_LOG_INFO("Reading pairing key slot %d (should fail)...", i);
+        LT_TEST_ASSERT(LT_L3_PAIRING_KEY_INVALID, lt_pairing_key_read(&h, read_key, i));
+    }
+    LT_LOG_LINE();
+
     LT_LOG_INFO("Aborting Secure Session");
     LT_TEST_ASSERT(LT_OK, lt_session_abort(&h));
 


### PR DESCRIPTION
Changes:
- updated logging
- test also Pairing_Key_Invalidate
- renamed to `lt_test_ire_pairing_key_slots`