### PR TITLE
Fix STM32 compilation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `STATIC` to `LT_STATIC` due to naming conflicts.
 - Moved `lt_uart_def_unix_t` to `libtropic_port.h`.
 - Updated `enum CONFIGURATION_OBJECTS_REGS` with values from `include/tropic01_application_co.h` and `include/tropic01_bootloader_co.h` to be compatible with User API v1.3.0.
+- Use strict format string types from `inttypes.h` or `%zu` for `size_t` (increases good portability).
 
 ### Added
 - Macro `LT_CONFIG_OBJ_CNT` for number of objects in the configuration structure.
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `rs_len` parameter from `lt_ecc_eddsa_sign()` and `lt_ecc_ecdsa_sign()`.
 - Removed macro `LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MIN`.
 - Header file `include/TROPIC01_configuration_objects.h`.
+- Checks with `<` for enums (fixes compilation errors on STM32 and shouldn't be needed anyway).
 
 ## [0.1.0]
 

--- a/examples/lt_ex_fw_update.c
+++ b/examples/lt_ex_fw_update.c
@@ -11,7 +11,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_examples.h"

--- a/examples/lt_ex_fw_update.c
+++ b/examples/lt_ex_fw_update.c
@@ -12,6 +12,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_examples.h"

--- a/examples/lt_ex_hello_world.c
+++ b/examples/lt_ex_hello_world.c
@@ -38,10 +38,10 @@ int lt_ex_hello_world(void)
         return -1;
     }
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_0,
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", (int)PAIRING_KEY_SLOT_INDEX_0,
                      lt_ret_verbose(ret));
         lt_deinit(&h);
         return -1;

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -6,12 +6,13 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_examples.h"
 #include "libtropic_logging.h"
 #include "string.h"
-#include <inttypes.h>
 
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "Ping message for TROPIC01"
@@ -308,7 +309,7 @@ static int session_initial(lt_handle_t *h)
         return -1;
     }
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08"PRIu32, cfg_desc_table[i].desc, r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIu32, cfg_desc_table[i].desc, r_config.obj[i]);
     }
 
     LT_LOG_INFO("Creating an example config from the read R config...");
@@ -329,12 +330,12 @@ static int session_initial(lt_handle_t *h)
         return -1;
     }
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08"PRIu32, cfg_desc_table[i].desc, r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIu32, cfg_desc_table[i].desc, r_config.obj[i]);
     }
 
     // Write pairing keys into slots 1,2,3
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Writing to pairing key slot %"PRIu8"...", i);
+        LT_LOG_INFO("Writing to pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, pub_keys[i], i);
         if (LT_OK != ret) {
             LT_LOG_ERROR("Failed to write pairing key, ret=%s", lt_ret_verbose(ret));
@@ -459,7 +460,7 @@ static int session1(lt_handle_t *h)
     uint8_t dummy_key[32] = {0};
     LT_LOG_INFO("Writing all pairing key slots (should fail):");
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("\tWriting pairing key slot %"PRIu8"...", i);
+        LT_LOG_INFO("\tWriting pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
@@ -533,7 +534,7 @@ static int session2(lt_handle_t *h)
 
     LT_LOG_INFO("Writing all pairing key slots (should fail):");
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("\tWriting pairing key slot %"PRIu8"...", i);
+        LT_LOG_INFO("\tWriting pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
@@ -721,7 +722,7 @@ static int session3(lt_handle_t *h)
 
     LT_LOG_INFO("Writing all pairing key slots (should fail):");
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("\tWriting pairing key slot %"PRIu8"...", i);
+        LT_LOG_INFO("\tWriting pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -6,13 +6,12 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_examples.h"
 #include "libtropic_logging.h"
 #include "string.h"
-#include "inttypes.h"
+#include <inttypes.h>
 
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "Ping message for TROPIC01"

--- a/examples/lt_ex_hw_wallet.c
+++ b/examples/lt_ex_hw_wallet.c
@@ -12,6 +12,7 @@
 #include "libtropic_examples.h"
 #include "libtropic_logging.h"
 #include "string.h"
+#include "inttypes.h"
 
 /** @brief Message to send with Ping L3 command. */
 #define PING_MSG "Ping message for TROPIC01"
@@ -293,10 +294,10 @@ static int session_initial(lt_handle_t *h)
         return -1;
     }
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_0,
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", (int)PAIRING_KEY_SLOT_INDEX_0,
                      lt_ret_verbose(ret));
         return -1;
     }
@@ -308,7 +309,7 @@ static int session_initial(lt_handle_t *h)
         return -1;
     }
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08"PRIu32, cfg_desc_table[i].desc, r_config.obj[i]);
     }
 
     LT_LOG_INFO("Creating an example config from the read R config...");
@@ -329,12 +330,12 @@ static int session_initial(lt_handle_t *h)
         return -1;
     }
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08"PRIu32, cfg_desc_table[i].desc, r_config.obj[i]);
     }
 
     // Write pairing keys into slots 1,2,3
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Writing to pairing key slot %d...", i);
+        LT_LOG_INFO("Writing to pairing key slot %"PRIu8"...", i);
         ret = lt_pairing_key_write(h, pub_keys[i], i);
         if (LT_OK != ret) {
             LT_LOG_ERROR("Failed to write pairing key, ret=%s", lt_ret_verbose(ret));
@@ -343,7 +344,7 @@ static int session_initial(lt_handle_t *h)
         LT_LOG_INFO("\tOK");
     }
 
-    LT_LOG_INFO("Invalidating pairing key slot %d...", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Invalidating pairing key slot %d...", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = lt_pairing_key_invalidate(h, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to invalidate pairing key slot, ret=%s", lt_ret_verbose(ret));
@@ -393,7 +394,7 @@ static int session0(lt_handle_t *h)
         return -1;
     }
 
-    LT_LOG_INFO("Starting Secure Session with key %d (should fail)", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d (should fail)", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_L2_HSK_ERR != ret) {
         LT_LOG_ERROR("Return value is not LT_L2_HSK_ERR, ret=%s", lt_ret_verbose(ret));
@@ -428,10 +429,10 @@ static int session1(lt_handle_t *h)
         return -1;
     }
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_1);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_1);
     ret = verify_chip_and_start_secure_session(h, sh1priv, sh1pub, PAIRING_KEY_SLOT_INDEX_1);
     if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_1,
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", (int)PAIRING_KEY_SLOT_INDEX_1,
                      lt_ret_verbose(ret));
         return -1;
     }
@@ -448,10 +449,10 @@ static int session1(lt_handle_t *h)
     LT_LOG_INFO("Message received from TROPIC01:");
     LT_LOG_INFO("\t\"%s\"", recv_buf);
 
-    LT_LOG_INFO("Storing attestation key into ECC slot %d...", ECC_SLOT_0);
+    LT_LOG_INFO("Storing attestation key into ECC slot %d...", (int)ECC_SLOT_0);
     ret = lt_ecc_key_store(h, ECC_SLOT_0, CURVE_ED25519, attestation_key);
     if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to store ECC key to slot %d, ret=%s", ECC_SLOT_0, lt_ret_verbose(ret));
+        LT_LOG_ERROR("Failed to store ECC key to slot %d, ret=%s", (int)ECC_SLOT_0, lt_ret_verbose(ret));
         return -1;
     }
     LT_LOG_INFO("\tOK");
@@ -459,7 +460,7 @@ static int session1(lt_handle_t *h)
     uint8_t dummy_key[32] = {0};
     LT_LOG_INFO("Writing all pairing key slots (should fail):");
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("\tWriting pairing key slot %d...", i);
+        LT_LOG_INFO("\tWriting pairing key slot %"PRIu8"...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
@@ -502,10 +503,10 @@ static int session2(lt_handle_t *h)
         return -1;
     }
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_2);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_2);
     ret = verify_chip_and_start_secure_session(h, sh2priv, sh2pub, PAIRING_KEY_SLOT_INDEX_2);
     if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_2,
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", (int)PAIRING_KEY_SLOT_INDEX_2,
                      lt_ret_verbose(ret));
         return -1;
     }
@@ -523,7 +524,7 @@ static int session2(lt_handle_t *h)
     LT_LOG_INFO("\t\"%s\"", recv_buf);
 
     uint8_t dummy_key[32];
-    LT_LOG_INFO("Trying to store key into ECC slot %d (should fail)", ECC_SLOT_0);
+    LT_LOG_INFO("Trying to store key into ECC slot %d (should fail)", (int)ECC_SLOT_0);
     ret = lt_ecc_key_store(h, ECC_SLOT_0, CURVE_ED25519, dummy_key);
     if (LT_L3_UNAUTHORIZED != ret) {
         LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
@@ -533,7 +534,7 @@ static int session2(lt_handle_t *h)
 
     LT_LOG_INFO("Writing all pairing key slots (should fail):");
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("\tWriting pairing key slot %d...", i);
+        LT_LOG_INFO("\tWriting pairing key slot %"PRIu8"...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
@@ -603,10 +604,10 @@ static int session3(lt_handle_t *h)
         return -1;
     }
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_3);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_3);
     ret = verify_chip_and_start_secure_session(h, sh3priv, sh3pub, PAIRING_KEY_SLOT_INDEX_3);
     if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_3,
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", (int)PAIRING_KEY_SLOT_INDEX_3,
                      lt_ret_verbose(ret));
         return -1;
     }
@@ -633,7 +634,7 @@ static int session3(lt_handle_t *h)
     }
     LT_LOG_INFO("\tOK");
 
-    LT_LOG_INFO("Reading ECC key slot %d...", ECC_SLOT_0);
+    LT_LOG_INFO("Reading ECC key slot %d...", (int)ECC_SLOT_0);
     uint8_t slot_0_pubkey[64];
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
@@ -652,7 +653,7 @@ static int session3(lt_handle_t *h)
     }
     LT_LOG_INFO("\tOK");
 
-    LT_LOG_INFO("Generating ECC key in slot %d...", ECC_SLOT_8);
+    LT_LOG_INFO("Generating ECC key in slot %d...", (int)ECC_SLOT_8);
     ret = lt_ecc_key_generate(h, ECC_SLOT_8, CURVE_ED25519);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to generate ECC key, ret=%s", lt_ret_verbose(ret));
@@ -660,7 +661,7 @@ static int session3(lt_handle_t *h)
     }
     LT_LOG_INFO("\tOK");
 
-    LT_LOG_INFO("Generating ECC key in slot %d...", ECC_SLOT_16);
+    LT_LOG_INFO("Generating ECC key in slot %d...", (int)ECC_SLOT_16);
     ret = lt_ecc_key_generate(h, ECC_SLOT_16, CURVE_ED25519);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to generate ECC key, ret=%s", lt_ret_verbose(ret));
@@ -668,7 +669,7 @@ static int session3(lt_handle_t *h)
     }
     LT_LOG_INFO("\tOK");
 
-    LT_LOG_INFO("Generating ECC key in slot %d...", ECC_SLOT_24);
+    LT_LOG_INFO("Generating ECC key in slot %d...", (int)ECC_SLOT_24);
     ret = lt_ecc_key_generate(h, ECC_SLOT_24, CURVE_ED25519);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to generate ECC key, ret=%s", lt_ret_verbose(ret));
@@ -676,7 +677,7 @@ static int session3(lt_handle_t *h)
     }
     LT_LOG_INFO("\tOK");
 
-    LT_LOG_INFO("Getting %d random bytes...", RANDOM_VALUE_GET_LEN_MAX);
+    LT_LOG_INFO("Getting %d random bytes...", (int)RANDOM_VALUE_GET_LEN_MAX);
     uint8_t buff[RANDOM_VALUE_GET_LEN_MAX];
     ret = lt_random_value_get(h, buff, RANDOM_VALUE_GET_LEN_MAX);
     if (LT_OK != ret) {
@@ -711,7 +712,7 @@ static int session3(lt_handle_t *h)
     LT_LOG_INFO("\tOK");
 
     uint8_t dummy_key[32];
-    LT_LOG_INFO("Trying to store key into ECC slot %d (should fail)", ECC_SLOT_0);
+    LT_LOG_INFO("Trying to store key into ECC slot %d (should fail)", (int)ECC_SLOT_0);
     ret = lt_ecc_key_store(h, ECC_SLOT_0, CURVE_ED25519, dummy_key);
     if (LT_L3_UNAUTHORIZED != ret) {
         LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));
@@ -721,7 +722,7 @@ static int session3(lt_handle_t *h)
 
     LT_LOG_INFO("Writing all pairing key slots (should fail):");
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("\tWriting pairing key slot %d...", i);
+        LT_LOG_INFO("\tWriting pairing key slot %"PRIu8"...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_UNAUTHORIZED, ret=%s", lt_ret_verbose(ret));

--- a/examples/lt_ex_macandd.c
+++ b/examples/lt_ex_macandd.c
@@ -132,7 +132,9 @@ static lt_ret_t lt_PIN_set(lt_handle_t *h, const uint8_t *PIN, const uint8_t PIN
     memcpy(kdf_input_buff + PIN_size, add, add_size);
 
     LT_LOG_INFO("Getting random bytes...");
-    lt_ret_t ret = lt_port_random_bytes((uint32_t *)s, 8);
+    uint32_t random_data[sizeof(s) / 4];
+    lt_ret_t ret = lt_port_random_bytes(random_data, sizeof(s) / 4);
+    memcpy(s, random_data, sizeof(s));
     if (ret != LT_OK) {
         LT_LOG_ERROR("Failed to get random bytes, ret=%s", lt_ret_verbose(ret));
         goto exit;

--- a/examples/lt_ex_macandd.c
+++ b/examples/lt_ex_macandd.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_examples.h"
 #include "libtropic_logging.h"
@@ -37,7 +38,7 @@ static char *print_bytes(uint8_t *data, uint16_t len)
     bytes_buffer[0] = '\0';
     for (uint16_t i = 0; i < len; i++) {
         char byte_str[4];
-        snprintf(byte_str, sizeof(byte_str), "%02"PRIX8, data[i]);
+        snprintf(byte_str, sizeof(byte_str), "%02" PRIX8, data[i]);
         // Check if appending the byte would exceed the buffer size
         if (strlen(bytes_buffer) + strlen(byte_str) + 1 > sizeof(bytes_buffer)) {
             break;  // Stop if the buffer is full

--- a/examples/lt_ex_macandd.c
+++ b/examples/lt_ex_macandd.c
@@ -37,7 +37,7 @@ static char *print_bytes(uint8_t *data, uint16_t len)
     bytes_buffer[0] = '\0';
     for (uint16_t i = 0; i < len; i++) {
         char byte_str[4];
-        snprintf(byte_str, sizeof(byte_str), "%02X", data[i]);
+        snprintf(byte_str, sizeof(byte_str), "%02"PRIX8, data[i]);
         // Check if appending the byte would exceed the buffer size
         if (strlen(bytes_buffer) + strlen(byte_str) + 1 > sizeof(bytes_buffer)) {
             break;  // Stop if the buffer is full
@@ -416,10 +416,10 @@ int lt_ex_macandd(void)
         return -1;
     }
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", PAIRING_KEY_SLOT_INDEX_0,
+        LT_LOG_ERROR("Failed to start Secure Session with key %d, ret=%s", (int)PAIRING_KEY_SLOT_INDEX_0,
                      lt_ret_verbose(ret));
         lt_deinit(&h);
         return -1;

--- a/examples/lt_ex_macandd.c
+++ b/examples/lt_ex_macandd.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_examples.h"
 #include "libtropic_logging.h"

--- a/hal/port/unix/lt_port_raspberrypi_wiringpi.c
+++ b/hal/port/unix/lt_port_raspberrypi_wiringpi.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include <wiringPi.h>     /// for GPIO control
 #include <wiringPiSPI.h>  /// For SPI control
 
@@ -31,7 +32,7 @@ int fd = 0;
 #define LOG_ERR(f_, ...) fprintf(stderr, "ERROR: " f_, ##__VA_ARGS__)
 #define LOG_U8_ARRAY(arr, len)      \
     for (int i = 0; i < len; i++) { \
-        printf("%02x ", arr[i]);    \
+        printf("%02"PRIx8" ", arr[i]);    \
     }                               \
     printf("\r\n");
 #else
@@ -93,7 +94,7 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *h)
 lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data_length, uint32_t timeout)
 {
     UNUSED(timeout);
-    LOG_OUT("-- Transfer of %d B\n", tx_data_length);
+    LOG_OUT("-- Transfer of %"PRIu16" B\n", tx_data_length);
 
     int ret = wiringPiSPIxDataRW(0, 0, h->buff + offset, tx_data_length);
 

--- a/hal/port/unix/lt_port_raspberrypi_wiringpi.c
+++ b/hal/port/unix/lt_port_raspberrypi_wiringpi.c
@@ -7,12 +7,12 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <inttypes.h>
 #include <wiringPi.h>     /// for GPIO control
 #include <wiringPiSPI.h>  /// For SPI control
 
@@ -30,10 +30,10 @@ int fd = 0;
 #ifdef LIBT_DEBUG
 #define LOG_OUT(f_, ...) printf("[TCP] " f_, ##__VA_ARGS__)
 #define LOG_ERR(f_, ...) fprintf(stderr, "ERROR: " f_, ##__VA_ARGS__)
-#define LOG_U8_ARRAY(arr, len)      \
-    for (int i = 0; i < len; i++) { \
-        printf("%02"PRIx8" ", arr[i]);    \
-    }                               \
+#define LOG_U8_ARRAY(arr, len)           \
+    for (int i = 0; i < len; i++) {      \
+        printf("%02" PRIx8 " ", arr[i]); \
+    }                                    \
     printf("\r\n");
 #else
 #define LOG_OUT(...)
@@ -94,7 +94,7 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *h)
 lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data_length, uint32_t timeout)
 {
     UNUSED(timeout);
-    LOG_OUT("-- Transfer of %"PRIu16" B\n", tx_data_length);
+    LOG_OUT("-- Transfer of %" PRIu16 " B\n", tx_data_length);
 
     int ret = wiringPiSPIxDataRW(0, 0, h->buff + offset, tx_data_length);
 

--- a/hal/port/unix/lt_port_unix.c
+++ b/hal/port/unix/lt_port_unix.c
@@ -15,14 +15,13 @@
 
 // GPIO
 #include <errno.h>
+#include <inttypes.h>
 #include <linux/gpio.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <inttypes.h>
 
 #include "libtropic_common.h"
 #include "libtropic_logging.h"
@@ -70,7 +69,8 @@ lt_ret_t lt_port_init(lt_l2_state_t *h)
         LT_LOG_ERROR("can't get spi mode");
         return LT_FAIL;
     }
-    if (request_mode != s.mode) LT_LOG_ERROR("WARNING device does not support requested mode 0x%"PRIx32"\n", request_mode);
+    if (request_mode != s.mode)
+        LT_LOG_ERROR("WARNING device does not support requested mode 0x%" PRIx32 "\n", request_mode);
 
     if (ioctl(s.fd, SPI_IOC_WR_MAX_SPEED_HZ, &device->spi_speed) < 0) {
         LT_LOG_ERROR("can't set max speed Hz");

--- a/hal/port/unix/lt_port_unix.c
+++ b/hal/port/unix/lt_port_unix.c
@@ -22,6 +22,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <inttypes.h>
+
 #include "libtropic_common.h"
 #include "libtropic_logging.h"
 #include "libtropic_port.h"
@@ -68,7 +70,7 @@ lt_ret_t lt_port_init(lt_l2_state_t *h)
         LT_LOG_ERROR("can't get spi mode");
         return LT_FAIL;
     }
-    if (request_mode != s.mode) LT_LOG_ERROR("WARNING device does not support requested mode 0x%x\n", request_mode);
+    if (request_mode != s.mode) LT_LOG_ERROR("WARNING device does not support requested mode 0x%"PRIx32"\n", request_mode);
 
     if (ioctl(s.fd, SPI_IOC_WR_MAX_SPEED_HZ, &device->spi_speed) < 0) {
         LT_LOG_ERROR("can't set max speed Hz");

--- a/hal/port/unix/lt_port_unix_tcp.c
+++ b/hal/port/unix/lt_port_unix_tcp.c
@@ -8,13 +8,13 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <inttypes.h>
 
 #include "libtropic_common.h"
 #include "libtropic_port.h"
@@ -27,10 +27,10 @@
 #ifdef LIBT_DEBUG
 #define LOG_OUT(f_, ...) printf("[TCP] " f_, ##__VA_ARGS__)
 #define LOG_ERR(f_, ...) fprintf(stderr, "ERROR: " f_, ##__VA_ARGS__)
-#define LOG_U8_ARRAY(arr, len)      \
-    for (int i = 0; i < len; i++) { \
-        printf("%02"PRIx8" ", arr[i]);    \
-    }                               \
+#define LOG_U8_ARRAY(arr, len)           \
+    for (int i = 0; i < len; i++) {      \
+        printf("%02" PRIx8 " ", arr[i]); \
+    }                                    \
     printf("\r\n");
 #else
 #define LOG_OUT(...)
@@ -178,7 +178,7 @@ static int lt_communicate(int *tx_payload_length_ptr, int *rx_payload_length_ptr
         return 1;
     }
 
-    LOG_OUT("Length field: %"PRIu16".\n", rx_buffer.LENGTH);
+    LOG_OUT("Length field: %" PRIu16 ".\n", rx_buffer.LENGTH);
     nb_bytes_to_receive += rx_buffer.LENGTH;
     nb_bytes_received_total += nb_bytes_received;
     LOG_OUT("Received %d bytes out of %d expected.\n", nb_bytes_received_total, nb_bytes_to_receive);
@@ -211,23 +211,23 @@ static int lt_communicate(int *tx_payload_length_ptr, int *rx_payload_length_ptr
 
     // server does not know the sent tag
     if (rx_buffer.TAG == TAG_E_INVALID) {
-        LOG_ERR("Tag %"PRIu8" is not known by the server.\n", tx_buffer.TAG);
+        LOG_ERR("Tag %" PRIu8 " is not known by the server.\n", tx_buffer.TAG);
         return 1;
     }
 
     // server does not know what to do with the sent tag
     else if (rx_buffer.TAG == TAG_E_UNSUPPORTED) {
-        LOG_ERR("Tag %"PRIu8" is not supported by the server.\n", tx_buffer.TAG);
+        LOG_ERR("Tag %" PRIu8 " is not supported by the server.\n", tx_buffer.TAG);
         return 1;
     }
 
     // RX tag and TX tag should be identical
     else if (rx_buffer.TAG != tx_buffer.TAG) {
-        LOG_ERR("Expected tag %"PRIu8", received %"PRIu8".\n", rx_buffer.TAG, tx_buffer.TAG);
+        LOG_ERR("Expected tag %" PRIu8 ", received %" PRIu8 ".\n", rx_buffer.TAG, tx_buffer.TAG);
         return 1;
     }
 
-    LOG_OUT("Rx tag and tx tag match: %"PRIu8".\n", rx_buffer.TAG);
+    LOG_OUT("Rx tag and tx tag match: %" PRIu8 ".\n", rx_buffer.TAG);
     if (rx_payload_length_ptr != NULL) {
         *rx_payload_length_ptr = nb_bytes_received_total - TCP_TAG_AND_LENGTH_SIZE;
     }

--- a/hal/port/unix/lt_port_unix_tcp.c
+++ b/hal/port/unix/lt_port_unix_tcp.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "libtropic_common.h"
 #include "libtropic_port.h"
@@ -28,7 +29,7 @@
 #define LOG_ERR(f_, ...) fprintf(stderr, "ERROR: " f_, ##__VA_ARGS__)
 #define LOG_U8_ARRAY(arr, len)      \
     for (int i = 0; i < len; i++) { \
-        printf("%02x ", arr[i]);    \
+        printf("%02"PRIx8" ", arr[i]);    \
     }                               \
     printf("\r\n");
 #else
@@ -123,7 +124,7 @@ static int lt_send_all(int socket, uint8_t *buffer, size_t length)
 
         nb_bytes_to_send -= nb_bytes_sent;
         if (nb_bytes_to_send == 0) {
-            LOG_OUT("All %ld bytes sent successfully.\n", length);
+            LOG_OUT("All %zu bytes sent successfully.\n", length);
             return 0;
         }
 
@@ -132,7 +133,7 @@ static int lt_send_all(int socket, uint8_t *buffer, size_t length)
     }
 
     // could not send all the data after several attempts
-    LOG_ERR("%d bytes sent instead of expected %lu ", nb_bytes_sent_total, length);
+    LOG_ERR("%d bytes sent instead of expected %zu ", nb_bytes_sent_total, length);
     LOG_ERR("after %d attempts.\n", TX_ATTEMPTS);
 
     return 1;
@@ -177,7 +178,7 @@ static int lt_communicate(int *tx_payload_length_ptr, int *rx_payload_length_ptr
         return 1;
     }
 
-    LOG_OUT("Length field: %d.\n", rx_buffer.LENGTH);
+    LOG_OUT("Length field: %"PRIu16".\n", rx_buffer.LENGTH);
     nb_bytes_to_receive += rx_buffer.LENGTH;
     nb_bytes_received_total += nb_bytes_received;
     LOG_OUT("Received %d bytes out of %d expected.\n", nb_bytes_received_total, nb_bytes_to_receive);
@@ -210,23 +211,23 @@ static int lt_communicate(int *tx_payload_length_ptr, int *rx_payload_length_ptr
 
     // server does not know the sent tag
     if (rx_buffer.TAG == TAG_E_INVALID) {
-        LOG_ERR("Tag %d is not known by the server.\n", tx_buffer.TAG);
+        LOG_ERR("Tag %"PRIu8" is not known by the server.\n", tx_buffer.TAG);
         return 1;
     }
 
     // server does not know what to do with the sent tag
     else if (rx_buffer.TAG == TAG_E_UNSUPPORTED) {
-        LOG_ERR("Tag %d is not supported by the server.\n", tx_buffer.TAG);
+        LOG_ERR("Tag %"PRIu8" is not supported by the server.\n", tx_buffer.TAG);
         return 1;
     }
 
     // RX tag and TX tag should be identical
     else if (rx_buffer.TAG != tx_buffer.TAG) {
-        LOG_ERR("Expected tag %d, received %d.\n", rx_buffer.TAG, tx_buffer.TAG);
+        LOG_ERR("Expected tag %"PRIu8", received %"PRIu8".\n", rx_buffer.TAG, tx_buffer.TAG);
         return 1;
     }
 
-    LOG_OUT("Rx tag and tx tag match: %d.\n", rx_buffer.TAG);
+    LOG_OUT("Rx tag and tx tag match: %"PRIu8".\n", rx_buffer.TAG);
     if (rx_payload_length_ptr != NULL) {
         *rx_payload_length_ptr = nb_bytes_received_total - TCP_TAG_AND_LENGTH_SIZE;
     }

--- a/hal/port/unix/lt_port_unix_usb_dongle.c
+++ b/hal/port/unix/lt_port_unix_usb_dongle.c
@@ -7,6 +7,7 @@
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "libtropic_common.h"
 #include "libtropic_port.h"
@@ -108,7 +109,7 @@ lt_ret_t lt_port_init(lt_l2_state_t *h)
             cfsetospeed(&options, B115200);
             break;
         default:
-            fprintf(stderr, "warning: baud rate %u is not supported, using 9600.\n",
+            fprintf(stderr, "warning: baud rate %"PRIu32" is not supported, using 9600.\n",
                     ((lt_uart_def_unix_t *)h->device)->baud_rate);
             cfsetospeed(&options, B9600);
             break;
@@ -189,7 +190,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data
     // Bytes from handle which are about to be sent are encoded as chars and stored here:
     char buffered_chars[512] = {0};
     for (int i = 0; i < (tx_data_length); i++) {
-        sprintf(buffered_chars + i * 2, "%02X", h->buff[i + offset]);  // TODO make this better?
+        sprintf(buffered_chars + i * 2, "%02"PRIX8, h->buff[i + offset]);  // TODO make this better?
     }
     // Controll characters to keep CS LOW, they are expected by USB dongle
     buffered_chars[tx_data_length * 2] = 'x';
@@ -208,7 +209,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data
     }
 
     for (size_t count = 0; count < 2 * tx_data_length; count++) {
-        sscanf(&buffered_chars[count * 2], "%2hhx", &h->buff[count + offset]);  // TODO make this better?
+        sscanf(&buffered_chars[count * 2], "%02"PRIx8, &h->buff[count + offset]);  // TODO make this better?
     }
 
     return LT_OK;

--- a/hal/port/unix/lt_port_unix_usb_dongle.c
+++ b/hal/port/unix/lt_port_unix_usb_dongle.c
@@ -1,4 +1,5 @@
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -7,7 +8,6 @@
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>
-#include <inttypes.h>
 
 #include "libtropic_common.h"
 #include "libtropic_port.h"
@@ -109,7 +109,7 @@ lt_ret_t lt_port_init(lt_l2_state_t *h)
             cfsetospeed(&options, B115200);
             break;
         default:
-            fprintf(stderr, "warning: baud rate %"PRIu32" is not supported, using 9600.\n",
+            fprintf(stderr, "warning: baud rate %" PRIu32 " is not supported, using 9600.\n",
                     ((lt_uart_def_unix_t *)h->device)->baud_rate);
             cfsetospeed(&options, B9600);
             break;
@@ -190,7 +190,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data
     // Bytes from handle which are about to be sent are encoded as chars and stored here:
     char buffered_chars[512] = {0};
     for (int i = 0; i < (tx_data_length); i++) {
-        sprintf(buffered_chars + i * 2, "%02"PRIX8, h->buff[i + offset]);  // TODO make this better?
+        sprintf(buffered_chars + i * 2, "%02" PRIX8, h->buff[i + offset]);  // TODO make this better?
     }
     // Controll characters to keep CS LOW, they are expected by USB dongle
     buffered_chars[tx_data_length * 2] = 'x';
@@ -209,7 +209,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data
     }
 
     for (size_t count = 0; count < 2 * tx_data_length; count++) {
-        sscanf(&buffered_chars[count * 2], "%02"PRIx8, &h->buff[count + offset]);  // TODO make this better?
+        sscanf(&buffered_chars[count * 2], "%02" PRIx8, &h->buff[count + offset]);  // TODO make this better?
     }
 
     return LT_OK;

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -24,9 +24,9 @@
         ##__VA_ARGS__)
 
 // Loggers with selectable message type.
-#define LT_LOG_INFO(f_, ...) printf("INFO    [%4u] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
-#define LT_LOG_WARN(f_, ...) printf("WARNING [%4u] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
-#define LT_LOG_ERROR(f_, ...) printf("ERROR   [%4u] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_INFO(f_, ...) printf("INFO    [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_WARN(f_, ...) printf("WARNING [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_ERROR(f_, ...) printf("ERROR   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 
 #ifdef LIBT_DEBUG
 #define LT_LOG_DEBUG(f_, ...) printf("DEBUG   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -24,9 +24,9 @@
         ##__VA_ARGS__)
 
 // Loggers with selectable message type.
-#define LT_LOG_INFO(f_, ...) printf("INFO    [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
-#define LT_LOG_WARN(f_, ...) printf("WARNING [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
-#define LT_LOG_ERROR(f_, ...) printf("ERROR   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_INFO(f_, ...) printf("INFO    [%4u] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_WARN(f_, ...) printf("WARNING [%4u] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_ERROR(f_, ...) printf("ERROR   [%4u] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 
 #ifdef LIBT_DEBUG
 #define LT_LOG_DEBUG(f_, ...) printf("DEBUG   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1495,7 +1495,7 @@ lt_ret_t lt_print_bytes(const uint8_t *bytes, const uint16_t length, char *out_b
     }
 
     for (uint16_t i = 0; i < length; i++) {
-        sprintf(&out_buf[i * 2], "%02X", bytes[i]);
+        sprintf(&out_buf[i * 2], "%02"PRIX8, bytes[i]);
     }
     out_buf[length * 2] = '\0';
 

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -966,7 +966,7 @@ lt_ret_t lt_random_value_get(lt_handle_t *h, uint8_t *buff, const uint16_t len)
 
 lt_ret_t lt_ecc_key_generate(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_curve_type_t curve)
 {
-    if (!h || slot < ECC_SLOT_0 || slot > ECC_SLOT_31 || ((curve != CURVE_P256) && (curve != CURVE_ED25519))) {
+    if (!h || (slot > ECC_SLOT_31) || ((curve != CURVE_P256) && (curve != CURVE_ED25519))) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -993,7 +993,7 @@ lt_ret_t lt_ecc_key_generate(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc
 
 lt_ret_t lt_ecc_key_store(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_curve_type_t curve, const uint8_t *key)
 {
-    if (!h || slot < ECC_SLOT_0 || slot > ECC_SLOT_31 || ((curve != CURVE_P256) && (curve != CURVE_ED25519)) || !key) {
+    if (!h || (slot > ECC_SLOT_31) || ((curve != CURVE_P256) && (curve != CURVE_ED25519)) || !key) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1020,7 +1020,7 @@ lt_ret_t lt_ecc_key_store(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_cu
 lt_ret_t lt_ecc_key_read(lt_handle_t *h, const ecc_slot_t ecc_slot, uint8_t *key, lt_ecc_curve_type_t *curve,
                          ecc_key_origin_t *origin)
 {
-    if (!h || ecc_slot < ECC_SLOT_0 || ecc_slot > ECC_SLOT_31 || !key || !curve || !origin) {
+    if (!h || (ecc_slot > ECC_SLOT_31) || !key || !curve || !origin) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1047,7 +1047,7 @@ lt_ret_t lt_ecc_key_read(lt_handle_t *h, const ecc_slot_t ecc_slot, uint8_t *key
 
 lt_ret_t lt_ecc_key_erase(lt_handle_t *h, const ecc_slot_t ecc_slot)
 {
-    if (!h || ecc_slot < ECC_SLOT_0 || ecc_slot > ECC_SLOT_31) {
+    if (!h || (ecc_slot > ECC_SLOT_31)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1075,7 +1075,7 @@ lt_ret_t lt_ecc_key_erase(lt_handle_t *h, const ecc_slot_t ecc_slot)
 lt_ret_t lt_ecc_ecdsa_sign(lt_handle_t *h, const ecc_slot_t ecc_slot, const uint8_t *msg, const uint32_t msg_len,
                            uint8_t *rs)
 {
-    if (!h || !msg || !rs || (ecc_slot < ECC_SLOT_0) || (ecc_slot > ECC_SLOT_31)) {
+    if (!h || !msg || !rs || (ecc_slot > ECC_SLOT_31)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1116,8 +1116,7 @@ lt_ret_t lt_ecc_ecdsa_sig_verify(const uint8_t *msg, const uint32_t msg_len, con
 lt_ret_t lt_ecc_eddsa_sign(lt_handle_t *h, const ecc_slot_t ecc_slot, const uint8_t *msg, const uint16_t msg_len,
                            uint8_t *rs)
 {
-    if (!h || !msg || !rs || (msg_len > LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX) || (ecc_slot < ECC_SLOT_0)
-        || (ecc_slot > ECC_SLOT_31)) {
+    if (!h || !msg || !rs || (msg_len > LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX) || (ecc_slot > ECC_SLOT_31)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1157,7 +1156,7 @@ lt_ret_t lt_ecc_eddsa_sig_verify(const uint8_t *msg, const uint16_t msg_len, con
 
 lt_ret_t lt_mcounter_init(lt_handle_t *h, const enum lt_mcounter_index_t mcounter_index, const uint32_t mcounter_value)
 {
-    if (!h || ((mcounter_index < 0) | (mcounter_index > 15)) || mcounter_value == 0) {
+    if (!h || (mcounter_index > MCOUNTER_INDEX_15) || mcounter_value == 0) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1184,7 +1183,7 @@ lt_ret_t lt_mcounter_init(lt_handle_t *h, const enum lt_mcounter_index_t mcounte
 
 lt_ret_t lt_mcounter_update(lt_handle_t *h, const enum lt_mcounter_index_t mcounter_index)
 {
-    if (!h || ((mcounter_index < 0) | (mcounter_index > 15))) {
+    if (!h || (mcounter_index > MCOUNTER_INDEX_15)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1211,7 +1210,7 @@ lt_ret_t lt_mcounter_update(lt_handle_t *h, const enum lt_mcounter_index_t mcoun
 
 lt_ret_t lt_mcounter_get(lt_handle_t *h, const enum lt_mcounter_index_t mcounter_index, uint32_t *mcounter_value)
 {
-    if (!h || ((mcounter_index < 0) | (mcounter_index > 15)) || !mcounter_value) {
+    if (!h || (mcounter_index > MCOUNTER_INDEX_15) || !mcounter_value) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -13,7 +13,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic_common.h"
 #include "libtropic_logging.h"
 #include "libtropic_port.h"

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -8,12 +8,12 @@
 
 #include "libtropic.h"
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
-#include <inttypes.h>
 #include "libtropic_common.h"
 #include "libtropic_logging.h"
 #include "libtropic_port.h"
@@ -1495,7 +1495,7 @@ lt_ret_t lt_print_bytes(const uint8_t *bytes, const uint16_t length, char *out_b
     }
 
     for (uint16_t i = 0; i < length; i++) {
-        sprintf(&out_buf[i * 2], "%02"PRIX8, bytes[i]);
+        sprintf(&out_buf[i * 2], "%02" PRIX8, bytes[i]);
     }
     out_buf[length * 2] = '\0';
 

--- a/src/lt_asn1_der.c
+++ b/src/lt_asn1_der.c
@@ -7,12 +7,12 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <lt_asn1_der.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 
 // Uncomment to enable parser logging
 // #define ASNDER_LOG_EN
@@ -38,12 +38,12 @@ struct parse_ctx_t {
 };
 
 #ifdef ASNDER_LOG_EN
-#define PARSE_ERR(ctx, msg, ...)                                   \
-    do {                                                           \
-        LT_LOG_ERROR("ASN1 DER Parsing error:");                   \
-        LT_LOG_ERROR("    Byte position:    %"PRIu16, ctx->past);       \
-        LT_LOG_ERROR("    Byte value:       0x%"PRIx8, *(ctx->head));  \
-        LT_LOG_ERROR("    Error:            " msg, ##__VA_ARGS__); \
+#define PARSE_ERR(ctx, msg, ...)                                       \
+    do {                                                               \
+        LT_LOG_ERROR("ASN1 DER Parsing error:");                       \
+        LT_LOG_ERROR("    Byte position:    %" PRIu16, ctx->past);     \
+        LT_LOG_ERROR("    Byte value:       0x%" PRIx8, *(ctx->head)); \
+        LT_LOG_ERROR("    Error:            " msg, ##__VA_ARGS__);     \
     } while (0);
 
 #else
@@ -63,7 +63,8 @@ struct parse_ctx_t {
 static lt_ret_t consume_bytes(struct parse_ctx_t *ctx, uint8_t *buf, uint16_t n, bool copy)
 {
     if (ctx->past + n > ctx->len) {
-        PARSE_ERR(ctx, "Incomplete byte stream. Past: %"PRIu16", n: %"PRIu16", len: %"PRIu16, ctx->past, n, ctx->len);
+        PARSE_ERR(ctx, "Incomplete byte stream. Past: %" PRIu16 ", n: %" PRIu16 ", len: %" PRIu16, ctx->past, n,
+                  ctx->len);
         return LT_CERT_STORE_INVALID;
     }
 
@@ -156,9 +157,9 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
 
 #ifdef ASNDER_LOG_EN
     LT_LOG("parse_object:");
-    LT_LOG("    Start: %"PRIu16, start);
-    LT_LOG("    Object type: 0x%"PRIx8, b);
-    LT_LOG("    Object len: %"PRIu16, len);
+    LT_LOG("    Start: %" PRIu16, start);
+    LT_LOG("    Object type: 0x%" PRIx8, b);
+    LT_LOG("    Object len: %" PRIu16, len);
 #endif
 
     switch (b) {
@@ -171,10 +172,13 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
             if (start + len != ctx->past) {
                 PARSE_ERR(ctx,
                           "Invalid Sequence length. "
-                          "Sequence start: %"PRIu16". "
-                          "Expected length: %"PRIu16". "
-                          "Expected end: %"PRIu16". "
-                          "Real end: %"PRIu16,
+                          "Sequence start: %" PRIu16
+                          ". "
+                          "Expected length: %" PRIu16
+                          ". "
+                          "Expected end: %" PRIu16
+                          ". "
+                          "Real end: %" PRIu16,
                           start, len, start + len - 1, ctx->past);
                 return LT_CERT_STORE_INVALID;
             }
@@ -189,7 +193,7 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
 
             if (ctx->obj_id == obj_id) {
 #ifdef ASNDER_LOG_EN
-                LT_LOG("Found searched object: 0x%"PRIx32". Next object will be sampled!", ctx->obj_id);
+                LT_LOG("Found searched object: 0x%" PRIx32 ". Next object will be sampled!", ctx->obj_id);
 #endif
                 ctx->sample_next = true;
             }
@@ -217,10 +221,10 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
                     ctx->cropped = true;
 
 #ifdef ASNDER_LOG_EN
-                    LT_LOG(
-                        "Sample buffer (%d) is smaller than size of the object to be sampled (%"PRIu8"). "
-                        "Cropping %"PRIu16" bytes from %s of the searched object",
-                        ctx->sbuf_len, sample_len, n_crop_bytes, crop_prefix ? "prefix" : "suffix");
+                    LT_LOG("Sample buffer (%d) is smaller than size of the object to be sampled (%" PRIu8
+                           "). "
+                           "Cropping %" PRIu16 " bytes from %s of the searched object",
+                           ctx->sbuf_len, sample_len, n_crop_bytes, crop_prefix ? "prefix" : "suffix");
 #endif
 
                     if (crop_prefix) {

--- a/src/lt_asn1_der.c
+++ b/src/lt_asn1_der.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 // Uncomment to enable parser logging
 // #define ASNDER_LOG_EN
@@ -40,8 +41,8 @@ struct parse_ctx_t {
 #define PARSE_ERR(ctx, msg, ...)                                   \
     do {                                                           \
         LT_LOG_ERROR("ASN1 DER Parsing error:");                   \
-        LT_LOG_ERROR("    Byte position:    %d", ctx->past);       \
-        LT_LOG_ERROR("    Byte value:       0x%x", *(ctx->head));  \
+        LT_LOG_ERROR("    Byte position:    %"PRIu16, ctx->past);       \
+        LT_LOG_ERROR("    Byte value:       0x%"PRIx8, *(ctx->head));  \
         LT_LOG_ERROR("    Error:            " msg, ##__VA_ARGS__); \
     } while (0);
 
@@ -62,7 +63,7 @@ struct parse_ctx_t {
 static lt_ret_t consume_bytes(struct parse_ctx_t *ctx, uint8_t *buf, uint16_t n, bool copy)
 {
     if (ctx->past + n > ctx->len) {
-        PARSE_ERR(ctx, "Incomplete byte stream. Past: %d, n: %d, len: %d", ctx->past, n, ctx->len);
+        PARSE_ERR(ctx, "Incomplete byte stream. Past: %"PRIu16", n: %"PRIu16", len: %"PRIu16, ctx->past, n, ctx->len);
         return LT_CERT_STORE_INVALID;
     }
 
@@ -155,9 +156,9 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
 
 #ifdef ASNDER_LOG_EN
     LT_LOG("parse_object:");
-    LT_LOG("    Start: %d", start);
-    LT_LOG("    Object type: 0x%x", b);
-    LT_LOG("    Object len: %d", len);
+    LT_LOG("    Start: %"PRIu16, start);
+    LT_LOG("    Object type: 0x%"PRIx8, b);
+    LT_LOG("    Object len: %"PRIu16, len);
 #endif
 
     switch (b) {
@@ -170,10 +171,10 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
             if (start + len != ctx->past) {
                 PARSE_ERR(ctx,
                           "Invalid Sequence length. "
-                          "Sequence start: %d. "
-                          "Expected length: %d. "
-                          "Expected end: %d. "
-                          "Real end: %d",
+                          "Sequence start: %"PRIu16". "
+                          "Expected length: %"PRIu16". "
+                          "Expected end: %"PRIu16". "
+                          "Real end: %"PRIu16,
                           start, len, start + len - 1, ctx->past);
                 return LT_CERT_STORE_INVALID;
             }
@@ -188,7 +189,7 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
 
             if (ctx->obj_id == obj_id) {
 #ifdef ASNDER_LOG_EN
-                LT_LOG("Found searched object: 0x%x. Next object will be sampled!", ctx->obj_id);
+                LT_LOG("Found searched object: 0x%"PRIx32". Next object will be sampled!", ctx->obj_id);
 #endif
                 ctx->sample_next = true;
             }
@@ -217,8 +218,8 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
 
 #ifdef ASNDER_LOG_EN
                     LT_LOG(
-                        "Sample buffer (%d) is smaller than size of the object to be sampled (%d). "
-                        "Cropping %d bytes from %s of the searched object",
+                        "Sample buffer (%d) is smaller than size of the object to be sampled (%"PRIu8"). "
+                        "Cropping %"PRIu16" bytes from %s of the searched object",
                         ctx->sbuf_len, sample_len, n_crop_bytes, crop_prefix ? "prefix" : "suffix");
 #endif
 

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -7,10 +7,10 @@
  */
 #include "lt_l1.h"
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <inttypes.h>
 
 #include "libtropic_common.h"
 #include "lt_l1_port_wrap.h"
@@ -26,7 +26,7 @@ void print_hex_chunks(const uint8_t *data, uint8_t len, uint8_t dir)
     }
     printf("%s", dir ? "  >>  TX: " : "  <<  RX: ");
     for (size_t i = 0; i < len; i++) {
-        printf("%02"PRIX8" ", data[i]);
+        printf("%02" PRIX8 " ", data[i]);
         if ((i + 1) % 32 == 0) {
             printf("\n          ");
         }

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #include "libtropic_common.h"
 #include "lt_l1_port_wrap.h"
@@ -25,7 +26,7 @@ void print_hex_chunks(const uint8_t *data, uint8_t len, uint8_t dir)
     }
     printf("%s", dir ? "  >>  TX: " : "  <<  RX: ");
     for (size_t i = 0; i < len; i++) {
-        printf("%02X ", data[i]);
+        printf("%02"PRIX8" ", data[i]);
         if ((i + 1) % 32 == 0) {
             printf("\n          ");
         }

--- a/src/lt_l3.c
+++ b/src/lt_l3.c
@@ -34,7 +34,9 @@ lt_ret_t lt_out__session_start(lt_handle_t *h, const pkey_index_t pkey_index, se
     memset(h->l3.decryption_IV, 0, sizeof(h->l3.decryption_IV));
 
     // Create ephemeral host keys
-    lt_ret_t ret = lt_random_bytes((uint32_t *)state->ehpriv, 8);
+    uint32_t random_data[8];
+    lt_ret_t ret = lt_random_bytes(random_data, 8);
+    memcpy(state->ehpriv, random_data, 8);
     if (ret != LT_OK) {
         return ret;
     }

--- a/src/lt_l3.c
+++ b/src/lt_l3.c
@@ -34,13 +34,12 @@ lt_ret_t lt_out__session_start(lt_handle_t *h, const pkey_index_t pkey_index, se
     memset(h->l3.decryption_IV, 0, sizeof(h->l3.decryption_IV));
 
     // Create ephemeral host keys
-    uint8_t random_data_size = sizeof(state->ehpriv) / 4;
-    uint32_t random_data[random_data_size];
-    lt_ret_t ret = lt_random_bytes(random_data, random_data_size);
+    uint32_t random_data[sizeof(state->ehpriv) / 4];
+    lt_ret_t ret = lt_random_bytes(random_data, sizeof(state->ehpriv) / 4);
     if (ret != LT_OK) {
         return ret;
     }
-    memcpy(state->ehpriv, random_data, random_data_size);
+    memcpy(state->ehpriv, random_data, sizeof(state->ehpriv) / 4);
     lt_X25519_scalarmult(state->ehpriv, state->ehpub);
 
     // Setup a request pointer to l2 buffer, which is placed in handle

--- a/src/lt_l3.c
+++ b/src/lt_l3.c
@@ -805,7 +805,7 @@ lt_ret_t lt_in__random_value_get(lt_handle_t *h, uint8_t *buff, const uint16_t l
 
 lt_ret_t lt_out__ecc_key_generate(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_curve_type_t curve)
 {
-    if (!h || slot < ECC_SLOT_0 || slot > ECC_SLOT_31 || ((curve != CURVE_P256) && (curve != CURVE_ED25519))) {
+    if (!h || (slot > ECC_SLOT_31) || ((curve != CURVE_P256) && (curve != CURVE_ED25519))) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -850,7 +850,7 @@ lt_ret_t lt_in__ecc_key_generate(lt_handle_t *h)
 lt_ret_t lt_out__ecc_key_store(lt_handle_t *h, const ecc_slot_t slot, const lt_ecc_curve_type_t curve,
                                const uint8_t *key)
 {
-    if (!h || slot < ECC_SLOT_0 || slot > ECC_SLOT_31 || ((curve != CURVE_P256) && (curve != CURVE_ED25519)) || !key) {
+    if (!h || (slot > ECC_SLOT_31) || ((curve != CURVE_P256) && (curve != CURVE_ED25519)) || !key) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -899,7 +899,7 @@ lt_ret_t lt_in__ecc_key_store(lt_handle_t *h)
 // lt_ecc_curve_type_t *curve, ecc_key_origin_t *origin)
 lt_ret_t lt_out__ecc_key_read(lt_handle_t *h, const ecc_slot_t slot)
 {
-    if (!h || slot < ECC_SLOT_0 || slot > ECC_SLOT_31) {
+    if (!h || (slot > ECC_SLOT_31)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -963,7 +963,7 @@ lt_ret_t lt_in__ecc_key_read(lt_handle_t *h, uint8_t *key, lt_ecc_curve_type_t *
 
 lt_ret_t lt_out__ecc_key_erase(lt_handle_t *h, const ecc_slot_t slot)
 {
-    if (!h || slot < ECC_SLOT_0 || slot > ECC_SLOT_31) {
+    if (!h || (slot > ECC_SLOT_31)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1008,7 +1008,7 @@ lt_ret_t lt_in__ecc_key_erase(lt_handle_t *h)
 
 lt_ret_t lt_out__ecc_ecdsa_sign(lt_handle_t *h, const ecc_slot_t slot, const uint8_t *msg, const uint32_t msg_len)
 {
-    if (!h || (slot < ECC_SLOT_0) || (slot > ECC_SLOT_31) || !msg) {
+    if (!h || (slot > ECC_SLOT_31) || !msg) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1065,8 +1065,7 @@ lt_ret_t lt_in__ecc_ecdsa_sign(lt_handle_t *h, uint8_t *rs)
 
 lt_ret_t lt_out__ecc_eddsa_sign(lt_handle_t *h, const ecc_slot_t ecc_slot, const uint8_t *msg, const uint16_t msg_len)
 {
-    if (!h || !msg || (msg_len > LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX) || (ecc_slot < ECC_SLOT_0)
-        || (ecc_slot > ECC_SLOT_31)) {
+    if (!h || !msg || (msg_len > LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX) || (ecc_slot > ECC_SLOT_31)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1117,7 +1116,7 @@ lt_ret_t lt_in__ecc_eddsa_sign(lt_handle_t *h, uint8_t *rs)
 lt_ret_t lt_out__mcounter_init(lt_handle_t *h, const enum lt_mcounter_index_t mcounter_index,
                                const uint32_t mcounter_value)
 {
-    if (!h || ((mcounter_index < 0) | (mcounter_index > 15)) || mcounter_value == 0) {
+    if (!h || (mcounter_index > MCOUNTER_INDEX_15) || mcounter_value == 0) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1163,7 +1162,7 @@ lt_ret_t lt_in__mcounter_init(lt_handle_t *h)
 
 lt_ret_t lt_out__mcounter_update(lt_handle_t *h, const enum lt_mcounter_index_t mcounter_index)
 {
-    if (!h || ((mcounter_index < 0) | (mcounter_index > 15))) {
+    if (!h || (mcounter_index > MCOUNTER_INDEX_15)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {
@@ -1208,7 +1207,7 @@ lt_ret_t lt_in__mcounter_update(lt_handle_t *h)
 
 lt_ret_t lt_out__mcounter_get(lt_handle_t *h, const enum lt_mcounter_index_t mcounter_index)
 {
-    if (!h || ((mcounter_index < 0) | (mcounter_index > 15))) {
+    if (!h || (mcounter_index > MCOUNTER_INDEX_15)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session != SESSION_ON) {

--- a/src/lt_l3.c
+++ b/src/lt_l3.c
@@ -34,12 +34,13 @@ lt_ret_t lt_out__session_start(lt_handle_t *h, const pkey_index_t pkey_index, se
     memset(h->l3.decryption_IV, 0, sizeof(h->l3.decryption_IV));
 
     // Create ephemeral host keys
-    uint32_t random_data[8];
-    lt_ret_t ret = lt_random_bytes(random_data, 8);
-    memcpy(state->ehpriv, random_data, 8);
+    uint8_t random_data_size = sizeof(state->ehpriv) / 4;
+    uint32_t random_data[random_data_size];
+    lt_ret_t ret = lt_random_bytes(random_data, random_data_size);
     if (ret != LT_OK) {
         return ret;
     }
+    memcpy(state->ehpriv, random_data, random_data_size);
     lt_X25519_scalarmult(state->ehpriv, state->ehpub);
 
     // Setup a request pointer to l2 buffer, which is placed in handle

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -62,7 +62,7 @@ lt_handle_t h;
 // TODO: REMOVE OR EDIT
 lt_ret_t lt_new_test_cleanup(void)
 {
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session, ret=%s", lt_ret_verbose(ret));
@@ -89,7 +89,7 @@ void lt_new_test(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 
 #include "libtropic.h"
+#include "inttypes.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
@@ -42,7 +43,7 @@ void hexdump_8byte(const uint8_t *data, uint16_t size)
         char *p = line;
 
         for (uint16_t j = 0; j < row_len; j++) {
-            p += sprintf(p, "%02x ", data[i + j]);
+            p += sprintf(p, "%02" PRIx8 " ", data[i + j]);
         }
 
         *p = '\0';  // null-terminate the string

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -6,10 +6,10 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <stdlib.h>
 
 #include "libtropic.h"
-#include <inttypes.h>
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 
 #include "libtropic.h"
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"

--- a/tests/functional/lt_test_ire_pairing_key_slots.c
+++ b/tests/functional/lt_test_ire_pairing_key_slots.c
@@ -23,7 +23,7 @@ static void print_bytes(uint8_t *data, uint16_t len)
     char buffer[256] = {0};
     for (uint16_t i = 0; i < len; i++) {
         char byte_str[4];
-        snprintf(byte_str, sizeof(byte_str), "%02X ", data[i]);
+        snprintf(byte_str, sizeof(byte_str), "%02" PRIX8 " ", data[i]);
         strncat(buffer, byte_str, sizeof(buffer) - strlen(buffer) - 1);
 
         // Print the buffer every 32 bytes or at the end of the data
@@ -53,17 +53,17 @@ void lt_test_ire_pairing_key_slots(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     // Read pairing keys (1,2,3 should be empty)
-    LT_LOG_INFO("Reading pairing key slot 0...");
+    LT_LOG_INFO("Reading pairing key slot %d...", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, PAIRING_KEY_SLOT_INDEX_0));
     print_bytes(read_key, 32);
     LT_LOG_INFO();
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Reading pairing key slot %d (should fail)...", i);
+        LT_LOG_INFO("Reading pairing key slot %" PRIu8 " (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_PAIRING_KEY_EMPTY, lt_pairing_key_read(&h, read_key, i));
         LT_LOG_INFO();
     }
@@ -71,7 +71,7 @@ void lt_test_ire_pairing_key_slots(void)
 
     // Write pairing keys into slot 1,2,3
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_1; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Writing to pairing key slot %d...", i);
+        LT_LOG_INFO("Writing to pairing key slot %" PRIu8 "...", i);
         print_bytes(pub_keys[i], 32);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_write(&h, pub_keys[i], i));
         LT_LOG_INFO();
@@ -80,7 +80,7 @@ void lt_test_ire_pairing_key_slots(void)
 
     // Read all pairing keys and check value
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Reading pairing key slot %d...", i);
+        LT_LOG_INFO("Reading pairing key slot %" PRIu8 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
 
@@ -92,10 +92,10 @@ void lt_test_ire_pairing_key_slots(void)
 
     // Write pairing key slots again (should fail)
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Writing to pairing key slot %d (should fail)...", i);
+        LT_LOG_INFO("Writing to pairing key slot %" PRIu8 " (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_FAIL, lt_pairing_key_write(&h, zeros, i));
 
-        LT_LOG_INFO("Reading pairing key slot %d...", i);
+        LT_LOG_INFO("Reading pairing key slot %" PRIu8 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_read(&h, read_key, i));
         print_bytes(read_key, 32);
 
@@ -106,10 +106,10 @@ void lt_test_ire_pairing_key_slots(void)
     LT_LOG_LINE();
 
     for (uint8_t i = PAIRING_KEY_SLOT_INDEX_0; i <= PAIRING_KEY_SLOT_INDEX_3; i++) {
-        LT_LOG_INFO("Invalidating pairing key slot %d...", i);
+        LT_LOG_INFO("Invalidating pairing key slot %" PRIu8 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_pairing_key_invalidate(&h, i));
 
-        LT_LOG_INFO("Reading pairing key slot %d (should fail)...", i);
+        LT_LOG_INFO("Reading pairing key slot %" PRIu8 " (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_PAIRING_KEY_INVALID, lt_pairing_key_read(&h, read_key, i));
     }
     LT_LOG_LINE();

--- a/tests/functional/lt_test_ire_pairing_key_slots.c
+++ b/tests/functional/lt_test_ire_pairing_key_slots.c
@@ -5,7 +5,7 @@
  *
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_ire_pairing_key_slots.c
+++ b/tests/functional/lt_test_ire_pairing_key_slots.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_ire_write_i_config.c
+++ b/tests/functional/lt_test_ire_write_i_config.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_ire_write_i_config.c
+++ b/tests/functional/lt_test_ire_write_i_config.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -33,7 +34,7 @@ void lt_test_ire_write_i_config(void)
     LT_LOG_INFO("Creating randomized I config for testing");
     LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(i_config_random.obj, LT_CONFIG_OBJ_CNT));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
@@ -44,7 +45,7 @@ void lt_test_ire_write_i_config(void)
     LT_LOG_INFO("Reading the whole I config");
     LT_TEST_ASSERT(LT_OK, read_whole_I_config(&h, &i_config));
     for (uint8_t i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)i_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, i_config.obj[i]);
         LT_LOG_INFO("Checking if it was written");
         LT_TEST_ASSERT(1, (i_config.obj[i] == i_config_random.obj[i]));
     }

--- a/tests/functional/lt_test_ire_write_i_config.c
+++ b/tests/functional/lt_test_ire_write_i_config.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ecc_key_generate.c
+++ b/tests/functional/lt_test_rev_ecc_key_generate.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -22,7 +23,7 @@ lt_ret_t lt_test_rev_ecc_key_generate_cleanup(void)
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
 
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session.");
@@ -32,14 +33,14 @@ lt_ret_t lt_test_rev_ecc_key_generate_cleanup(void)
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Erasing slot #%d", i);
+        LT_LOG_INFO("Erasing slot #%" PRIu8, i);
         ret = lt_ecc_key_erase(&h, i);
         if (LT_OK != ret) {
             LT_LOG_ERROR("Failed to erase slot.");
             return ret;
         }
 
-        LT_LOG_INFO("Reading slot #%d (should fail)", i);
+        LT_LOG_INFO("Reading slot #%" PRIu8 " (should fail)", i);
         ret = lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin);
         if (LT_L3_ECC_INVALID_KEY != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_ECC_INVALID_KEY.");
@@ -82,7 +83,7 @@ void lt_test_rev_ecc_key_generate(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
@@ -91,7 +92,7 @@ void lt_test_rev_ecc_key_generate(void)
     LT_LOG_INFO("Testing ECC_Key_Generate using P256 curve...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing ECC key slot #%" PRIu8 "...", i);
 
         LT_LOG_INFO("Checking if slot is empty...");
         LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin));
@@ -122,7 +123,7 @@ void lt_test_rev_ecc_key_generate(void)
     LT_LOG_INFO("Testing ECC_Key_Generate using Ed25519 curve...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing ECC key slot #%" PRIu8 "...", i);
 
         LT_LOG_INFO("Checking if slot is empty...");
         LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin));

--- a/tests/functional/lt_test_rev_ecc_key_generate.c
+++ b/tests/functional/lt_test_rev_ecc_key_generate.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ecc_key_generate.c
+++ b/tests/functional/lt_test_rev_ecc_key_generate.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ecc_key_store.c
+++ b/tests/functional/lt_test_rev_ecc_key_store.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ecc_key_store.c
+++ b/tests/functional/lt_test_rev_ecc_key_store.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ecc_key_store.c
+++ b/tests/functional/lt_test_rev_ecc_key_store.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -43,7 +44,7 @@ lt_ret_t lt_test_rev_ecc_key_store_cleanup(void)
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
 
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session.");
@@ -53,14 +54,14 @@ lt_ret_t lt_test_rev_ecc_key_store_cleanup(void)
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Erasing slot #%d", i);
+        LT_LOG_INFO("Erasing slot #%" PRIu8, i);
         ret = lt_ecc_key_erase(&h, i);
         if (LT_OK != ret) {
             LT_LOG_ERROR("Failed to erase slot.");
             return ret;
         }
 
-        LT_LOG_INFO("Reading slot #%d (should fail)", i);
+        LT_LOG_INFO("Reading slot #%" PRIu8 " (should fail)", i);
         ret = lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin);
         if (LT_L3_ECC_INVALID_KEY != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_ECC_INVALID_KEY.");
@@ -103,7 +104,7 @@ void lt_test_rev_ecc_key_store(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
@@ -112,7 +113,7 @@ void lt_test_rev_ecc_key_store(void)
     LT_LOG_INFO("Testing ECC_Key_Store using P256 curve...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing ECC key slot #%" PRIu8 "...", i);
 
         LT_LOG_INFO("Checking if slot is empty...");
         LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin));
@@ -149,7 +150,7 @@ void lt_test_rev_ecc_key_store(void)
     LT_LOG_INFO("Testing ECC_Key_Store using Ed25519 curve...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing ECC key slot #%" PRIu8 "...", i);
 
         LT_LOG_INFO("Checking if slot is empty...");
         LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin));

--- a/tests/functional/lt_test_rev_ecdsa_sign.c
+++ b/tests/functional/lt_test_rev_ecdsa_sign.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -31,7 +32,7 @@ lt_ret_t lt_test_rev_ecdsa_sign_cleanup(void)
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
 
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session.");
@@ -41,14 +42,14 @@ lt_ret_t lt_test_rev_ecdsa_sign_cleanup(void)
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Erasing slot #%d", i);
+        LT_LOG_INFO("Erasing slot #%" PRIu8, i);
         ret = lt_ecc_key_erase(&h, i);
         if (LT_OK != ret) {
             LT_LOG_ERROR("Failed to erase slot.");
             return ret;
         }
 
-        LT_LOG_INFO("Reading slot #%d (should fail)", i);
+        LT_LOG_INFO("Reading slot #%" PRIu8 " (should fail)", i);
         ret = lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin);
         if (LT_L3_ECC_INVALID_KEY != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_ECC_INVALID_KEY.");
@@ -92,7 +93,7 @@ void lt_test_rev_ecdsa_sign(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
@@ -101,13 +102,13 @@ void lt_test_rev_ecdsa_sign(void)
     LT_LOG_INFO("Test ECDSA_Sign with stored key...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing signing with ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
         LT_LOG_INFO("Generating random data length <= %d...", MSG_TO_SIGN_LEN_MAX);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= MSG_TO_SIGN_LEN_MAX + 1;  // 0-MSG_TO_SIGN_LEN_MAX
 
-        LT_LOG_INFO("Generating random message with length %d for signing...", random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(msg_to_sign, random_data, random_data_size);
 
@@ -137,13 +138,13 @@ void lt_test_rev_ecdsa_sign(void)
     LT_LOG_INFO("Test ECDSA_Sign with generated key...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing signing with ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
         LT_LOG_INFO("Generating random data length <= %d...", MSG_TO_SIGN_LEN_MAX);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= MSG_TO_SIGN_LEN_MAX + 1;  // 0-MSG_TO_SIGN_LEN_MAX
 
-        LT_LOG_INFO("Generating random message with length %d for signing...", random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(msg_to_sign, random_data, random_data_size);
 

--- a/tests/functional/lt_test_rev_ecdsa_sign.c
+++ b/tests/functional/lt_test_rev_ecdsa_sign.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ecdsa_sign.c
+++ b/tests/functional/lt_test_rev_ecdsa_sign.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_eddsa_sign.c
+++ b/tests/functional/lt_test_rev_eddsa_sign.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -29,7 +30,7 @@ lt_ret_t lt_test_rev_eddsa_sign_cleanup(void)
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
 
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session.");
@@ -39,14 +40,14 @@ lt_ret_t lt_test_rev_eddsa_sign_cleanup(void)
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Erasing slot #%d", i);
+        LT_LOG_INFO("Erasing slot #%" PRIu8, i);
         ret = lt_ecc_key_erase(&h, i);
         if (LT_OK != ret) {
             LT_LOG_ERROR("Failed to erase slot.");
             return ret;
         }
 
-        LT_LOG_INFO("Reading slot #%d (should fail)", i);
+        LT_LOG_INFO("Reading slot #%" PRIu8 " (should fail)", i);
         ret = lt_ecc_key_read(&h, i, read_pub_key, &curve, &origin);
         if (LT_L3_ECC_INVALID_KEY != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_ECC_INVALID_KEY.");
@@ -90,7 +91,7 @@ void lt_test_rev_eddsa_sign(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
@@ -99,13 +100,13 @@ void lt_test_rev_eddsa_sign(void)
     LT_LOG_INFO("Test EDDSA_Sign with stored key...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing signing with ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
-        LT_LOG_INFO("Generating random data length <= %d...", LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
+        LT_LOG_INFO("Generating random data length <= %d...", (int)LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX + 1;  // 0-4096
 
-        LT_LOG_INFO("Generating random message with length %d for signing...", random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(msg_to_sign, random_data, random_data_size);
 
@@ -135,13 +136,13 @@ void lt_test_rev_eddsa_sign(void)
     LT_LOG_INFO("Test EDDSA_Sign with generated key...");
     for (uint8_t i = ECC_SLOT_0; i <= ECC_SLOT_31; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Testing signing with ECC key slot #%d...", i);
+        LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
-        LT_LOG_INFO("Generating random data length <= %d...", LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
+        LT_LOG_INFO("Generating random data length <= %d...", (int)LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX + 1;  // 0-4096
 
-        LT_LOG_INFO("Generating random message with length %d for signing...", random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(msg_to_sign, random_data, random_data_size);
 

--- a/tests/functional/lt_test_rev_eddsa_sign.c
+++ b/tests/functional/lt_test_rev_eddsa_sign.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_eddsa_sign.c
+++ b/tests/functional/lt_test_rev_eddsa_sign.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_erase_r_config.c
+++ b/tests/functional/lt_test_rev_erase_r_config.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -20,7 +21,7 @@ lt_ret_t lt_test_rev_erase_r_config_cleanup(void)
     lt_ret_t ret;
     struct lt_config_t r_config;
 
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session.");
@@ -87,14 +88,14 @@ void lt_test_rev_erase_r_config(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Backing up the whole R config:");
     LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config_backup.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, r_config_backup.obj[i]);
     }
     LT_LOG_LINE();
 
@@ -108,7 +109,7 @@ void lt_test_rev_erase_r_config(void)
     LT_LOG_INFO("Reading the whole R config");
     LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, r_config.obj[i]);
         LT_LOG_INFO("Checking if it was erased");
         LT_TEST_ASSERT(1, ((uint32_t)0xFFFFFFFF == r_config.obj[i]));
     }

--- a/tests/functional/lt_test_rev_erase_r_config.c
+++ b/tests/functional/lt_test_rev_erase_r_config.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_erase_r_config.c
+++ b/tests/functional/lt_test_rev_erase_r_config.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ping.c
+++ b/tests/functional/lt_test_rev_ping.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -34,22 +35,22 @@ void lt_test_rev_ping(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Will send %d Ping commands with random data of random length", PING_MAX_LOOPS);
     for (uint16_t i = 0; i < PING_MAX_LOOPS; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Generating random data length <= %d...", PING_LEN_MAX);
+        LT_LOG_INFO("Generating random data length <= %d...", (int)PING_LEN_MAX);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= PING_LEN_MAX + 1;  // 0-4096
 
-        LT_LOG_INFO("Generating %d random bytes...", random_data_size);
+        LT_LOG_INFO("Generating %" PRIu32 " random bytes...", random_data_size);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(ping_msg_out, random_data, random_data_size);
 
-        LT_LOG_INFO("Sending Ping command #%d...", i);
+        LT_LOG_INFO("Sending Ping command #%" PRIu16 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_ping(&h, ping_msg_out, ping_msg_in, random_data_size));
 
         LT_LOG_INFO("Comparing sent and received message...");

--- a/tests/functional/lt_test_rev_ping.c
+++ b/tests/functional/lt_test_rev_ping.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_ping.c
+++ b/tests/functional/lt_test_rev_ping.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_r_mem.c
+++ b/tests/functional/lt_test_rev_r_mem.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -22,7 +23,7 @@ lt_ret_t lt_test_rev_r_mem_cleanup(void)
     uint8_t r_mem_data[R_MEM_DATA_SIZE_MAX];
     uint16_t read_data_size;
 
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session.");
@@ -32,14 +33,14 @@ lt_ret_t lt_test_rev_r_mem_cleanup(void)
     LT_LOG_INFO("Erasing all slots...");
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Erasing slot #%d...", i);
+        LT_LOG_INFO("Erasing slot #%" PRIu16 "...", i);
         ret = lt_r_mem_data_erase(&h, i);
         if (LT_OK != ret) {
             LT_LOG_ERROR("Failed to erase slot.");
             return ret;
         }
 
-        LT_LOG_INFO("Reading slot #%d (should fail)...", i);
+        LT_LOG_INFO("Reading slot #%" PRIu16 " (should fail)...", i);
         ret = lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size);
         if (LT_L3_R_MEM_DATA_READ_SLOT_EMPTY != ret) {
             LT_LOG_ERROR("Return value is not LT_L3_R_MEM_DATA_READ_SLOT_EMPTY.");
@@ -88,14 +89,14 @@ void lt_test_rev_r_mem(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Checking if all slots are empty...");
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Reading slot #%d (should fail)...", i);
+        LT_LOG_INFO("Reading slot #%" PRIu16 " (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
         LT_LOG_INFO("Checking number of read bytes (should be 0)...");
@@ -109,14 +110,14 @@ void lt_test_rev_r_mem(void)
     LT_LOG_INFO("Testing writing all slots entirely...");
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Generating random data for slot #%d...", i);
+        LT_LOG_INFO("Generating random data for slot #%" PRIu16 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(write_data, random_data, sizeof(write_data));
 
-        LT_LOG_INFO("Writing to slot #%d...", i);
+        LT_LOG_INFO("Writing to slot #%" PRIu16 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_r_mem_data_write(&h, i, write_data, R_MEM_DATA_SIZE_MAX));
 
-        LT_LOG_INFO("Reading slot #%d...", i);
+        LT_LOG_INFO("Reading slot #%" PRIu16 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
         LT_LOG_INFO("Checking number of read bytes...");
@@ -125,10 +126,10 @@ void lt_test_rev_r_mem(void)
         LT_LOG_INFO("Checking contents...");
         LT_TEST_ASSERT(0, memcmp(r_mem_data, write_data, R_MEM_DATA_SIZE_MAX));
 
-        LT_LOG_INFO("Writing zeros to slot #%d (should fail)...", i);
+        LT_LOG_INFO("Writing zeros to slot #%" PRIu16 " (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_R_MEM_DATA_WRITE_WRITE_FAIL, lt_r_mem_data_write(&h, i, zeros, R_MEM_DATA_SIZE_MAX));
 
-        LT_LOG_INFO("Reading slot #%d...", i);
+        LT_LOG_INFO("Reading slot #%" PRIu16 "...", i);
         read_data_size = 0;  // Set different value just in case
         LT_TEST_ASSERT(LT_OK, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
@@ -143,10 +144,10 @@ void lt_test_rev_r_mem(void)
     LT_LOG_INFO("Erasing all slots...");
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Erasing slot #%d...", i);
+        LT_LOG_INFO("Erasing slot #%" PRIu16 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_r_mem_data_erase(&h, i));
 
-        LT_LOG_INFO("Reading slot #%d (should fail)...", i);
+        LT_LOG_INFO("Reading slot #%" PRIu16 " (should fail)...", i);
         LT_TEST_ASSERT(LT_L3_R_MEM_DATA_READ_SLOT_EMPTY, lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size));
 
         LT_LOG_INFO("Checking number of read bytes (should be 0)...");
@@ -157,19 +158,19 @@ void lt_test_rev_r_mem(void)
     LT_LOG_INFO("Testing writing all slots partially or with zero data size...");
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Generating random data length < %d...", R_MEM_DATA_SIZE_MAX);
+        LT_LOG_INFO("Generating random data length < %d...", (int)R_MEM_DATA_SIZE_MAX);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= R_MEM_DATA_SIZE_MAX;
 
-        LT_LOG_INFO("Generating %d random bytes for slot #%d...", random_data_size, i);
+        LT_LOG_INFO("Generating %" PRIu32 " random bytes for slot #%" PRIu16 "...", random_data_size, i);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
         memcpy(write_data, random_data, random_data_size);
 
-        LT_LOG_INFO("Writing to slot #%d...", i);
+        LT_LOG_INFO("Writing to slot #%" PRIu16 "...", i);
         LT_TEST_ASSERT_COND(lt_r_mem_data_write(&h, i, write_data, random_data_size), random_data_size != 0, LT_OK,
                             LT_L3_FAIL);
 
-        LT_LOG_INFO("Reading slot #%d...", i);
+        LT_LOG_INFO("Reading slot #%" PRIu16 "...", i);
         LT_TEST_ASSERT_COND(lt_r_mem_data_read(&h, i, r_mem_data, &read_data_size), random_data_size != 0, LT_OK,
                             LT_L3_R_MEM_DATA_READ_SLOT_EMPTY);
 

--- a/tests/functional/lt_test_rev_r_mem.c
+++ b/tests/functional/lt_test_rev_r_mem.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_r_mem.c
+++ b/tests/functional/lt_test_rev_r_mem.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_random_value_get.c
+++ b/tests/functional/lt_test_rev_random_value_get.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -33,18 +34,19 @@ void lt_test_rev_random_value_get(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Random_Value_Get will be executed %d times", RANDOM_VALUE_GET_LOOPS);
     for (uint16_t i = 0; i < RANDOM_VALUE_GET_LOOPS; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Generating random data length <= %d (with lt_port_random_bytes())...", RANDOM_VALUE_GET_LEN_MAX);
+        LT_LOG_INFO("Generating random data length <= %d (with lt_port_random_bytes())...",
+                    (int)RANDOM_VALUE_GET_LEN_MAX);
         LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
         random_data_size %= RANDOM_VALUE_GET_LEN_MAX + 1;  // 0-255
 
-        LT_LOG_INFO("Getting %d random numbers from TROPIC01...", random_data_size);
+        LT_LOG_INFO("Getting %" PRIu32 " random numbers from TROPIC01...", random_data_size);
         LT_TEST_ASSERT(LT_OK, lt_random_value_get(&h, random_data, random_data_size));
         LT_LOG_INFO("Random data from TROPIC01:");
         hexdump_8byte(random_data, random_data_size);

--- a/tests/functional/lt_test_rev_random_value_get.c
+++ b/tests/functional/lt_test_rev_random_value_get.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_random_value_get.c
+++ b/tests/functional/lt_test_rev_random_value_get.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_read_cert_store.c
+++ b/tests/functional/lt_test_rev_read_cert_store.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_read_cert_store.c
+++ b/tests/functional/lt_test_rev_read_cert_store.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_read_cert_store.c
+++ b/tests/functional/lt_test_rev_read_cert_store.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -43,13 +44,14 @@ void lt_test_rev_read_cert_store(void)
         LT_LOG_INFO("Certificate number: %d", i);
         LT_LOG_INFO("Checking if size of certificate is not zero");
         LT_TEST_ASSERT(1, (store.cert_len[i] != 0));
-        LT_LOG_INFO("Size in bytes: %d", store.cert_len[i]);
+        LT_LOG_INFO("Size in bytes: %" PRIu16, store.cert_len[i]);
 
         for (int j = 0; j < store.cert_len[i]; j += 16)
-            LT_LOG_INFO("%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", cert[j], cert[j + 1],
-                        cert[j + 2], cert[j + 3], cert[j + 4], cert[j + 5], cert[j + 6], cert[j + 7], cert[j + 8],
-                        cert[j + 9], cert[j + 10], cert[j + 11], cert[j + 12], cert[j + 13], cert[j + 14],
-                        cert[j + 15]);
+            LT_LOG_INFO("%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8
+                        "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8,
+                        cert[j], cert[j + 1], cert[j + 2], cert[j + 3], cert[j + 4], cert[j + 5], cert[j + 6],
+                        cert[j + 7], cert[j + 8], cert[j + 9], cert[j + 10], cert[j + 11], cert[j + 12], cert[j + 13],
+                        cert[j + 14], cert[j + 15]);
         LT_LOG_INFO();
     }
     LT_LOG_LINE();

--- a/tests/functional/lt_test_rev_read_chip_id.c
+++ b/tests/functional/lt_test_rev_read_chip_id.c
@@ -5,7 +5,6 @@
  *
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
-
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_read_i_config.c
+++ b/tests/functional/lt_test_rev_read_i_config.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_read_i_config.c
+++ b/tests/functional/lt_test_rev_read_i_config.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_read_i_config.c
+++ b/tests/functional/lt_test_rev_read_i_config.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -28,14 +29,14 @@ void lt_test_rev_read_i_config(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Reading the whole I config:");
     LT_TEST_ASSERT(LT_OK, read_whole_I_config(&h, &i_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)i_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, i_config.obj[i]);
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_read_r_config.c
+++ b/tests/functional/lt_test_rev_read_r_config.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -28,14 +29,14 @@ void lt_test_rev_read_r_config(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Reading the whole R config:");
     LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, r_config.obj[i]);
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_read_r_config.c
+++ b/tests/functional/lt_test_rev_read_r_config.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_read_r_config.c
+++ b/tests/functional/lt_test_rev_read_r_config.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_sleep_req.c
+++ b/tests/functional/lt_test_rev_sleep_req.c
@@ -31,7 +31,7 @@ void lt_test_rev_sleep_req(void)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(&h));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
 
     LT_LOG_INFO("Sending Sleep_Req...");

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -6,6 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include "inttypes.h"
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
@@ -22,7 +23,7 @@ lt_ret_t lt_test_rev_write_r_config_cleanup(void)
     lt_ret_t ret;
     struct lt_config_t r_config;
 
-    LT_LOG_INFO("Starting secure session with slot %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting secure session with slot %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     ret = verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to establish secure session.");
@@ -92,14 +93,14 @@ void lt_test_rev_write_r_config(void)
     LT_LOG_INFO("Creating randomized R config for testing");
     LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(r_config_random.obj, LT_CONFIG_OBJ_CNT));
 
-    LT_LOG_INFO("Starting Secure Session with key %d", PAIRING_KEY_SLOT_INDEX_0);
+    LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, verify_chip_and_start_secure_session(&h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));
     LT_LOG_LINE();
 
     LT_LOG_INFO("Backing up the whole R config:");
     LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config_backup));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config_backup.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, r_config_backup.obj[i]);
     }
     LT_LOG_LINE();
 
@@ -113,7 +114,7 @@ void lt_test_rev_write_r_config(void)
     LT_LOG_INFO("Reading the whole R config");
     LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, r_config.obj[i]);
         LT_LOG_INFO("Checking if it was written");
         LT_TEST_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
     }
@@ -128,7 +129,7 @@ void lt_test_rev_write_r_config(void)
     memset(r_config.obj, 0, sizeof(r_config.obj));
     LT_TEST_ASSERT(LT_OK, read_whole_R_config(&h, &r_config));
     for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
-        LT_LOG_INFO("%s: 0x%08x", cfg_desc_table[i].desc, (unsigned int)r_config.obj[i]);
+        LT_LOG_INFO("%s: 0x%08" PRIx32, cfg_desc_table[i].desc, r_config.obj[i]);
         LT_LOG_INFO("Checking if it was not rewritten");
         LT_TEST_ASSERT(1, (r_config.obj[i] == r_config_random.obj[i]));
     }

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -6,7 +6,7 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "inttypes.h"
+#include <inttypes.h>
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -7,6 +7,7 @@
  */
 
 #include <inttypes.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"


### PR DESCRIPTION
- Fixed all errors mentioned in task ETR01SDK-147
- Changed all format strings to macros from `inttypes.h` (ofc not for `int` or `char`) or for `%zu` for `size_t`