### PR TITLE
ETR01SDK-167: Change parameter type of buff in lt_port_random_bytes to void*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Runtime state of Generic Linux ports (SPI, USB) is now kept in device structure in handle. This structure
   is also used for port configuration (device mapping, speeds...).
 - Strict compile flags can now be activated with `LT_STRICT_COMP_FLAGS` CMake variable, which is automatically set when examples or tests are built.
+- API change in `lt_random_bytes()`, `lt_port_random_bytes()`: changed `buff` parameter to `void*`, renamed parameter `len` to `count`
 
 ### Added
 - Macro `LT_CONFIG_OBJ_CNT` for number of objects in the configuration structure.

--- a/examples/lt_ex_macandd.c
+++ b/examples/lt_ex_macandd.c
@@ -13,8 +13,8 @@
 #include "libtropic_logging.h"
 #include "string.h"
 
-// Needed to access to lt_port_random_bytes()
-#include "libtropic_port.h"
+// Needed to access to lt_random_bytes()
+#include "lt_random.h"
 // Needed to access HMAC_SHA256
 #include "lt_hmac_sha256.h"
 
@@ -107,10 +107,8 @@ static lt_ret_t lt_PIN_set(lt_handle_t *h, const uint8_t *PIN, const uint8_t PIN
     memcpy(kdf_input_buff, PIN, PIN_size);
     memcpy(kdf_input_buff + PIN_size, add, add_size);
 
-    LT_LOG_INFO("Getting random bytes...");
-    uint32_t random_data[sizeof(s) / 4];
-    lt_ret_t ret = lt_port_random_bytes(random_data, sizeof(s) / 4);
-    memcpy(s, random_data, sizeof(s));
+    LT_LOG_INFO("Generating random secret s...");
+    lt_ret_t ret = lt_random_bytes(s, sizeof(s));
     if (ret != LT_OK) {
         LT_LOG_ERROR("Failed to get random bytes, ret=%s", lt_ret_verbose(ret));
         goto exit;

--- a/hal/port/stm32/lt_port_stm32_nucleo_f439zi.c
+++ b/hal/port/stm32/lt_port_stm32_nucleo_f439zi.c
@@ -17,13 +17,13 @@
 // Random number generator's handle
 RNG_HandleTypeDef rng;
 
-lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
+lt_ret_t lt_port_random_bytes(void *buff, size_t count)
 {
-    uint16_t bytes_left = count;
+    size_t bytes_left = count;
     uint8_t *buff_ptr = buff;
     while (bytes_left) {
         uint32_t random_data = HAL_RNG_GetRandomNumber(&rng);
-        uint16_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
+        size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
         memcpy(buff_ptr, &random_data, cpy_cnt);
         bytes_left -= cpy_cnt;
         buff_ptr += cpy_cnt;

--- a/hal/port/stm32/lt_port_stm32_nucleo_f439zi.c
+++ b/hal/port/stm32/lt_port_stm32_nucleo_f439zi.c
@@ -17,11 +17,16 @@
 // Random number generator's handle
 RNG_HandleTypeDef rng;
 
-lt_ret_t lt_port_random_bytes(uint32_t *buff, uint16_t len)
+lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
 {
-    for (int i = 0; i < len; i++) {
-        uint32_t helper = HAL_RNG_GetRandomNumber(&rng);
-        buff[i] = helper;
+    uint16_t bytes_left = count;
+    uint8_t *buff_ptr = buff;
+    while (bytes_left) {
+        uint32_t random_data = HAL_RNG_GetRandomNumber(&rng);
+        uint16_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
+        memcpy(buff_ptr, &random_data, cpy_cnt);
+        bytes_left -= cpy_cnt;
+        buff_ptr += cpy_cnt;
     }
 
     return LT_OK;

--- a/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
+++ b/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
@@ -23,11 +23,16 @@ RNG_HandleTypeDef rng;
 // SPI handle declaration
 SPI_HandleTypeDef SpiHandle;
 
-lt_ret_t lt_port_random_bytes(uint32_t *buff, uint16_t len)
+lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
 {
-    for (int i = 0; i < len; i++) {
-        uint32_t helper = HAL_RNG_GetRandomNumber(&rng);
-        buff[i] = helper;
+    uint16_t bytes_left = count;
+    uint8_t *buff_ptr = buff;
+    while (bytes_left) {
+        uint32_t random_data = HAL_RNG_GetRandomNumber(&rng);
+        uint16_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
+        memcpy(buff_ptr, &random_data, cpy_cnt);
+        bytes_left -= cpy_cnt;
+        buff_ptr += cpy_cnt;
     }
 
     return LT_OK;

--- a/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
+++ b/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
@@ -23,13 +23,13 @@ RNG_HandleTypeDef rng;
 // SPI handle declaration
 SPI_HandleTypeDef SpiHandle;
 
-lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
+lt_ret_t lt_port_random_bytes(void *buff, size_t count)
 {
-    uint16_t bytes_left = count;
+    size_t bytes_left = count;
     uint8_t *buff_ptr = buff;
     while (bytes_left) {
         uint32_t random_data = HAL_RNG_GetRandomNumber(&rng);
-        uint16_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
+        size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
         memcpy(buff_ptr, &random_data, cpy_cnt);
         bytes_left -= cpy_cnt;
         buff_ptr += cpy_cnt;

--- a/hal/port/unix/lt_port_unix_spi.c
+++ b/hal/port/unix/lt_port_unix_spi.c
@@ -191,10 +191,10 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t wait_time_msecs)
     return LT_OK;
 }
 
-lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
+lt_ret_t lt_port_random_bytes(void *buff, size_t count)
 {
     uint8_t *buff_ptr = buff;
-    for (uint16_t i = 0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
         // Number from rand() is guaranteed to have at least 15 bits valid
         buff_ptr[i] = (uint8_t)(rand() & 0xFF);
     }

--- a/hal/port/unix/lt_port_unix_spi.c
+++ b/hal/port/unix/lt_port_unix_spi.c
@@ -191,10 +191,12 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t wait_time_msecs)
     return LT_OK;
 }
 
-lt_ret_t lt_port_random_bytes(uint32_t *buff, uint16_t len)
+lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
 {
-    for (int i = 0; i < len; i++) {
-        buff[i] = (uint32_t)rand();
+    uint8_t *buff_ptr = buff;
+    for (uint16_t i = 0; i < count; i++) {
+        // Number from rand() is guaranteed to have at least 15 bits valid
+        buff_ptr[i] = (uint8_t)(rand() & 0xFF);
     }
 
     return LT_OK;

--- a/hal/port/unix/lt_port_unix_tcp.c
+++ b/hal/port/unix/lt_port_unix_tcp.c
@@ -337,10 +337,10 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t wait_time_usecs)
     return lt_communicate(&payload_length, NULL);
 }
 
-lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
+lt_ret_t lt_port_random_bytes(void *buff, size_t count)
 {
     uint8_t *buff_ptr = buff;
-    for (uint16_t i = 0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
         // Number from rand() is guaranteed to have at least 15 bits valid
         buff_ptr[i] = (uint8_t)(rand() & 0xFF);
     }

--- a/hal/port/unix/lt_port_unix_tcp.c
+++ b/hal/port/unix/lt_port_unix_tcp.c
@@ -337,10 +337,12 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t wait_time_usecs)
     return lt_communicate(&payload_length, NULL);
 }
 
-lt_ret_t lt_port_random_bytes(uint32_t *buff, uint16_t len)
+lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
 {
-    for (int i = 0; i < len; i++) {
-        buff[i] = (uint32_t)rand();
+    uint8_t *buff_ptr = buff;
+    for (uint16_t i = 0; i < count; i++) {
+        // Number from rand() is guaranteed to have at least 15 bits valid
+        buff_ptr[i] = (uint8_t)(rand() & 0xFF);
     }
 
     return LT_OK;

--- a/hal/port/unix/lt_port_unix_usb_dongle.c
+++ b/hal/port/unix/lt_port_unix_usb_dongle.c
@@ -155,10 +155,12 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t wait_time_msecs)
     return LT_OK;
 }
 
-lt_ret_t lt_port_random_bytes(uint32_t *buff, uint16_t len)
+lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
 {
-    for (int i = 0; i < len; i++) {
-        buff[i] = (uint32_t)rand();
+    uint8_t *buff_ptr = buff;
+    for (uint16_t i = 0; i < count; i++) {
+        // Number from rand() is guaranteed to have at least 15 bits valid
+        buff_ptr[i] = (uint8_t)(rand() & 0xFF);
     }
 
     return LT_OK;

--- a/hal/port/unix/lt_port_unix_usb_dongle.c
+++ b/hal/port/unix/lt_port_unix_usb_dongle.c
@@ -155,10 +155,10 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t wait_time_msecs)
     return LT_OK;
 }
 
-lt_ret_t lt_port_random_bytes(void *buff, uint16_t count)
+lt_ret_t lt_port_random_bytes(void *buff, size_t count)
 {
     uint8_t *buff_ptr = buff;
-    for (uint16_t i = 0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
         // Number from rand() is guaranteed to have at least 15 bits valid
         buff_ptr[i] = (uint8_t)(rand() & 0xFF);
     }

--- a/include/libtropic_functional_tests.h
+++ b/include/libtropic_functional_tests.h
@@ -371,7 +371,7 @@ void lt_test_rev_ecc_key_store(lt_handle_t *h);
  *
  * Test steps:
  *  1. Start Secure Session with pairing key slot 0.
- *  2. Generate random number 0-255 using lt_port_random_bytes(), which will be
+ *  2. Generate random number 0-255 using lt_random_bytes(), which will be
  *     used in the Random_Value_Get command.
  *  3. Get random count (from step 2) of random bytes from TROPIC01.
  *  4. Dump the random bytes from TROPIC01 into the log.

--- a/include/libtropic_port.h
+++ b/include/libtropic_port.h
@@ -9,6 +9,8 @@
 #ifndef LT_LIBTROPIC_PORT_H
 #define LT_LIBTROPIC_PORT_H
 
+#include <stdlib.h>
+
 #include "libtropic_common.h"
 
 /**
@@ -95,7 +97,7 @@ lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms);
  * @param len         Number of random bytes
  * @return lt_ret_t   LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_port_random_bytes(void *buff, uint16_t count);
+lt_ret_t lt_port_random_bytes(void *buff, size_t count);
 
 /** @} */  // end of group_port_functions
 

--- a/include/libtropic_port.h
+++ b/include/libtropic_port.h
@@ -92,10 +92,10 @@ lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms);
  * @brief Fill buffer with random bytes, platform defined function.
  *
  * @param buff        Buffer to be filled
- * @param len         number of 32bit numbers
+ * @param len         Number of random bytes
  * @return lt_ret_t   LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_port_random_bytes(uint32_t *buff, uint16_t len);
+lt_ret_t lt_port_random_bytes(void *buff, uint16_t count);
 
 /** @} */  // end of group_port_functions
 

--- a/src/lt_l3.c
+++ b/src/lt_l3.c
@@ -34,12 +34,10 @@ lt_ret_t lt_out__session_start(lt_handle_t *h, const pkey_index_t pkey_index, se
     memset(h->l3.decryption_IV, 0, sizeof(h->l3.decryption_IV));
 
     // Create ephemeral host keys
-    uint32_t random_data[sizeof(state->ehpriv) / 4];
-    lt_ret_t ret = lt_random_bytes(random_data, sizeof(state->ehpriv) / 4);
+    lt_ret_t ret = lt_random_bytes(state->ehpriv, sizeof(state->ehpriv));
     if (ret != LT_OK) {
         return ret;
     }
-    memcpy(state->ehpriv, random_data, sizeof(state->ehpriv) / 4);
     lt_X25519_scalarmult(state->ehpriv, state->ehpub);
 
     // Setup a request pointer to l2 buffer, which is placed in handle

--- a/src/lt_random.c
+++ b/src/lt_random.c
@@ -9,12 +9,12 @@
 #include "libtropic_common.h"
 #include "libtropic_port.h"
 
-lt_ret_t lt_random_bytes(uint32_t *buff, uint16_t len)
+lt_ret_t lt_random_bytes(void *buff, uint16_t count)
 {
 #ifdef LIBT_DEBUG
     if (!buff) {
         return LT_PARAM_ERR;
     }
 #endif
-    return lt_port_random_bytes(buff, len);
+    return lt_port_random_bytes(buff, count);
 }

--- a/src/lt_random.c
+++ b/src/lt_random.c
@@ -6,10 +6,12 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include <stdlib.h>
+
 #include "libtropic_common.h"
 #include "libtropic_port.h"
 
-lt_ret_t lt_random_bytes(void *buff, uint16_t count)
+lt_ret_t lt_random_bytes(void *buff, size_t count)
 {
 #ifdef LIBT_DEBUG
     if (!buff) {

--- a/src/lt_random.h
+++ b/src/lt_random.h
@@ -16,9 +16,9 @@
  * @brief Get random bytes in a form of 32bit numbers. This is wrapper for platform defined function.
  *
  * @param buff        Buffer to be filled
- * @param len         number of 32bit numbers
+ * @param count       Number of random bytes
  * @return lt_ret_t
  */
-lt_ret_t lt_random_bytes(uint32_t *buff, uint16_t len);
+lt_ret_t lt_random_bytes(void *buff, uint16_t count);
 
 #endif

--- a/src/lt_random.h
+++ b/src/lt_random.h
@@ -10,6 +10,8 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
+#include <stdlib.h>
+
 #include "libtropic_common.h"
 
 /**
@@ -19,6 +21,6 @@
  * @param count       Number of random bytes
  * @return lt_ret_t
  */
-lt_ret_t lt_random_bytes(void *buff, uint16_t count);
+lt_ret_t lt_random_bytes(void *buff, size_t count);
 
 #endif

--- a/tests/functional/lt_test_ire_write_i_config.c
+++ b/tests/functional/lt_test_ire_write_i_config.c
@@ -12,7 +12,7 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port.h"
+#include "lt_random.h"
 #include "string.h"
 
 void lt_test_ire_write_i_config(lt_handle_t *h)
@@ -27,7 +27,7 @@ void lt_test_ire_write_i_config(lt_handle_t *h)
     LT_TEST_ASSERT(LT_OK, lt_init(h));
 
     LT_LOG_INFO("Creating randomized I config for testing");
-    LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(i_config_random.obj, LT_CONFIG_OBJ_CNT));
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(i_config_random.obj, sizeof(i_config_random.obj)));
 
     LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, lt_verify_chip_and_start_secure_session(h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));

--- a/tests/functional/lt_test_rev_ecdsa_sign.c
+++ b/tests/functional/lt_test_rev_ecdsa_sign.c
@@ -12,8 +12,8 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port.h"
 #include "lt_l3_api_structs.h"
+#include "lt_random.h"
 #include "string.h"
 
 #define MSG_TO_SIGN_LEN_MAX 4096
@@ -87,7 +87,7 @@ void lt_test_rev_ecdsa_sign(lt_handle_t *h)
     uint8_t read_pub_key[64], msg_to_sign[MSG_TO_SIGN_LEN_MAX], rs[64];
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
-    uint32_t random_data[MSG_TO_SIGN_LEN_MAX / sizeof(uint32_t)], random_data_size;
+    uint32_t msg_to_sign_len;
 
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(h));
@@ -103,16 +103,15 @@ void lt_test_rev_ecdsa_sign(lt_handle_t *h)
         LT_LOG_INFO();
         LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
-        LT_LOG_INFO("Generating random data length <= %d...", MSG_TO_SIGN_LEN_MAX);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
-        random_data_size %= MSG_TO_SIGN_LEN_MAX + 1;  // 0-MSG_TO_SIGN_LEN_MAX
+        LT_LOG_INFO("Generating random message length <= %d...", MSG_TO_SIGN_LEN_MAX);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&msg_to_sign_len, sizeof(msg_to_sign_len)));
+        msg_to_sign_len %= MSG_TO_SIGN_LEN_MAX + 1;  // 0-MSG_TO_SIGN_LEN_MAX
 
-        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
-        memcpy(msg_to_sign, random_data, random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", msg_to_sign_len);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(msg_to_sign, msg_to_sign_len));
 
         LT_LOG_INFO("Signing message with empty slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Storing private key pre-generated using P256 curve...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_store(h, i, CURVE_P256, priv_test_key));
@@ -121,16 +120,16 @@ void lt_test_rev_ecdsa_sign(lt_handle_t *h)
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_read(h, i, read_pub_key, &curve, &origin));
 
         LT_LOG_INFO("Signing message...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Verifying signature...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sig_verify(msg_to_sign, random_data_size, read_pub_key, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sig_verify(msg_to_sign, msg_to_sign_len, read_pub_key, rs));
 
         LT_LOG_INFO("Erasing the slot...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_erase(h, i));
 
         LT_LOG_INFO("Signing message with erased slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
     }
     LT_LOG_LINE();
 
@@ -139,16 +138,15 @@ void lt_test_rev_ecdsa_sign(lt_handle_t *h)
         LT_LOG_INFO();
         LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
-        LT_LOG_INFO("Generating random data length <= %d...", MSG_TO_SIGN_LEN_MAX);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
-        random_data_size %= MSG_TO_SIGN_LEN_MAX + 1;  // 0-MSG_TO_SIGN_LEN_MAX
+        LT_LOG_INFO("Generating random message length <= %d...", MSG_TO_SIGN_LEN_MAX);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&msg_to_sign_len, sizeof(msg_to_sign_len)));
+        msg_to_sign_len %= MSG_TO_SIGN_LEN_MAX + 1;  // 0-MSG_TO_SIGN_LEN_MAX
 
-        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
-        memcpy(msg_to_sign, random_data, random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", msg_to_sign_len);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(msg_to_sign, msg_to_sign_len));
 
         LT_LOG_INFO("Signing message with empty slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Generating private key using P256 curve...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_generate(h, i, CURVE_P256));
@@ -157,16 +155,16 @@ void lt_test_rev_ecdsa_sign(lt_handle_t *h)
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_read(h, i, read_pub_key, &curve, &origin));
 
         LT_LOG_INFO("Signing message...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Verifying signature...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sig_verify(msg_to_sign, random_data_size, read_pub_key, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_ecdsa_sig_verify(msg_to_sign, msg_to_sign_len, read_pub_key, rs));
 
         LT_LOG_INFO("Erasing the slot...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_erase(h, i));
 
         LT_LOG_INFO("Signing message with erased slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_ecdsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_eddsa_sign.c
+++ b/tests/functional/lt_test_rev_eddsa_sign.c
@@ -12,8 +12,8 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port.h"
 #include "lt_l3_api_structs.h"
+#include "lt_random.h"
 #include "string.h"
 
 // Pre-generated key for testing using OpenSSL
@@ -85,7 +85,7 @@ void lt_test_rev_eddsa_sign(lt_handle_t *h)
     uint8_t read_pub_key[32], msg_to_sign[LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX], rs[64];
     lt_ecc_curve_type_t curve;
     ecc_key_origin_t origin;
-    uint32_t random_data[LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX / sizeof(uint32_t)], random_data_size;
+    uint32_t msg_to_sign_len;
 
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(h));
@@ -101,16 +101,15 @@ void lt_test_rev_eddsa_sign(lt_handle_t *h)
         LT_LOG_INFO();
         LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
-        LT_LOG_INFO("Generating random data length <= %d...", (int)LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
-        random_data_size %= LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX + 1;  // 0-4096
+        LT_LOG_INFO("Generating random message length <= %d...", (int)LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&msg_to_sign_len, sizeof(msg_to_sign_len)));
+        msg_to_sign_len %= LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX + 1;  // 0-4096
 
-        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
-        memcpy(msg_to_sign, random_data, random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", msg_to_sign_len);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(msg_to_sign, msg_to_sign_len));
 
         LT_LOG_INFO("Signing message with empty slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Storing private key pre-generated using Ed25519 curve...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_store(h, i, CURVE_ED25519, priv_test_key));
@@ -119,16 +118,16 @@ void lt_test_rev_eddsa_sign(lt_handle_t *h)
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_read(h, i, read_pub_key, &curve, &origin));
 
         LT_LOG_INFO("Signing message...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Verifying signature...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sig_verify(msg_to_sign, random_data_size, read_pub_key, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sig_verify(msg_to_sign, msg_to_sign_len, read_pub_key, rs));
 
         LT_LOG_INFO("Erasing the slot...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_erase(h, i));
 
         LT_LOG_INFO("Signing message with erased slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
     }
     LT_LOG_LINE();
 
@@ -137,16 +136,15 @@ void lt_test_rev_eddsa_sign(lt_handle_t *h)
         LT_LOG_INFO();
         LT_LOG_INFO("Testing signing with ECC key slot #%" PRIu8 "...", i);
 
-        LT_LOG_INFO("Generating random data length <= %d...", (int)LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
-        random_data_size %= LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX + 1;  // 0-4096
+        LT_LOG_INFO("Generating random message length <= %d...", (int)LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&msg_to_sign_len, sizeof(msg_to_sign_len)));
+        msg_to_sign_len %= LT_L3_EDDSA_SIGN_CMD_MSG_LEN_MAX + 1;  // 0-4096
 
-        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", random_data_size);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
-        memcpy(msg_to_sign, random_data, random_data_size);
+        LT_LOG_INFO("Generating random message with length %" PRIu32 " for signing...", msg_to_sign_len);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(msg_to_sign, msg_to_sign_len));
 
         LT_LOG_INFO("Signing message with empty slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Generating private key using Ed25519 curve...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_generate(h, i, CURVE_ED25519));
@@ -155,16 +153,16 @@ void lt_test_rev_eddsa_sign(lt_handle_t *h)
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_read(h, i, read_pub_key, &curve, &origin));
 
         LT_LOG_INFO("Signing message...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
 
         LT_LOG_INFO("Verifying signature...");
-        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sig_verify(msg_to_sign, random_data_size, read_pub_key, rs));
+        LT_TEST_ASSERT(LT_OK, lt_ecc_eddsa_sig_verify(msg_to_sign, msg_to_sign_len, read_pub_key, rs));
 
         LT_LOG_INFO("Erasing the slot...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_erase(h, i));
 
         LT_LOG_INFO("Signing message with erased slot (should fail)...");
-        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, random_data_size, rs));
+        LT_TEST_ASSERT(LT_L3_ECC_INVALID_KEY, lt_ecc_eddsa_sign(h, i, msg_to_sign, msg_to_sign_len, rs));
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_mcounter.c
+++ b/tests/functional/lt_test_rev_mcounter.c
@@ -12,7 +12,7 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port.h"
+#include "lt_random.h"
 #include "string.h"
 
 // Shared with cleanup function.
@@ -84,7 +84,7 @@ void lt_test_rev_mcounter(lt_handle_t *h)
     LT_LOG_INFO("Starting basic test...");
     for (int i = MCOUNTER_INDEX_0; i <= MCOUNTER_INDEX_15; i++) {
         LT_LOG_INFO("Generating random init value...");
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&init_val, 1));
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&init_val, sizeof(init_val)));
         LT_LOG_INFO("Initializing monotonic counter %d with %" PRIu32 "...", i, init_val);
         LT_TEST_ASSERT(LT_OK, lt_mcounter_init(h, i, init_val));
 
@@ -110,7 +110,7 @@ void lt_test_rev_mcounter(lt_handle_t *h)
     LT_LOG_INFO("Starting decrement to zero test...");
     for (int i = MCOUNTER_INDEX_0; i <= MCOUNTER_INDEX_15; i++) {
         LT_LOG_INFO("Generating random small init value...");
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&init_val, 1));
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&init_val, sizeof(init_val)));
         init_val %= 100;
         LT_LOG_INFO("Initializing monotonic counter %d with %" PRIu32 "...", i, init_val);
         LT_TEST_ASSERT(LT_OK, lt_mcounter_init(h, i, init_val));

--- a/tests/functional/lt_test_rev_r_mem.c
+++ b/tests/functional/lt_test_rev_r_mem.c
@@ -12,7 +12,7 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port.h"
+#include "lt_random.h"
 #include "string.h"
 
 // Shared with cleanup function
@@ -82,8 +82,7 @@ void lt_test_rev_r_mem(lt_handle_t *h)
     g_h = h;
 
     uint8_t r_mem_data[R_MEM_DATA_SIZE_MAX], write_data[R_MEM_DATA_SIZE_MAX], zeros[R_MEM_DATA_SIZE_MAX] = {0};
-    uint16_t read_data_size;
-    uint32_t random_data[R_MEM_DATA_SIZE_MAX / sizeof(uint32_t)], random_data_size;
+    uint16_t read_data_size, write_data_len;
 
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(h));
@@ -110,8 +109,7 @@ void lt_test_rev_r_mem(lt_handle_t *h)
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
         LT_LOG_INFO("Generating random data for slot #%" PRIu16 "...", i);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
-        memcpy(write_data, random_data, sizeof(write_data));
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(write_data, sizeof(write_data)));
 
         LT_LOG_INFO("Writing to slot #%" PRIu16 "...", i);
         LT_TEST_ASSERT(LT_OK, lt_r_mem_data_write(h, i, write_data, R_MEM_DATA_SIZE_MAX));
@@ -158,26 +156,25 @@ void lt_test_rev_r_mem(lt_handle_t *h)
     for (uint16_t i = 0; i <= R_MEM_DATA_SLOT_MAX; i++) {
         LT_LOG_INFO();
         LT_LOG_INFO("Generating random data length < %d...", (int)R_MEM_DATA_SIZE_MAX);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
-        random_data_size %= R_MEM_DATA_SIZE_MAX;
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&write_data_len, sizeof(write_data_len)));
+        write_data_len %= R_MEM_DATA_SIZE_MAX;
 
-        LT_LOG_INFO("Generating %" PRIu32 " random bytes for slot #%" PRIu16 "...", random_data_size, i);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(random_data, sizeof(random_data) / sizeof(uint32_t)));
-        memcpy(write_data, random_data, random_data_size);
+        LT_LOG_INFO("Generating %" PRIu16 " random bytes for slot #%" PRIu16 "...", write_data_len, i);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(write_data, write_data_len));
 
         LT_LOG_INFO("Writing to slot #%" PRIu16 "...", i);
-        LT_TEST_ASSERT_COND(lt_r_mem_data_write(h, i, write_data, random_data_size), random_data_size != 0, LT_OK,
+        LT_TEST_ASSERT_COND(lt_r_mem_data_write(h, i, write_data, write_data_len), write_data_len != 0, LT_OK,
                             LT_L3_FAIL);
 
         LT_LOG_INFO("Reading slot #%" PRIu16 "...", i);
-        LT_TEST_ASSERT_COND(lt_r_mem_data_read(h, i, r_mem_data, &read_data_size), random_data_size != 0, LT_OK,
+        LT_TEST_ASSERT_COND(lt_r_mem_data_read(h, i, r_mem_data, &read_data_size), write_data_len != 0, LT_OK,
                             LT_L3_R_MEM_DATA_READ_SLOT_EMPTY);
 
         LT_LOG_INFO("Checking number of read bytes...");
-        LT_TEST_ASSERT(1, (read_data_size == random_data_size));
+        LT_TEST_ASSERT(1, (read_data_size == write_data_len));
 
         LT_LOG_INFO("Checking contents...");
-        LT_TEST_ASSERT(0, memcmp(r_mem_data, write_data, random_data_size));
+        LT_TEST_ASSERT(0, memcmp(r_mem_data, write_data, write_data_len));
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_random_value_get.c
+++ b/tests/functional/lt_test_rev_random_value_get.c
@@ -12,7 +12,7 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port.h"
+#include "lt_random.h"
 #include "string.h"
 
 #define RANDOM_VALUE_GET_LOOPS 300
@@ -23,8 +23,8 @@ void lt_test_rev_random_value_get(lt_handle_t *h)
     LT_LOG_INFO("lt_test_rev_random_value_get()");
     LT_LOG_INFO("----------------------------------------------");
 
-    uint32_t random_data_size;
     uint8_t random_data[RANDOM_VALUE_GET_LEN_MAX];
+    uint16_t random_data_len;
 
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(h));
@@ -36,15 +36,14 @@ void lt_test_rev_random_value_get(lt_handle_t *h)
     LT_LOG_INFO("Random_Value_Get will be executed %d times", RANDOM_VALUE_GET_LOOPS);
     for (uint16_t i = 0; i < RANDOM_VALUE_GET_LOOPS; i++) {
         LT_LOG_INFO();
-        LT_LOG_INFO("Generating random data length <= %d (with lt_port_random_bytes())...",
-                    (int)RANDOM_VALUE_GET_LEN_MAX);
-        LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(&random_data_size, 1));
-        random_data_size %= RANDOM_VALUE_GET_LEN_MAX + 1;  // 0-255
+        LT_LOG_INFO("Generating random data length <= %d (with lt_random_bytes())...", (int)RANDOM_VALUE_GET_LEN_MAX);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(&random_data_len, sizeof(random_data_len)));
+        random_data_len %= RANDOM_VALUE_GET_LEN_MAX + 1;  // 0-255
 
-        LT_LOG_INFO("Getting %" PRIu32 " random numbers from TROPIC01...", random_data_size);
-        LT_TEST_ASSERT(LT_OK, lt_random_value_get(h, random_data, random_data_size));
+        LT_LOG_INFO("Getting %" PRIu16 " random numbers from TROPIC01...", random_data_len);
+        LT_TEST_ASSERT(LT_OK, lt_random_value_get(h, random_data, random_data_len));
         LT_LOG_INFO("Random data from TROPIC01:");
-        hexdump_8byte(random_data, random_data_size);
+        hexdump_8byte(random_data, random_data_len);
     }
     LT_LOG_LINE();
 

--- a/tests/functional/lt_test_rev_write_r_config.c
+++ b/tests/functional/lt_test_rev_write_r_config.c
@@ -12,7 +12,7 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port.h"
+#include "lt_random.h"
 #include "string.h"
 
 // Shared with cleanup function.
@@ -90,7 +90,7 @@ void lt_test_rev_write_r_config(lt_handle_t *h)
     LT_TEST_ASSERT(LT_OK, lt_init(h));
 
     LT_LOG_INFO("Creating randomized R config for testing");
-    LT_TEST_ASSERT(LT_OK, lt_port_random_bytes(r_config_random.obj, LT_CONFIG_OBJ_CNT));
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(r_config_random.obj, sizeof(r_config_random.obj)));
 
     LT_LOG_INFO("Starting Secure Session with key %d", (int)PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, lt_verify_chip_and_start_secure_session(h, sh0priv, sh0pub, PAIRING_KEY_SLOT_INDEX_0));


### PR DESCRIPTION
And also use `lt_random_bytes` instead of `lt_port_random_bytes` in examples and tests.