### PR TITLE
ETR01SDK-215: Rename parameter timeout to timeout_ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API change in `lt_random_bytes()`, `lt_port_random_bytes()`: changed `buff` parameter to `void*`, renamed parameter `len` to `count`
 - API change in `lt_random_bytes()`, `lt_port_random_bytes()`: added `s2` parameter.
 - API change in `lt_get_log()`: renamed to `lt_get_log_req()`, renamed `msg_len_max` to `log_msg_len` and made an output parameter.
+- API change in `lt_port_spi_transfer()`, `lt_l1_spi_transfer()`, `lt_l1_read()`, `lt_l1_write()`: renamed `timeout` to `timeout_ms`
 
 ### Added
 - Macro `LT_CONFIG_OBJ_CNT` for number of objects in the configuration structure.

--- a/hal/port/stm32/lt_port_stm32_nucleo_f439zi.c
+++ b/hal/port/stm32/lt_port_stm32_nucleo_f439zi.c
@@ -144,7 +144,7 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
     return LT_OK;
 }
 
-lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout)
+lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
 {
     lt_dev_stm32_nucleo_f439zi *device = (lt_dev_stm32_nucleo_f439zi *)(s2->device);
 
@@ -152,8 +152,8 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
         LT_LOG_ERROR("Invalid data length!");
         return LT_L1_DATA_LEN_ERROR;
     }
-    int ret
-        = HAL_SPI_TransmitReceive(&device->spi_handle, s2->buff + offset, s2->buff + offset, tx_data_length, timeout);
+    int ret = HAL_SPI_TransmitReceive(&device->spi_handle, s2->buff + offset, s2->buff + offset, tx_data_length,
+                                      timeout_ms);
     if (ret != HAL_OK) {
         LT_LOG_ERROR("HAL_SPI_TransmitReceive failed, ret=%d", ret);
         return LT_L1_SPI_ERROR;

--- a/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
+++ b/hal/port/stm32/lt_port_stm32_nucleo_l432kc.c
@@ -120,12 +120,12 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *h)
     return LT_OK;
 }
 
-lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data_length, uint32_t timeout)
+lt_ret_t lt_port_spi_transfer(lt_l2_state_t *h, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
 {
     if (offset + tx_data_length > LT_L1_LEN_MAX) {
         return LT_L1_DATA_LEN_ERROR;
     }
-    int ret = HAL_SPI_TransmitReceive(&SpiHandle, h->buff + offset, h->buff + offset, tx_data_length, timeout);
+    int ret = HAL_SPI_TransmitReceive(&SpiHandle, h->buff + offset, h->buff + offset, tx_data_length, timeout_ms);
     if (ret != HAL_OK) {
         return LT_FAIL;
     }

--- a/hal/port/unix/lt_port_unix_spi.c
+++ b/hal/port/unix/lt_port_unix_spi.c
@@ -160,9 +160,9 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
     return LT_OK;
 }
 
-lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout)
+lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
 {
-    UNUSED(timeout);
+    UNUSED(timeout_ms);
     lt_dev_unix_spi_t *device = (lt_dev_unix_spi_t *)(s2->device);
 
     int ret = 0;

--- a/hal/port/unix/lt_port_unix_tcp.c
+++ b/hal/port/unix/lt_port_unix_tcp.c
@@ -240,9 +240,9 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
     return communicate(dev, NULL, NULL);
 }
 
-lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout)
+lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
 {
-    UNUSED(timeout);
+    UNUSED(timeout_ms);
     lt_dev_unix_tcp_t *dev = (lt_dev_unix_tcp_t *)(s2->device);
     lt_ret_t ret;
 

--- a/hal/port/unix/lt_port_unix_usb_dongle.c
+++ b/hal/port/unix/lt_port_unix_usb_dongle.c
@@ -216,9 +216,9 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
     return LT_OK;
 }
 
-lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout)
+lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
 {
-    UNUSED(timeout);
+    UNUSED(timeout_ms);
 
     lt_dev_unix_usb_dongle_t *device = (lt_dev_unix_usb_dongle_t *)s2->device;
 

--- a/include/libtropic_port.h
+++ b/include/libtropic_port.h
@@ -73,12 +73,12 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2);
  * @param s2          Structure holding l2 state
  * @param tx_len      The length of data to be transferred
  * @param offset      Offset in handle's internal buffer where incomming bytes should be stored into
- * @param timeout     Timeout
+ * @param timeout_ms  Timeout
  *
  * @retval            LT_OK   Function executed successfully
  * @retval            LT_FAIL Function did not execute successully
  */
-lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_len, uint32_t timeout);
+lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_len, uint32_t timeout_ms);
 
 /**
  * @brief Platform defined function for delay, specifies what host platform should do when libtropic's functions need

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -35,13 +35,13 @@ void print_hex_chunks(const uint8_t *data, uint8_t len, uint8_t dir)
 }
 #endif
 
-lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t timeout)
+lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t timeout_ms)
 {
 #ifdef LIBT_DEBUG
     if (!s2) {
         return LT_PARAM_ERR;
     }
-    if ((timeout < LT_L1_TIMEOUT_MS_MIN) | (timeout > LT_L1_TIMEOUT_MS_MAX)) {
+    if ((timeout_ms < LT_L1_TIMEOUT_MS_MIN) | (timeout_ms > LT_L1_TIMEOUT_MS_MAX)) {
         return LT_PARAM_ERR;
     }
     if ((max_len < LT_L1_LEN_MIN) | (max_len > LT_L1_LEN_MAX)) {
@@ -65,7 +65,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
             return ret;
         }
 
-        ret = lt_l1_spi_transfer(s2, 0, 1, timeout);
+        ret = lt_l1_spi_transfer(s2, 0, 1, timeout_ms);
         if (ret != LT_OK) {
             lt_ret_t ret_unused = lt_l1_spi_csn_high(s2);
             UNUSED(ret_unused);  // We don't care about it, we return ret from SPI transfer anyway.
@@ -91,7 +91,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
         // Proceed further in case CHIP_STATUS contains READY bit, signalizing that chip is ready to receive request
         if (s2->buff[0] & (CHIP_MODE_READY_bit)) {
             // receive STATUS byte and length byte
-            ret = lt_l1_spi_transfer(s2, 1, 2, timeout);
+            ret = lt_l1_spi_transfer(s2, 1, 2, timeout_ms);
             if (ret != LT_OK) {  // offset 1
                 lt_ret_t ret_unused = lt_l1_spi_csn_high(s2);
                 UNUSED(ret_unused);  // We don't care about it, we return ret from SPI transfer anyway.
@@ -119,7 +119,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
                 return LT_L1_DATA_LEN_ERROR;
             }
             // Receive the rest of incomming bytes, including crc
-            ret = lt_l1_spi_transfer(s2, 3, length, timeout);
+            ret = lt_l1_spi_transfer(s2, 3, length, timeout_ms);
             if (ret != LT_OK) {  // offset 3
                 lt_ret_t ret_unused = lt_l1_spi_csn_high(s2);
                 UNUSED(ret_unused);  // We don't care about it, we return ret from SPI transfer anyway.
@@ -171,13 +171,13 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
     return LT_L1_CHIP_BUSY;
 }
 
-lt_ret_t lt_l1_write(lt_l2_state_t *s2, const uint16_t len, const uint32_t timeout)
+lt_ret_t lt_l1_write(lt_l2_state_t *s2, const uint16_t len, const uint32_t timeout_ms)
 {
 #ifdef LIBT_DEBUG
     if (!s2) {
         return LT_PARAM_ERR;
     }
-    if ((timeout < LT_L1_TIMEOUT_MS_MIN) | (timeout > LT_L1_TIMEOUT_MS_MAX)) {
+    if ((timeout_ms < LT_L1_TIMEOUT_MS_MIN) | (timeout_ms > LT_L1_TIMEOUT_MS_MAX)) {
         return LT_PARAM_ERR;
     }
     if ((len < LT_L1_LEN_MIN) | (len > LT_L1_LEN_MAX)) {
@@ -194,7 +194,7 @@ lt_ret_t lt_l1_write(lt_l2_state_t *s2, const uint16_t len, const uint32_t timeo
 #ifdef LT_PRINT_SPI_DATA
     print_hex_chunks(s2->buff, len, SPI_DIR_MOSI);
 #endif
-    ret = lt_l1_spi_transfer(s2, 0, len, timeout);
+    ret = lt_l1_spi_transfer(s2, 0, len, timeout_ms);
     if (ret != LT_OK) {
         lt_ret_t ret_unused = lt_l1_spi_csn_high(s2);
         UNUSED(ret_unused);  // We don't care about it, we return ret from SPI transfer anyway.

--- a/src/lt_l1.h
+++ b/src/lt_l1.h
@@ -46,10 +46,10 @@
  *
  * @param s2          Structure holding l2 state
  * @param max_len     Max len of receive buffer
- * @param timeout     Timeout - how long function will wait for response
+ * @param timeout_ms  Timeout - how long function will wait for response
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t timeout)
+lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t timeout_ms)
     __attribute__((warn_unused_result));
 
 /**
@@ -57,10 +57,11 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
  *
  * @param s2          Structure holding l2 state
  * @param len         Length of data to send
- * @param timeout     Timeout
+ * @param timeout_ms  Timeout
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_l1_write(lt_l2_state_t *s2, const uint16_t len, const uint32_t timeout) __attribute__((warn_unused_result));
+lt_ret_t lt_l1_write(lt_l2_state_t *s2, const uint16_t len, const uint32_t timeout_ms)
+    __attribute__((warn_unused_result));
 
 /** @} */  // end of group_l1_functions
 

--- a/src/lt_l1_port_wrap.c
+++ b/src/lt_l1_port_wrap.c
@@ -53,14 +53,14 @@ lt_ret_t lt_l1_spi_csn_high(lt_l2_state_t *s)
     return lt_port_spi_csn_high(s);
 }
 
-lt_ret_t lt_l1_spi_transfer(lt_l2_state_t *s, uint8_t offset, uint16_t tx_len, uint32_t timeout)
+lt_ret_t lt_l1_spi_transfer(lt_l2_state_t *s, uint8_t offset, uint16_t tx_len, uint32_t timeout_ms)
 {
 #ifdef LIBT_DEBUG
     if (!s) {
         return LT_PARAM_ERR;
     }
 #endif
-    return lt_port_spi_transfer(s, offset, tx_len, timeout);
+    return lt_port_spi_transfer(s, offset, tx_len, timeout_ms);
 }
 
 lt_ret_t lt_l1_delay(lt_l2_state_t *s, uint32_t ms)

--- a/src/lt_l1_port_wrap.h
+++ b/src/lt_l1_port_wrap.h
@@ -57,10 +57,10 @@ lt_ret_t lt_l1_spi_csn_high(lt_l2_state_t *s2) __attribute__((warn_unused_result
  * @param s2          Structure holding l2 state
  * @param offset      Offset in handle's internal buffer where incomming bytes should be stored into
  * @param tx_len      The length of data to be transferred
- * @param timeout     Timeout
+ * @param timeout_ms  Timeout
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_l1_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_len, uint32_t timeout)
+lt_ret_t lt_l1_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_len, uint32_t timeout_ms)
     __attribute__((warn_unused_result));
 
 /**


### PR DESCRIPTION
Affected functions: `lt_port_spi_transfer()`, `lt_l1_spi_transfer()`, `lt_l1_read()`, `lt_l1_write()`

Compilation checked in platform repos.