### PR TITLE
Change logging functions to use stderr

### DIFF
--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -40,25 +40,25 @@ extern "C" {
     } while (0)
 
 #if LT_LOG_ENABLE_INFO
-#define LT_LOG_INFO(f_, ...) printf("INFO    [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_INFO(f_, ...) fprintf(stderr, "INFO    [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_INFO(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif
 
 #if LT_LOG_ENABLE_WARN
-#define LT_LOG_WARN(f_, ...) printf("WARNING [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_WARN(f_, ...) fprintf(stderr, "WARNING [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_WARN(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif
 
 #if LT_LOG_ENABLE_ERROR
-#define LT_LOG_ERROR(f_, ...) printf("ERROR   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_ERROR(f_, ...) fprintf(stderr, "ERROR   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_ERROR(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif
 
 #if LT_LOG_ENABLE_DEBUG
-#define LT_LOG_DEBUG(f_, ...) printf("DEBUG   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_DEBUG(f_, ...) fprintf(stderr, "DEBUG   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_DEBUG(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif


### PR DESCRIPTION
## Description

Libtropic_logging macros defaults to stdout, which broke my scripts, communicating each other over stdin/stdout. This PR changes logging to use stderr, as it should be.

---

## Type of Change

Select the type(s) that best describe your change:

- [ x ] 🐛 Bug fix

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [ x ] I opened the Pull Request to the **develop** branch
- [ x ] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [ x ] The project **builds without errors or warnings**  
- [ x ] I have **verified the functionality against the hardware/model** as applicable  
- [ x ] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review
