### PR TITLE
ETR01SDK-355: HAL port functions for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+### Added
+- Logging: `lt_port_log` function for platform-specific logging mechanism; is used by the logging macros declared in `libtropic_logging.h`.
+
+### Fixed
+
+### Removed
+- Logging: Redundant/unused macros `LT_LOG`, `LT_LOG_RESULT`, `LT_LOG_VALUE`.
+
 ## [3.0.0]
 
 ### Changed

--- a/examples/lt_ex_fw_update.c
+++ b/examples/lt_ex_fw_update.c
@@ -8,6 +8,7 @@
  */
 
 #include <inttypes.h>
+#include <stdio.h>
 
 #include "fw_CPU.h"
 #include "fw_SPECT.h"

--- a/examples/lt_ex_fw_update.c
+++ b/examples/lt_ex_fw_update.c
@@ -91,7 +91,7 @@ int lt_ex_fw_update(lt_handle_t *h)
     LT_LOG_INFO("OK");
 
     LT_LOG_LINE();
-    LT_LOG("Successfully updated all 4 FW banks:");
+    LT_LOG_INFO("Successfully updated all 4 FW banks:");
 
     ret = lt_print_fw_header(h, TR01_FW_BANK_FW1, printf);
     if (ret != LT_OK) {

--- a/examples/lt_ex_macandd.c
+++ b/examples/lt_ex_macandd.c
@@ -533,7 +533,7 @@ int lt_ex_macandd(lt_handle_t *h)
     LT_LOG_INFO("Generated master_secret: %s", print_buff);
 
     // Set the PIN and log out the final_key
-    LT_LOG("Setting the user PIN...");
+    LT_LOG_INFO("Setting the user PIN...");
     ret = lt_new_PIN_setup(h, master_secret, pin, sizeof(pin), NULL, sizeof(additional_data), final_key_initialized);
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to set the user PIN, ret=%s", lt_ret_verbose(ret));

--- a/examples/lt_ex_show_chip_id_and_fwver.c
+++ b/examples/lt_ex_show_chip_id_and_fwver.c
@@ -9,6 +9,7 @@
  */
 
 #include <inttypes.h>
+#include <stdio.h>
 
 #include "libtropic.h"
 #include "libtropic_common.h"

--- a/hal/arduino/libtropic_port_arduino.cpp
+++ b/hal/arduino/libtropic_port_arduino.cpp
@@ -10,6 +10,8 @@
 
 #include <Arduino.h>
 #include <SPI.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 #include "libtropic_port.h"
 
@@ -109,4 +111,18 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     }
 
     return LT_OK;
+}
+
+void lt_port_log(const char *format, ...)
+{
+    // 1 KiB should be enough.
+    // Using static to avoid stack overflow.
+    static char log_buff[1024];
+    va_list args;
+
+    va_start(args, format);
+    vsnprintf(log_buff, sizeof(log_buff), format, args);
+    va_end(args);
+
+    Serial.print(log_buff);
 }

--- a/hal/linux/spi/libtropic_port_linux_spi.c
+++ b/hal/linux/spi/libtropic_port_linux_spi.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 // Other
+#include <stdarg.h>
 #include <sys/random.h>
 
 #include "libtropic_common.h"
@@ -306,3 +307,12 @@ lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms)
     return LT_FAIL;
 }
 #endif
+
+void lt_port_log(const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+}

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -11,6 +11,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -301,4 +302,13 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     }
 
     return LT_OK;
+}
+
+void lt_port_log(const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
 }

--- a/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
+++ b/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
@@ -16,6 +16,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -276,4 +277,13 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
     }
 
     return LT_OK;
+}
+
+void lt_port_log(const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
 }

--- a/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
+++ b/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
@@ -11,7 +11,9 @@
 
 #include "libtropic_port_stm32_nucleo_f439zi.h"
 
+#include <stdarg.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "libtropic_common.h"
@@ -178,3 +180,12 @@ lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms)
     return LT_OK;
 }
 #endif
+
+void lt_port_log(const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+}

--- a/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.c
+++ b/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.c
@@ -5,7 +5,9 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <stdarg.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "libtropic_common.h"
@@ -145,4 +147,13 @@ lt_ret_t lt_port_delay(lt_l2_state_t *h, uint32_t ms)
     HAL_Delay(ms);
 
     return LT_OK;
+}
+
+void lt_port_log(const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
 }

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -16,17 +16,6 @@
 extern "C" {
 #endif
 
-// Only info-level loggers and decorators.
-// This has no effect, test runner just simply copies these lines to the log.
-#define LT_LOG(f_, ...) LT_LOG_INFO(f_, ##__VA_ARGS__)
-#define LT_LOG_RESULT(f_, ...) LT_LOG_INFO("  result: " f_, ##__VA_ARGS__)
-#define LT_LOG_VALUE(f_, ...) LT_LOG_INFO("\t\t- " f_, ##__VA_ARGS__)
-#define LT_LOG_LINE(f_, ...)                                                                                           \
-    LT_LOG_INFO(                                                                                                       \
-        "\t----------------------------------------------------------------------------------------------------------" \
-        "---" f_,                                                                                                      \
-        ##__VA_ARGS__)
-
 // Loggers with selectable message type.
 
 /** @brief Dummy macro used when no logging is configured. */
@@ -62,6 +51,11 @@ extern "C" {
 #else
 #define LT_LOG_DEBUG(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif
+
+// This has no effect, test runner just simply copies these lines to the log.
+#define LT_LOG_LINE(f_, ...)                                                                                \
+    LT_LOG_INFO("\t-----------------------------------------------------------------------------------" f_, \
+                ##__VA_ARGS__)
 
 // Assertions. Will log as a system message and call native assert function.
 // Note that parameters are stored to _val_ and _exp_ for a case when there

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -10,7 +10,6 @@
  */
 
 #include <assert.h>
-#include <stdio.h>
 
 #include "libtropic_port.h"
 

--- a/include/libtropic_logging.h
+++ b/include/libtropic_logging.h
@@ -12,6 +12,8 @@
 #include <assert.h>
 #include <stdio.h>
 
+#include "libtropic_port.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -24,30 +26,30 @@ extern "C" {
         if (0) {                                                 \
             /* A base string ensures printf is always valid. */  \
             /* Using a single space is minimal and effective. */ \
-            printf(" " __VA_ARGS__);                             \
+            lt_port_log(" " __VA_ARGS__);                        \
         }                                                        \
     } while (0)
 
 #if LT_LOG_ENABLE_INFO
-#define LT_LOG_INFO(f_, ...) printf("INFO    [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_INFO(f_, ...) lt_port_log("INFO    [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_INFO(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif
 
 #if LT_LOG_ENABLE_WARN
-#define LT_LOG_WARN(f_, ...) printf("WARNING [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_WARN(f_, ...) lt_port_log("WARNING [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_WARN(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif
 
 #if LT_LOG_ENABLE_ERROR
-#define LT_LOG_ERROR(f_, ...) printf("ERROR   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_ERROR(f_, ...) lt_port_log("ERROR   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_ERROR(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif
 
 #if LT_LOG_ENABLE_DEBUG
-#define LT_LOG_DEBUG(f_, ...) printf("DEBUG   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
+#define LT_LOG_DEBUG(f_, ...) lt_port_log("DEBUG   [%4d] " f_ "\r\n", __LINE__, ##__VA_ARGS__)
 #else
 #define LT_LOG_DEBUG(f_, ...) LT_LOG_DISABLED(f_, ##__VA_ARGS__)
 #endif

--- a/include/libtropic_port.h
+++ b/include/libtropic_port.h
@@ -127,6 +127,7 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count);
  * @brief Port-specific logging function.
  * @note  The caller should not append any newline characters. This function is exlusively used by the logging macros in
  * libtropic_logging.h, that always append "\r\n" at the end.
+ * @warning Some implementations use size limited buffer for temporarily storing the log message.
  *
  * @param format      Pointer to a null-terminated byte string specifying how to interpret the data
  * @param ...         Arguments specifying data to print

--- a/include/libtropic_port.h
+++ b/include/libtropic_port.h
@@ -123,6 +123,14 @@ lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms);
  */
 lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count);
 
+/**
+ * @brief Port-specific logging function.
+ *
+ * @param format      Pointer to a null-terminated byte string specifying how to interpret the data
+ * @param ...         Arguments specifying data to print
+ */
+void lt_port_log(const char *format, ...);
+
 /** @} */  // end of group_port_functions
 
 #ifdef __cplusplus

--- a/include/libtropic_port.h
+++ b/include/libtropic_port.h
@@ -125,6 +125,8 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count);
 
 /**
  * @brief Port-specific logging function.
+ * @note  The caller should not append any newline characters. This function is exlusively used by the logging macros in
+ * libtropic_logging.h, that always append "\r\n" at the end.
  *
  * @param format      Pointer to a null-terminated byte string specifying how to interpret the data
  * @param ...         Arguments specifying data to print

--- a/src/lt_asn1_der.c
+++ b/src/lt_asn1_der.c
@@ -150,10 +150,10 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
     uint16_t start = ctx->past;
 
 #ifdef ASNDER_LOG_EN
-    LT_LOG("parse_object:");
-    LT_LOG("    Start: %" PRIu16, start);
-    LT_LOG("    Object type: 0x%" PRIx8, b);
-    LT_LOG("    Object len: %" PRIu16, len);
+    LT_LOG_DEBUG("parse_object:");
+    LT_LOG_DEBUG("    Start: %" PRIu16, start);
+    LT_LOG_DEBUG("    Object type: 0x%" PRIx8, b);
+    LT_LOG_DEBUG("    Object len: %" PRIu16, len);
 #endif
 
     switch (b) {
@@ -181,7 +181,7 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
         case LT_ASN1DER_OBJECT_IDENTIFIER: {
             if (len < 3) {
 #ifdef ASNDER_LOG_EN
-                LT_LOG("Length too short (< 3), skipping.");
+                LT_LOG_DEBUG("Length too short (< 3), skipping.");
 #endif  // ASNDER_LOG_EN
                 break;
             }
@@ -194,7 +194,7 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
 
             if (ctx->obj_id == obj_id) {
 #ifdef ASNDER_LOG_EN
-                LT_LOG("Found searched object: 0x%" PRIx32 ". Next object will be sampled!", ctx->obj_id);
+                LT_LOG_DEBUG("Found searched object: 0x%" PRIx32 ". Next object will be sampled!", ctx->obj_id);
 #endif
                 ctx->sample_next = true;
             }
@@ -212,7 +212,7 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
         case LT_ASN1DER_UTC_TIME: {
             if (ctx->sample_next & !ctx->found) {
 #ifdef ASNDER_LOG_EN
-                LT_LOG("Sampling this object!", ctx->obj_id);
+                LT_LOG_DEBUG("Sampling this object!", ctx->obj_id);
 #endif
                 uint8_t sample_len = len;
 
@@ -222,10 +222,10 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
                     ctx->cropped = true;
 
 #ifdef ASNDER_LOG_EN
-                    LT_LOG("Sample buffer (%d) is smaller than size of the object to be sampled (%" PRIu8
-                           "). "
-                           "Cropping %" PRIu16 " bytes from %s of the searched object",
-                           ctx->sbuf_len, sample_len, n_crop_bytes, crop_prefix ? "prefix" : "suffix");
+                    LT_LOG_DEBUG("Sample buffer (%d) is smaller than size of the object to be sampled (%" PRIu8
+                                 "). "
+                                 "Cropping %" PRIu16 " bytes from %s of the searched object",
+                                 ctx->sbuf_len, sample_len, n_crop_bytes, crop_prefix ? "prefix" : "suffix");
 #endif
 
                     if (crop_prefix) {

--- a/src/lt_port_wrap.c
+++ b/src/lt_port_wrap.c
@@ -8,7 +8,6 @@
 
 #include "lt_port_wrap.h"
 
-#include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/lt_port_wrap.c
+++ b/src/lt_port_wrap.c
@@ -8,6 +8,7 @@
 
 #include "lt_port_wrap.h"
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/lt_port_wrap.h
+++ b/src/lt_port_wrap.h
@@ -92,7 +92,8 @@ lt_ret_t lt_l1_delay_on_int(lt_l2_state_t *s2, uint32_t ms) __attribute__((warn_
 #endif
 
 /**
- * @brief Generate `count` random bytes using host's random number generator. This is wrapper for platform defined function.
+ * @brief Generate `count` random bytes using host's random number generator. This is wrapper for platform defined
+ * function.
  *
  * @param h           Handle for communication with TROPIC01
  * @param buff        Buffer to be filled

--- a/src/lt_port_wrap.h
+++ b/src/lt_port_wrap.h
@@ -92,7 +92,7 @@ lt_ret_t lt_l1_delay_on_int(lt_l2_state_t *s2, uint32_t ms) __attribute__((warn_
 #endif
 
 /**
- * @brief Generate `count` random bytes using host's random number generator. This is wrapper for platform defined
+ * @brief Generate `count` random bytes using host's random number generator. This is a wrapper for platform defined
  * function.
  *
  * @param h           Handle for communication with TROPIC01

--- a/tests/functional/lt_test_common.c
+++ b/tests/functional/lt_test_common.c
@@ -8,6 +8,7 @@
 
 #include <inttypes.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
## Description
At the moment, we use printf()in our logging macros and if it is not available on the target host platform, the macros can simply be redefined, but that is not the most clean solution in my opinion.

A better solution would be to introduce new port functions in libtropic_port.h for the logging.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---