### PR TITLE
ETR01SDK-455: Remove rng_seed from lt_dev_arduino_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Logging: Redundant/unused macros `LT_LOG`, `LT_LOG_RESULT`, `LT_LOG_VALUE`.
+- Arduino HAL: Removed `rng_seed` from `lt_dev_arduino_t`, as it should be user's responsibility to initialize the PRNG.
 
 ## [3.0.0]
 

--- a/hal/arduino/libtropic_port_arduino.cpp
+++ b/hal/arduino/libtropic_port_arduino.cpp
@@ -29,9 +29,6 @@ lt_ret_t lt_port_init(lt_l2_state_t *s2)
     pinMode(device->int_gpio_pin, INPUT);
 #endif
 
-    // Initialize RNG
-    randomSeed(device->rng_seed);
-
     return LT_OK;
 }
 

--- a/hal/arduino/libtropic_port_arduino.h
+++ b/hal/arduino/libtropic_port_arduino.h
@@ -28,8 +28,6 @@ typedef struct lt_dev_arduino_t {
 #endif
     /** @public @brief SPI settings. */
     SPISettings spi_settings;
-    /** @public @brief Seed for random number generator. */
-    unsigned int rng_seed;
 
     /** @private @brief Pointer to the SPI class. */
     SPIClass *spi;


### PR DESCRIPTION
## Description
Some while ago, we agreed to transfer responsibility for initializing the RNG to the user.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---