### PR TITLE
ETR01SDK-449: Add `HSK_ERR` to FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,7 +21,7 @@ The reason is that we detect the status of the TROPIC01 using a single flag; if 
 Normally, this means the TROPIC01 entered Alarm Mode. However, it can also mean — similarly to `LT_L1_CHIP_BUSY` — that all ones are received on `MISO`. Check your connections.
 
 ### `LT_L2_HSK_ERR`
-This error is caused by a problem during Secure Session estabilishment. See [I cannot establish a Secure Session](#i-cannot-establish-a-secure-session).
+This error is caused by a problem during Secure Session establishment. See [I cannot establish a Secure Session](#i-cannot-establish-a-secure-session).
 
 ### `LT_L3_DATA_LEN_ERROR`
 This error normally means that the L3 packet size we sent to the TROPIC01 is incorrect, which can be caused by a bug or an attack. However, it can also mean that the chip select is connected incorrectly. Check your connections and GPIO assignments.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,6 +20,9 @@ The reason is that we detect the status of the TROPIC01 using a single flag; if 
 ### `LT_L1_CHIP_ALARM_MODE`
 Normally, this means the TROPIC01 entered Alarm Mode. However, it can also mean — similarly to `LT_L1_CHIP_BUSY` — that all ones are received on `MISO`. Check your connections.
 
+### `LT_L2_HSK_ERR`
+This error is caused by a problem during Secure Session estabilishment. See [I cannot establish a Secure Session](#i-cannot-establish-a-secure-session).
+
 ### `LT_L3_DATA_LEN_ERROR`
 This error normally means that the L3 packet size we sent to the TROPIC01 is incorrect, which can be caused by a bug or an attack. However, it can also mean that the chip select is connected incorrectly. Check your connections and GPIO assignments.
 


### PR DESCRIPTION
## Description

In this PR, I added a new entry to the FAQ, which describes `LT_L2_HSK_ERR`.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage