### PR TITLE
ETR01SDK-415: Collect coverage from functional mock tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,29 +60,39 @@ jobs:
             pip install ${{ env.WHEEL_FILE_NAME }}
             pip install gcovr jsonschema
 
-      - name: Compile libtropic with tests and coverage enabled
+      - name: Compile and run functional tests with coverage enabled, export trace
         run: |
             cd tropic01_model/
             cmake ./ -B build -DLT_CAL=mbedtls_v4 -DLT_BUILD_TESTS=1 -DLT_TEST_COVERAGE=1
             cd build/
             make
-
-      - name: Execute tests with CTest
-        run: |
-            cd tropic01_model/build/
             ctest -V
 
-      - name: Export Markdown report
+            cd ..
+            gcovr --json coverage_trace.json --exclude 'build/_deps/.*|\.\./tests/.*|\.\./vendor/.*|\.\./hal/.*|\.\./cal/.*'
+
+      - name: Compile and run functional mock tests with coverage enabled, export trace
         run: |
-            cd tropic01_model
-            gcovr --markdown coverage_report.md --exclude 'build/_deps/.*|\.\./tests/.*|\.\./vendor/.*'
+          cd tests/functional_mock
+          mkdir -p build
+          cd build
+          cmake -DLT_TEST_COVERAGE=1 ..
+          make
+          ctest -V
+
+          cd ..
+          gcovr --json coverage_trace.json --exclude 'build/_deps/.*|\.\./tests/.*|\.\./vendor/.*|\.\./\.\./hal/.*|\.\./\.\./cal/.*'
+
+      - name: Merge coverage and generate markdown report
+        run: |
+          gcovr --json-add-tracefile tropic01_model/coverage_trace.json  --json-add-tracefile tests/functional_mock/coverage_trace.json --markdown coverage_report.md
 
       - name: Post or update PR comment
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs");
-            const path = "tropic01_model/coverage_report.md";
+            const path = "./coverage_report.md";
             const marker = "<!-- coverage-bot-comment -->";
 
             let commentBody;

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Merge coverage and generate markdown report
         run: |
-          gcovr --json-add-tracefile tropic01_model/coverage_trace.json  --json-add-tracefile tests/functional_mock/coverage_trace.json --markdown coverage_report.md
+          gcovr --json-add-tracefile tropic01_model/coverage_trace.json --json-add-tracefile tests/functional_mock/coverage_trace.json --markdown coverage_report.md
 
       - name: Post or update PR comment
         uses: actions/github-script@v7

--- a/hal/mock/libtropic_port_mock.c
+++ b/hal/mock/libtropic_port_mock.c
@@ -9,6 +9,7 @@
 #include "libtropic_port_mock.h"
 
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -197,4 +198,13 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     }
 
     return LT_OK;
+}
+
+void lt_port_log(const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
 }

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -122,16 +122,17 @@ foreach(test_name IN LISTS LIBTROPIC_MOCK_TEST_LIST)
 
     set(exe_name ${test_name})
     set(LIBTROPIC_MOCK_TEST_FUNCTION ${test_name})
+    set(TEST_SPECIFIC_MAIN main.${test_name}.c)
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/main.c.in
-        ${CMAKE_CURRENT_BINARY_DIR}/main.c
+        ${CMAKE_CURRENT_BINARY_DIR}/${TEST_SPECIFIC_MAIN}
         @ONLY
     )
 
     # Define executable (separate for each test) and link dependencies.
     add_executable(${exe_name} 
-        ${CMAKE_CURRENT_BINARY_DIR}/main.c
+        ${CMAKE_CURRENT_BINARY_DIR}/${TEST_SPECIFIC_MAIN}
     )
     target_link_libraries(${exe_name} PUBLIC libtropic_functional_mock_tests_objs)
     


### PR DESCRIPTION
## Description

In this PR, I mainly updated coverage CI to also collect coverage from functional mock tests. Additional updates:
- added lt_port_log to mock HAL
- fixed functional mock test building

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [x] Other (please describe): CI update

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [x] Measure Test Coverage