### PR TITLE
ETR01SDK-415: Add mock tests CI config

### DIFF
--- a/.github/workflows/functional_mock_tests.yml
+++ b/.github/workflows/functional_mock_tests.yml
@@ -66,8 +66,8 @@ jobs:
             cd tests/functional_mock
             mkdir -p build
             cd build
-            cmake -DLT_VALGRIND=1 ..
-            make -j4
+            cmake -DLT_VALGRIND=1 -G Ninja ..
+            ninja
 
       - name: Execute tests with CTest
         run: |

--- a/.github/workflows/functional_mock_tests.yml
+++ b/.github/workflows/functional_mock_tests.yml
@@ -34,8 +34,8 @@ jobs:
             cd tests/functional_mock
             mkdir -p build
             cd build
-            cmake -DLT_ASAN=1 ..
-            make -j4
+            cmake -DLT_ASAN=1 -G Ninja ..
+            ninja
 
       - name: Execute tests with CTest
         run: |

--- a/.github/workflows/functional_mock_tests.yml
+++ b/.github/workflows/functional_mock_tests.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Compile functional mock tests with AddressSanitizer
         run: |
-          cd tests/functional_mock
-          mkdir -p build
-          cd build
-          cmake -DLT_ASAN=1 ..
-          make -j4
+            cd tests/functional_mock
+            mkdir -p build
+            cd build
+            cmake -DLT_ASAN=1 ..
+            make -j4
 
       - name: Execute tests with CTest
         run: |

--- a/.github/workflows/functional_mock_tests.yml
+++ b/.github/workflows/functional_mock_tests.yml
@@ -1,0 +1,75 @@
+name: Run functional mock tests
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+      - 'develop'
+
+jobs:
+  tests_asan:
+    name: Run functional mock tests with AddressSanitizer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+            sudo apt-get install cmake build-essential
+            pip install jsonschema jinja2
+
+      - name: Compile functional mock tests with AddressSanitizer
+        run: |
+          cd tests/functional_mock
+          mkdir -p build
+          cd build
+          cmake -DLT_ASAN=1 ..
+          make -j4
+
+      - name: Execute tests with CTest
+        run: |
+            cd tests/functional_mock/build
+            ctest -V
+    
+  tests_valgrind:
+    name: Run tests with Valgrind
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+            sudo apt-get install cmake build-essential valgrind
+            pip install jsonschema jinja2
+
+      - name: Compile functional mock tests with Valgrind
+        run: |
+            cd tests/functional_mock
+            mkdir -p build
+            cd build
+            cmake -DLT_VALGRIND=1 ..
+            make -j4
+
+      - name: Execute tests with CTest
+        run: |
+            cd tests/functional_mock/build
+            ctest -V

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -26,7 +26,7 @@ option(LT_STRICT_COMPILATION "Enable strict compilation flags" ON)
 option(LT_VALGRIND "Run tests with Valgrind" OFF)
 option(LT_ASAN "Enable static AddressSanitizer (ASan)" OFF)
 
-if (LT_ASAN and LT_VALGRIND)
+if (${LT_ASAN} AND ${LT_VALGRIND})
     message(WARNING "Using Valgrind with ASan enabled may lead to unexpected behavior.")
 endif()
 

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -155,7 +155,7 @@ foreach(test_name IN LISTS LIBTROPIC_MOCK_TEST_LIST)
 
     # Add CTest entry.
     if (LT_VALGRIND)
-        add_test(NAME ${test_name} COMMAND valgrind ./${exe_name})
+        add_test(NAME ${test_name} COMMAND valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --error-exitcode=1 ./${exe_name})
     else()
         add_test(NAME ${test_name} COMMAND ./${exe_name})
     endif()

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 include(FetchContent)
 include(${PATH_TO_LIBTROPIC}cmake/strict_compile_flags.cmake)
+include(${PATH_TO_LIBTROPIC}cmake/static_asan_flags.cmake)
 
 ###########################################################################
 #                                                                         #
@@ -22,12 +23,21 @@ include(${PATH_TO_LIBTROPIC}cmake/strict_compile_flags.cmake)
 ###########################################################################
 
 option(LT_STRICT_COMPILATION "Enable strict compilation flags" ON)
+option(LT_VALGRIND "Run tests with Valgrind" OFF)
+option(LT_ASAN "Enable static AddressSanitizer (ASan)" OFF)
 
 ###########################################################################
 #                                                                         #
 #   Add libtropic library and set it up                                   #
 #                                                                         #
 ###########################################################################
+
+if(LT_ASAN)
+    message(STATUS "Enabling static AddressSanitizer (ASan).")
+    # This applies the flags to all targets
+    add_compile_options(${LT_ASAN_COMPILE_FLAGS})
+    add_link_options(${LT_ASAN_LINK_FLAGS})
+endif()
 
 # Add path to libtropic's repository root folder
 if (NOT LT_LOG_LVL)
@@ -144,7 +154,9 @@ foreach(test_name IN LISTS LIBTROPIC_MOCK_TEST_LIST)
     target_include_directories(${exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
     # Add CTest entry.
-    add_test(NAME ${test_name}
-                COMMAND ./${exe_name}
-    )
+    if (LT_VALGRIND)
+        add_test(NAME ${test_name} COMMAND valgrind ./${exe_name})
+    else()
+        add_test(NAME ${test_name} COMMAND ./${exe_name})
+    endif()
 endforeach()

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -26,6 +26,10 @@ option(LT_STRICT_COMPILATION "Enable strict compilation flags" ON)
 option(LT_VALGRIND "Run tests with Valgrind" OFF)
 option(LT_ASAN "Enable static AddressSanitizer (ASan)" OFF)
 
+if (LT_ASAN and LT_VALGRIND)
+    message(WARNING "Using Valgrind with ASan enabled may lead to unexpected behavior.")
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Add libtropic library and set it up                                   #


### PR DESCRIPTION
## Description

In this PR, I add CI config for running functional mock tests and extend `CMakeLists.txt` to support ASan and Valgrind.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [x] Other (please describe): CI update

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [ ] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [ ] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage