### PR TITLE
ETR01SDK-463: Fix typo in `lt_print_fw_header`

### DIFF
--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1912,7 +1912,7 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id, int (*pr
             print_func("    Reading header from SPECT's firmware bank 1:\r\n");
             break;
         case TR01_FW_BANK_SPECT2:
-            print_func("    Reading header from SPECT's foirmware bank 2:\r\n");
+            print_func("    Reading header from SPECT's firmware bank 2:\r\n");
             break;
         default:
             print_func("    Reading header: Unknown bank ID: %d\r\n", (int)bank_id);


### PR DESCRIPTION
## Description

Fixes typo in `lt_print_fw_header`.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [ ] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [ ] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage