### PR TITLE
ETR01SDK-469: Change `lt_port_log` signature to match `printf`-like functions

### DIFF
--- a/hal/arduino/libtropic_port_arduino.cpp
+++ b/hal/arduino/libtropic_port_arduino.cpp
@@ -110,16 +110,19 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     return LT_OK;
 }
 
-void lt_port_log(const char *format, ...)
+int lt_port_log(const char *format, ...)
 {
     // 1 KiB should be enough.
     // Using static to avoid stack overflow.
     static char log_buff[1024];
     va_list args;
+    int ret;
 
     va_start(args, format);
-    vsnprintf(log_buff, sizeof(log_buff), format, args);
+    ret = vsnprintf(log_buff, sizeof(log_buff), format, args);
     va_end(args);
 
     Serial.print(log_buff);
+
+    return ret;
 }

--- a/hal/arduino/libtropic_port_arduino.cpp
+++ b/hal/arduino/libtropic_port_arduino.cpp
@@ -122,7 +122,9 @@ int lt_port_log(const char *format, ...)
     ret = vsnprintf(log_buff, sizeof(log_buff), format, args);
     va_end(args);
 
-    Serial.print(log_buff);
+    if (ret > 0) {
+        Serial.print(log_buff);
+    }
 
     return ret;
 }

--- a/hal/linux/spi/libtropic_port_linux_spi.c
+++ b/hal/linux/spi/libtropic_port_linux_spi.c
@@ -308,11 +308,14 @@ lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms)
 }
 #endif
 
-void lt_port_log(const char *format, ...)
+int lt_port_log(const char *format, ...)
 {
     va_list args;
+    int ret;
 
     va_start(args, format);
-    vfprintf(stderr, format, args);
+    ret = vfprintf(stderr, format, args);
     va_end(args);
+
+    return ret;
 }

--- a/hal/mock/libtropic_port_mock.c
+++ b/hal/mock/libtropic_port_mock.c
@@ -200,11 +200,14 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     return LT_OK;
 }
 
-void lt_port_log(const char *format, ...)
+int lt_port_log(const char *format, ...)
 {
     va_list args;
+    int ret;
 
     va_start(args, format);
-    vfprintf(stderr, format, args);
+    ret = vfprintf(stderr, format, args);
     va_end(args);
+
+    return ret;
 }

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -304,11 +304,14 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     return LT_OK;
 }
 
-void lt_port_log(const char *format, ...)
+int lt_port_log(const char *format, ...)
 {
     va_list args;
+    int ret;
 
     va_start(args, format);
-    vfprintf(stderr, format, args);
+    ret = vfprintf(stderr, format, args);
     va_end(args);
+
+    return ret;
 }

--- a/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
+++ b/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
@@ -279,11 +279,14 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
     return LT_OK;
 }
 
-void lt_port_log(const char *format, ...)
+int lt_port_log(const char *format, ...)
 {
     va_list args;
+    int ret;
 
     va_start(args, format);
-    vfprintf(stderr, format, args);
+    ret = vfprintf(stderr, format, args);
     va_end(args);
+
+    return ret;
 }

--- a/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
+++ b/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
@@ -181,11 +181,14 @@ lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms)
 }
 #endif
 
-void lt_port_log(const char *format, ...)
+int lt_port_log(const char *format, ...)
 {
     va_list args;
+    int ret;
 
     va_start(args, format);
-    vprintf(format, args);
+    ret = vprintf(format, args);
     va_end(args);
+
+    return ret;
 }

--- a/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.c
+++ b/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.c
@@ -149,11 +149,14 @@ lt_ret_t lt_port_delay(lt_l2_state_t *h, uint32_t ms)
     return LT_OK;
 }
 
-void lt_port_log(const char *format, ...)
+int lt_port_log(const char *format, ...)
 {
     va_list args;
+    int ret;
 
     va_start(args, format);
-    vprintf(format, args);
+    ret = vprintf(format, args);
     va_end(args);
+
+    return ret;
 }

--- a/include/libtropic_port.h
+++ b/include/libtropic_port.h
@@ -131,8 +131,11 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count);
  *
  * @param format      Pointer to a null-terminated byte string specifying how to interpret the data
  * @param ...         Arguments specifying data to print
+ *
+ * @return The number of characters printed (like printf), or a negative
+ *         value on encoding/printing error.
  */
-void lt_port_log(const char *format, ...);
+int lt_port_log(const char *format, ...);
 
 /** @} */  // end of group_port_functions
 


### PR DESCRIPTION
## Description

Changed `lt_port_log` signature. Mainly for compatibility with our print helpers.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage
