### PR TITLE
ETR01SDK-477: Tests: make local var for handle a pointer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ foreach(example_name ${LIBTROPIC_EXAMPLE_LIST})
     string(REPLACE " " "_" example_macro ${example_macro})
     string(APPEND LIBTROPIC_EXAMPLE_FUNCTIONS_CONTENT
         "#elif defined(${example_macro})\n"
-        "__lt_ex_return_val__ = ${example_name}(&__lt_handle__);\n"
+        "__lt_ex_return_val__ = ${example_name}(__lt_handle__);\n"
     )
 endforeach()
 
@@ -315,7 +315,7 @@ foreach(test_name ${LIBTROPIC_TEST_LIST})
     string(REPLACE " " "_" test_macro ${test_macro})
     string(APPEND LIBTROPIC_TEST_FUNCTIONS_CONTENT
         "#elif defined(${test_macro})\n"
-        "  ${test_name}(&__lt_handle__);\n"
+        "  ${test_name}(__lt_handle__);\n"
     )
 endforeach()
 

--- a/tropic01_model/main.c
+++ b/tropic01_model/main.c
@@ -50,17 +50,18 @@ int main(void)
     }
 #endif
 
-    lt_handle_t __lt_handle__ = {0};
+    lt_handle_t handle = {0};              // Local variable for the handle.
+    lt_handle_t *__lt_handle__ = &handle;  // Variable used by tests and examples template.
 #if LT_SEPARATE_L3_BUFF
     uint8_t l3_buffer[LT_SIZE_OF_L3_BUFF] __attribute__((aligned(16))) = {0};
-    __lt_handle__.l3.buff = l3_buffer;
-    __lt_handle__.l3.buff_len = sizeof(l3_buffer);
+    handle.l3.buff = l3_buffer;
+    handle.l3.buff_len = sizeof(l3_buffer);
 #endif
     // Initialize device before handing handle to the test.
     lt_dev_posix_tcp_t device;
     device.addr = inet_addr("127.0.0.1");
     device.port = 28992;
-    __lt_handle__.l2.device = &device;
+    handle.l2.device = &device;
 
     // Initialize crypto context.
 #if LT_USE_TREZOR_CRYPTO
@@ -69,7 +70,7 @@ int main(void)
     lt_ctx_mbedtls_v4_t
 #endif
         crypto_ctx;
-    __lt_handle__.l3.crypto_ctx = &crypto_ctx;
+    handle.l3.crypto_ctx = &crypto_ctx;
 
     // Generate seed for the PRNG.
     unsigned int prng_seed;


### PR DESCRIPTION
## Description

In ESP-IDF HAL, to not waste stack size, I use dynamic allocation in main.c. So I am forced to declare the variable for the handle as a pointer. But the Functional test call template (lt_test_registry_template.c.inc) is not compatible with passing a pointer.

The solution is to change the template and all main.c to declare the handle as a pointer.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---