### PR TITLE
ETR01SDK-489: Add lt_sha256_deinit function to CAL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Logging: `lt_port_log` function for platform-specific logging mechanism; is used by the logging macros declared in `libtropic_logging.h`.
+- CAL: `lt_sha256_deinit` function to deinitialize the SHA-256 context. It is called after the SHA-256 operation is finalized, so it must do an exhaustive cleanup.
 
 ### Fixed
 - `lt_print_bytes` function now returns `LT_PARAM_ERR` when incorrect parameters are passed instead of `LT_FAIL`.

--- a/cal/mbedtls_v4/lt_mbedtls_v4_sha256.c
+++ b/cal/mbedtls_v4/lt_mbedtls_v4_sha256.c
@@ -36,7 +36,6 @@ lt_ret_t lt_sha256_start(void *ctx)
     status = psa_hash_setup(&_ctx->sha256_ctx, PSA_ALG_SHA_256);
     if (status != PSA_SUCCESS) {
         LT_LOG_ERROR("SHA-256 setup failed, status=%" PRId32 " (psa_status_t)", status);
-        psa_hash_abort(&_ctx->sha256_ctx);
         return LT_CRYPTO_ERR;
     }
 
@@ -52,7 +51,6 @@ lt_ret_t lt_sha256_update(void *ctx, const uint8_t *input, const size_t input_le
     status = psa_hash_update(&_ctx->sha256_ctx, input, input_len);
     if (status != PSA_SUCCESS) {
         LT_LOG_ERROR("SHA-256 update failed, status=%" PRId32 " (psa_status_t)", status);
-        psa_hash_abort(&_ctx->sha256_ctx);
         return LT_CRYPTO_ERR;
     }
 
@@ -69,7 +67,20 @@ lt_ret_t lt_sha256_finish(void *ctx, uint8_t *output)
     status = psa_hash_finish(&_ctx->sha256_ctx, output, PSA_HASH_LENGTH(PSA_ALG_SHA_256), &hash_length);
     if (status != PSA_SUCCESS) {
         LT_LOG_ERROR("SHA-256 finish failed, status=%" PRId32 " (psa_status_t)", status);
-        psa_hash_abort(&_ctx->sha256_ctx);
+        return LT_CRYPTO_ERR;
+    }
+
+    return LT_OK;
+}
+
+lt_ret_t lt_sha256_deinit(void *ctx)
+{
+    lt_ctx_mbedtls_v4_t *_ctx = (lt_ctx_mbedtls_v4_t *)ctx;
+
+    // Abort the hash operation to free resources
+    psa_status_t status = psa_hash_abort(&_ctx->sha256_ctx);
+    if (status != PSA_SUCCESS) {
+        LT_LOG_ERROR("SHA-256 deinit failed, status=%" PRId32 " (psa_status_t)", status);
         return LT_CRYPTO_ERR;
     }
 

--- a/cal/trezor_crypto/lt_trezor_crypto_sha256.c
+++ b/cal/trezor_crypto/lt_trezor_crypto_sha256.c
@@ -11,7 +11,6 @@
 #include "hasher.h"
 #include "libtropic_common.h"
 #include "libtropic_trezor_crypto.h"
-#include "lt_secure_memzero.h"
 #include "lt_sha256.h"
 
 lt_ret_t lt_sha256_init(void *ctx)
@@ -43,5 +42,12 @@ lt_ret_t lt_sha256_finish(void *ctx, uint8_t *output)
     lt_ctx_trezor_crypto_t *_ctx = (lt_ctx_trezor_crypto_t *)ctx;
 
     hasher_Final(&_ctx->sha256_ctx, output);
+    return LT_OK;
+}
+
+lt_ret_t lt_sha256_deinit(void *ctx)
+{
+    // Nothing to do, hasher_Final (called by lt_sha256_finish) already cleans up the context.
+    LT_UNUSED(ctx);
     return LT_OK;
 }

--- a/src/lt_sha256.h
+++ b/src/lt_sha256.h
@@ -22,7 +22,7 @@ extern "C" {
 #define LT_SHA256_DIGEST_LENGTH 32
 
 /**
- * @brief Initializes SHA-256 context.
+ * @brief Initializes SHA-256 context. Call once before any other SHA-256 function.
  *
  * @param  ctx Hash context
  * @return LT_OK if success, otherwise returns other error code.
@@ -55,6 +55,16 @@ lt_ret_t lt_sha256_update(void *ctx, const uint8_t *input, const size_t input_le
  * @return LT_OK if success, otherwise returns other error code.
  */
 lt_ret_t lt_sha256_finish(void *ctx, uint8_t *output) __attribute__((warn_unused_result));
+
+/**
+ * @brief Deinitializes SHA-256 context. Call once after finishing SHA-256 operations.
+ * @warning This function has to be called even if any other SHA-256 function failed. If `lt_sha256_init`
+ * failed, calling this function is not necessary.
+ *
+ * @param  ctx Hash context
+ * @return LT_OK if success, otherwise returns other error code.
+ */
+lt_ret_t lt_sha256_deinit(void *ctx) __attribute__((warn_unused_result));
 
 #ifdef __cplusplus
 }

--- a/tropic01_model/main.c
+++ b/tropic01_model/main.c
@@ -7,6 +7,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 


### PR DESCRIPTION
## Description

Currently, we have `lt_sha256_init` function for initializing the SHA-256 context structure (CFP specific). However, we forgot to implement `lt_sha256_deinit` function to deinitialize the context.

In the case of Trezor crypto, there is no dedicated function to deinitialize the context - `hasher_Final` is used for ending the hashing and clean up.

In the case of MbedTLS, `psa_hash_abort` should be called in the proposed `lt_sha256_deinit` function. Currently, we only call it in the other functions on error. We can stop calling it on error and only call it in `lt_sha256_deinit`, which should be called by the caller on error or successful hash session.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [x] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---