### PR TITLE
ETR01SDK-319: Add mocking of L3 communication, add HARDWARE_FAIL test

### DIFF
--- a/docs/for_contributors/tests/functional_mock_tests.md
+++ b/docs/for_contributors/tests/functional_mock_tests.md
@@ -62,13 +62,13 @@ There are several helper functions to help you mock the Secure Session:
 
 As you can see, there are two functions for mocking replies. Normally, you have to use both. To understand why, you need to understand how the L3 communication works. For example, you will call `lt_ping`. Let's assume a small payload, so it'll fit into a single chunk. From a communication perspective, Libtropic will:
 
-1. Write a L2 Request with L3 Command as a payload. It will receive single `CHIP_STATUS` as a response.
+1. Write an L2 Request with L3 Command as a payload. It will receive single `CHIP_STATUS` as a response.
 2. Read a confirmation response (using `Get_Response`) to confirm that the chunk was received OK. It will receive a short frame with `STATUS=REQ_OK`.
 3. After confirmation that the chunk was received OK, Libtropic will send another `Get_Response` to get the L3 Result itself.
 
 Steps 1. and 2. are mocked using the `mock_l3_command_responses()`, step 3. using `mock_l3_result()`.
 
-!!! info "Chunking"
+!!! warning "Chunking"
     Commands with large payloads that do not fit into a single chunk are not supported yet, because chunking is not implemented in the mock HAL.
 
 ### Creating the Test

--- a/docs/for_contributors/tests/functional_mock_tests.md
+++ b/docs/for_contributors/tests/functional_mock_tests.md
@@ -47,6 +47,30 @@ Notes about lengths and CRC
 - Do not assume `sizeof()` matches the transmitted length — some reply structures are overlayed or have variable-length fields. Use the helper `calc_mocked_resp_len()` (found in the mock helpers) to produce correct mocked lengths including CRC.
 - The CRC bytes may not always sit in a named `crc` field in the C struct; if the data are shorter the CRC can appear earlier in the layout. Use the `add_resp_crc()` helper or compute the CRC manually when constructing the frame bytes.
 
+### Secure Session mocking
+We support mocking of Secure Session using several provided helper functions. There are two limitations to be aware of:
+
+- No handshake is actually done (between Libtropic and mock HAL), provided helper functions only set up internal state of Libtropic (state flags and encryption).
+- Command encryption key and result encryption key have to match. This is a simplification to be able to use existing CAL interface for both Libtropic and mock HAL purposes without a need to reinitialize AES contexts every time.
+
+There are several helper functions to help you mock the Secure Session:
+
+- `mock_session_start()`, which will start a mocked Secure Session,
+- `mock_l3_command_responses()` to mock reply to L3 Command (not the L3 Result yet, just confirmations),
+- `mock_l3_result()` to mock the L3 Result,
+- `mock_session_abort()` to abort mocked Secure Session.
+
+As you can see, there are two functions for mocking replies. Normally, you have to use both. To understand why, you need to understand how the L3 communication works. For example, you will call `lt_ping`. Let's assume a small payload, so it'll fit into a single chunk. From a communication perspective, Libtropic will:
+
+1. Write a L2 Request with L3 Command as a payload. It will receive single `CHIP_STATUS` as a response.
+2. Read a confirmation response (using `Get_Response`) to confirm that the chunk was received OK. It will receive a short frame with `STATUS=REQ_OK`.
+3. After confirmation that the chunk was received OK, Libtropic will send another `Get_Response` to get the L3 Result itself.
+
+Steps 1. and 2. are mocked using the `mock_l3_command_responses()`, step 3. using `mock_l3_result()`.
+
+!!! info "Chunking"
+    Commands with large payloads (which will not fit into a single chunk) are not supported yet, as chunking is not implemented in the mock HAL.
+
 ### Creating the Test
 To add a new test, do the following:
 
@@ -97,3 +121,6 @@ int lt_test_mock_my_test(lt_handle_t *h)
     return 0;
 }
 ```
+
+!!! info "Mock helpers usage"
+    Refer to already existing tests for examples on mock helpers usage.

--- a/docs/for_contributors/tests/functional_mock_tests.md
+++ b/docs/for_contributors/tests/functional_mock_tests.md
@@ -69,7 +69,7 @@ As you can see, there are two functions for mocking replies. Normally, you have 
 Steps 1. and 2. are mocked using the `mock_l3_command_responses()`, step 3. using `mock_l3_result()`.
 
 !!! info "Chunking"
-    Commands with large payloads (which will not fit into a single chunk) are not supported yet, as chunking is not implemented in the mock HAL.
+    Commands with large payloads that do not fit into a single chunk are not supported yet, because chunking is not implemented in the mock HAL.
 
 ### Creating the Test
 To add a new test, do the following:

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -117,6 +117,7 @@ target_include_directories(libtropic_functional_mock_tests_objs PUBLIC ${CMAKE_C
 set(LIBTROPIC_MOCK_TEST_LIST
     lt_test_mock_attrs
     lt_test_mock_invalid_in_crc
+    lt_test_mock_hardware_fail
 )
 
 ###########################################################################

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -119,7 +119,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
                         + TR01_L2_REQ_RSP_CRC_SIZE;
 
     if (packet_size > TR01_L2_CHUNK_MAX_DATA_SIZE) {
-        LT_LOG_ERROR("Payloads >%u b not supported due to chunking not implemented.", TR01_L2_CHUNK_MAX_DATA_SIZE);
+        LT_LOG_ERROR("Payloads >%u B not supported due to chunking not implemented.", TR01_L2_CHUNK_MAX_DATA_SIZE);
         return LT_PARAM_ERR;
     }
 

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -163,7 +163,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
     return LT_OK;
 }
 
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count)
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count)
 {
     if (chunk_count > 1) {
         LT_LOG_ERROR("Only single chunk supported now!");

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -77,8 +77,8 @@ lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_L
                             const uint8_t kres[TR01_AES256_KEY_LEN])
 {
     // Check if kcmd and kres are equal.
-    // This is needed so we can reuse AES-GCM functions currently provided by CAL and not having to reinitializace AES
-    // with swapped encryption and decryption keys everytime.
+    // This is needed so we can reuse AES-GCM functions currently provided by CAL and not having to reinitialize AES
+    // with swapped encryption and decryption keys every time.
     if (memcmp(kcmd, kres, TR01_AES256_KEY_LEN) != 0) {
         LT_LOG_ERROR("kcmd and kres has to match for L3 mocking to work (simplification).");
         return LT_PARAM_ERR;

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -189,7 +189,8 @@ lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count)
     ret = lt_mock_hal_enqueue_response(&h->l2, req_ok_frame, sizeof(req_ok_frame));
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to enqueue L3 Command response 2/2 (L2 Response)");
-    };
+        return ret;
+    }
 
     return LT_OK;
 }

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -18,6 +18,8 @@
 #include "lt_l1.h"
 #include "lt_l2_api_structs.h"
 #include "lt_l2_frame_check.h"
+#include "lt_l3_process.h"
+#include "lt_aesgcm.h"
 
 void add_resp_crc(void *resp_buf)
 {
@@ -67,6 +69,113 @@ lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4])
         != lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp, calc_mocked_resp_len(&get_info_resp))) {
         return LT_FAIL;
     }
+
+    return LT_OK;
+}
+
+lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_LEN], const uint8_t kres[TR01_AES256_KEY_LEN]) {
+    
+    // Check if kcmd and kres are equal.
+    // This is needed so we can reuse AES-GCM functions currently provided by CAL and not having to reinitializace AES
+    // with swapped encryption and decryption keys everytime.
+    if(memcmp(kcmd, kres, TR01_AES256_KEY_LEN) != 0) {
+        LT_LOG_ERROR("kcmd and kres has to match for L3 mocking to work (simplification).");
+        return LT_PARAM_ERR;
+    }
+
+    // Initialize IVs.
+    lt_l3_invalidate_host_session_data(&h->l3);
+
+    // Initialize AES-GCM with provided keys.
+    lt_ret_t ret = lt_aesgcm_encrypt_init(h->l3.crypto_ctx, kcmd, TR01_AES256_KEY_LEN);
+    if (ret != LT_OK) {
+        return LT_CRYPTO_ERR;
+    }
+    ret = lt_aesgcm_decrypt_init(h->l3.crypto_ctx, kres, TR01_AES256_KEY_LEN);
+    if (ret != LT_OK) {
+        return LT_CRYPTO_ERR;
+    }
+
+    // Mark session status as started.
+    h->l3.session_status = LT_SECURE_SESSION_ON;
+
+    return LT_OK;
+}
+
+lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const size_t result_plaintext_size)
+{
+    uint8_t l2_frame[TR01_L2_MAX_FRAME_SIZE];
+
+    size_t packet_size = TR01_L3_SIZE_SIZE + result_plaintext_size + TR01_L3_TAG_SIZE;
+    size_t frame_size = TR01_L1_CHIP_STATUS_SIZE + TR01_L2_STATUS_SIZE + TR01_L2_REQ_RSP_LEN_SIZE + packet_size + TR01_L2_REQ_RSP_CRC_SIZE;
+
+    if (packet_size > TR01_L2_CHUNK_MAX_DATA_SIZE) {
+        LT_LOG_ERROR("Payloads >%u b not supported due to chunking not implemented.", TR01_L2_CHUNK_MAX_DATA_SIZE);
+        return LT_PARAM_ERR;
+    }
+    
+    // This will happen only if the internal macros are implemented incorrectly.
+    if (frame_size > TR01_L2_MAX_FRAME_SIZE) {
+        LT_LOG_ERROR("Implementation error! Total frame size won't fit to the buffer.  Need at least: %zu", frame_size);
+        return LT_FAIL;
+    }
+
+    l2_frame[TR01_L2_CHIP_STATUS_OFFSET] = TR01_L1_CHIP_MODE_READY_bit;
+    l2_frame[TR01_L2_STATUS_OFFSET]      = TR01_L2_STATUS_RESULT_OK;
+    l2_frame[TR01_L2_RSP_LEN_OFFSET] = (uint8_t)packet_size;
+
+    l2_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET]     = result_plaintext_size;
+    l2_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET + 1] = 0x00;
+
+    lt_ret_t ret;
+    if (LT_OK != (ret = lt_aesgcm_encrypt(h->l3.crypto_ctx, h->l3.decryption_IV, TR01_L3_IV_SIZE, NULL, 0, result_plaintext, result_plaintext_size, &l2_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET + TR01_L3_SIZE_SIZE], result_plaintext_size + TR01_L3_TAG_SIZE))) {
+        LT_LOG_ERROR("Encryption failed! ret=%d", ret);
+        return ret;
+    }
+    
+    uint16_t crc = crc16(&l2_frame[TR01_L2_STATUS_OFFSET], TR01_L2_STATUS_SIZE + TR01_L2_REQ_RSP_LEN_SIZE + packet_size);
+    size_t crc_offset = TR01_L2_RSP_DATA_RSP_CRC_OFFSET + packet_size;
+    l2_frame[crc_offset] = crc >> 8;   
+    l2_frame[crc_offset + 1] = crc & 0x00FF;
+
+    lt_mock_hal_enqueue_response(&h->l2, l2_frame, frame_size);
+
+    return LT_OK;
+}
+
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count) {
+
+    if (chunk_count > 1) {
+        LT_LOG_ERROR("Only single chunk supported now!");
+        return LT_PARAM_ERR;
+    }
+
+    uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+    // Enqueue replies to L3 Command. There are actually two replies for each chunk sent:
+    //  - reply to writing the chunk (using Encrypted_Cmd_Req L2 Request) -> only CHIP_READY (as to other L2 Requests)
+    //  - reply to Get_Response -> L2 Response with status REQ_OK (last chunk) or REQ_CONT (not the last chunk)
+    lt_ret_t ret = lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready));
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to enqueue L3 Command response 1/2 (CHIP_READY).");
+        return ret;
+    }
+
+    uint8_t req_ok_frame[5] = {
+        TR01_L1_CHIP_MODE_READY_bit,
+        TR01_L2_STATUS_REQUEST_OK,
+        0x00, // Zero RSP length
+        0x00, // | Dummy CRC -- will be calculated later
+        0x00  // |
+    };
+
+    uint16_t crc = crc16(req_ok_frame + 1, 2);
+    req_ok_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET] = crc >> 8;
+    req_ok_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET + 1] = crc & 0x00FF;
+
+    ret = lt_mock_hal_enqueue_response(&h->l2, req_ok_frame, sizeof(req_ok_frame));
+    if(LT_OK != ret) {
+        LT_LOG_ERROR("Failed to enqueue L3 Command response 2/2 (L2 Response)");
+    };
 
     return LT_OK;
 }

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -145,7 +145,8 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
         LT_LOG_ERROR("Encryption failed! ret=%d", ret);
         return ret;
     }
-    // As the mock helpers share CAL interface with Libtropic (simplification), IV is handled in the Libtropic itself -> no need to increment here.
+    // As the mock helpers share CAL interface with Libtropic (simplification), IV is handled in the Libtropic itself ->
+    // no need to increment here.
 
     uint16_t crc
         = crc16(&l2_frame[TR01_L2_STATUS_OFFSET], TR01_L2_STATUS_SIZE + TR01_L2_REQ_RSP_LEN_SIZE + packet_size);

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -152,7 +152,11 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
     l2_frame[crc_offset] = crc >> 8;
     l2_frame[crc_offset + 1] = crc & 0x00FF;
 
-    lt_mock_hal_enqueue_response(&h->l2, l2_frame, frame_size);
+    ret = lt_mock_hal_enqueue_response(&h->l2, l2_frame, frame_size);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to enqueue response with L3 Result!");
+        return ret;
+    }
 
     return LT_OK;
 }

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -80,7 +80,7 @@ lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_L
     // This is needed so we can reuse AES-GCM functions currently provided by CAL and not having to reinitialize AES
     // with swapped encryption and decryption keys every time.
     if (memcmp(kcmd, kres, TR01_AES256_KEY_LEN) != 0) {
-        LT_LOG_ERROR("kcmd and kres has to match for L3 mocking to work (simplification).");
+        LT_LOG_ERROR("kcmd and kres have to match for L3 mocking to work (simplification).");
         return LT_PARAM_ERR;
     }
 

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -102,6 +102,13 @@ lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_L
     return LT_OK;
 }
 
+lt_ret_t mock_session_abort(lt_handle_t *h) {
+
+    lt_l3_invalidate_host_session_data(&h->l3);
+
+    return LT_OK;
+}
+
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const size_t result_plaintext_size)
 {
     uint8_t l2_frame[TR01_L2_MAX_FRAME_SIZE];

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -158,9 +158,6 @@ lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count) {
     }
 
     uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
-    // Enqueue replies to L3 Command. There are actually two replies for each chunk sent:
-    //  - reply to writing the chunk (using Encrypted_Cmd_Req L2 Request) -> only CHIP_READY (as to other L2 Requests)
-    //  - reply to Get_Response -> L2 Response with status REQ_OK (last chunk) or REQ_CONT (not the last chunk)
     lt_ret_t ret = lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready));
     if (LT_OK != ret) {
         LT_LOG_ERROR("Failed to enqueue L3 Command response 1/2 (CHIP_READY).");

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -125,7 +125,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
 
     // This will happen only if the internal macros are implemented incorrectly.
     if (frame_size > TR01_L2_MAX_FRAME_SIZE) {
-        LT_LOG_ERROR("Implementation error! Total frame size won't fit to the buffer.  Need at least: %zu", frame_size);
+        LT_LOG_ERROR("Implementation error! Total frame size won't fit to the buffer. Need at least: %zu", frame_size);
         return LT_FAIL;
     }
 

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -145,6 +145,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
         LT_LOG_ERROR("Encryption failed! ret=%d", ret);
         return ret;
     }
+    // As the mock helpers share CAL interface with Libtropic (simplification), IV is handled in the Libtropic itself -> no need to increment here.
 
     uint16_t crc
         = crc16(&l2_frame[TR01_L2_STATUS_OFFSET], TR01_L2_STATUS_SIZE + TR01_L2_REQ_RSP_LEN_SIZE + packet_size);

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -54,7 +54,7 @@ lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
  *
  * Prepares the provided handle for use in mocked TR01 operations, using the
  * supplied AES-256 keys for L3 Result encryption. This does not simulate
- * comunication of Secure Session handshake, just prepares the handle.
+ * communication of Secure Session handshake, just prepares the handle.
  *
  * On success, *h is initialized as if the Secure Session handshake occurred.
  *

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -110,7 +110,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
  *
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count);
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count);
 
 #ifdef __cplusplus
 }

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -54,8 +54,8 @@ lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
  *
  * Prepares the provided handle for use in mocked TR01 operations, using the
  * supplied AES-256 keys for L3 Result encryption. This does not simulate
- * comunication of Secure Session handshake, just prepares the handle. 
- * 
+ * comunication of Secure Session handshake, just prepares the handle.
+ *
  * On success, *h is initialized as if the Secure Session handshake occured.
  *
  * @param h
@@ -70,14 +70,15 @@ lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
  * @return
  *     LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
-lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_LEN], const uint8_t kres[TR01_AES256_KEY_LEN]);
+lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_LEN],
+                            const uint8_t kres[TR01_AES256_KEY_LEN]);
 
 /**
  * Abort mocked Secure Session.
- * 
+ *
  * Removes all data relevant to the Secure Session and modifies the handle
  * as if the lt_session_abort was called, but does not actually simulate any communication.
- * 
+ *
  * @param h
  *     Pointer to an lt_handle_t to be modified.
  *
@@ -88,28 +89,28 @@ lt_ret_t mock_session_abort(lt_handle_t *h);
 
 /**
  * Mock whole L2 Frame containing the L3 Result as a reply to any Libtropic's L3 Command.
- * 
+ *
  * You only need to provide plaintext part (RESULT field + any data if applicable). It will
  * be encrypted, tag will be added and inserted to an appropriate L2 Response frame.
- * 
+ *
  * @warning Currently only Results which fits to a single chunk are supported, as chunking
  * is not implemented yet.
- * 
+ *
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueing).
  * @param result_plaintext Plaintext of the L3 Result data to use.
  * @param result_plaintext_size Size of the result_plaintext.
- * 
+ *
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const size_t result_plaintext_size);
 
 /**
  * Mock replies to a L3 Command.
- * 
+ *
  * There are two types of replies from TROPIC01 to each L3 Command chunk:
  *   1. reply to writing the chunk (using Encrypted_Cmd_Req L2 Request) -> only CHIP_READY (as to other L2 Requests)
  *   2. reply to Get_Response -> L2 Response with status REQ_OK (last chunk) or REQ_CONT (not the last chunk)
- * 
+ *
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueing).
  * @param chunk_count Count of the L3 Result chunks.
  */

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -96,7 +96,7 @@ lt_ret_t mock_session_abort(lt_handle_t *h);
  * @warning Currently only Results which fits to a single chunk are supported, as chunking
  * is not implemented yet.
  *
- * @param h Pointer to an lt_handle_t to use (for encryption and enqueing).
+ * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
  * @param result_plaintext Plaintext of the L3 Result data to use.
  * @param result_plaintext_size Size of the result_plaintext.
  *

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -49,6 +49,12 @@ size_t calc_mocked_resp_len(const void *resp_buf);
  */
 lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
 
+lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_LEN], const uint8_t kres[TR01_AES256_KEY_LEN]);
+
+lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const size_t result_plaintext_size);
+
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -107,6 +107,8 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
  *
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
  * @param chunk_count Count of the L3 Command chunks. Only single chunk supported now.
+ *
+ * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
 lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count);
 

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -49,10 +49,70 @@ size_t calc_mocked_resp_len(const void *resp_buf);
  */
 lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
 
+/**
+ * Initialize and start a mocked Secure Session for functional mock tests.
+ *
+ * Prepares the provided handle for use in mocked TR01 operations, using the
+ * supplied AES-256 keys for L3 Result encryption. This does not simulate
+ * comunication of Secure Session handshake, just prepares the handle. 
+ * 
+ * On success, *h is initialized as if the Secure Session handshake occured.
+ *
+ * @param h
+ *     Pointer to an lt_handle_t that will be initialized. Must be non-NULL.
+ * @param kcmd
+ *     Buffer of TR01_AES256_KEY_LEN bytes containing the AES-256 key used for
+ *     command encryption. Must be equal to kres.
+ * @param kres
+ *     Buffer of TR01_AES256_KEY_LEN bytes containing the AES-256 key used for
+ *     response encryption. Must be equal to kcmd.
+ *
+ * @return
+ *     LT_OK on success, or an appropriate lt_ret_t error code on failure.
+ */
 lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_LEN], const uint8_t kres[TR01_AES256_KEY_LEN]);
 
+/**
+ * Abort mocked Secure Session.
+ * 
+ * Removes all data relevant to the Secure Session and modifies the handle
+ * as if the lt_session_abort was called, but does not actually simulate any communication.
+ * 
+ * @param h
+ *     Pointer to an lt_handle_t to be modified.
+ *
+ * @return
+ *     LT_OK on success, or an appropriate lt_ret_t error code on failure.
+ */
+lt_ret_t mock_session_abort(lt_handle_t *h);
+
+/**
+ * Mock whole L2 Frame containing the L3 Result as a reply to any Libtropic's L3 Command.
+ * 
+ * You only need to provide plaintext part (RESULT field + any data if applicable). It will
+ * be encrypted, tag will be added and inserted to an appropriate L2 Response frame.
+ * 
+ * @warning Currently only Results which fits to a single chunk are supported, as chunking
+ * is not implemented yet.
+ * 
+ * @param h Pointer to an lt_handle_t to use (for encryption and enqueing).
+ * @param result_plaintext Plaintext of the L3 Result data to use.
+ * @param result_plaintext_size Size of the result_plaintext.
+ * 
+ * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
+ */
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const size_t result_plaintext_size);
 
+/**
+ * Mock replies to a L3 Command.
+ * 
+ * There are two types of replies from TROPIC01 to each L3 Command chunk:
+ *   1. reply to writing the chunk (using Encrypted_Cmd_Req L2 Request) -> only CHIP_READY (as to other L2 Requests)
+ *   2. reply to Get_Response -> L2 Response with status REQ_OK (last chunk) or REQ_CONT (not the last chunk)
+ * 
+ * @param h Pointer to an lt_handle_t to use (for encryption and enqueing).
+ * @param chunk_count Count of the L3 Result chunks.
+ */
 lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count);
 
 #ifdef __cplusplus

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -111,7 +111,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
  *   1. reply to writing the chunk (using Encrypted_Cmd_Req L2 Request) -> only CHIP_READY (as to other L2 Requests)
  *   2. reply to Get_Response -> L2 Response with status REQ_OK (last chunk) or REQ_CONT (not the last chunk)
  *
- * @param h Pointer to an lt_handle_t to use (for encryption and enqueing).
+ * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
  * @param chunk_count Count of the L3 Result chunks.
  */
 lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count);

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -50,7 +50,7 @@ size_t calc_mocked_resp_len(const void *resp_buf);
 lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
 
 /**
- * Initialize and start a mocked Secure Session for functional mock tests.
+ * @brief Initialize and start a mocked Secure Session for functional mock tests.
  *
  * Prepares the provided handle for use in mocked TR01 operations, using the
  * supplied AES-256 keys for L3 Result encryption. This does not simulate
@@ -58,42 +58,36 @@ lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
  *
  * On success, *h is initialized as if the Secure Session handshake occurred.
  *
- * @param h
- *     Pointer to an lt_handle_t that will be initialized. Must be non-NULL.
- * @param kcmd
- *     Buffer of TR01_AES256_KEY_LEN bytes containing the AES-256 key used for
- *     command encryption. Must be equal to kres.
- * @param kres
- *     Buffer of TR01_AES256_KEY_LEN bytes containing the AES-256 key used for
- *     response encryption. Must be equal to kcmd.
+ * @param h Pointer to an lt_handle_t that will be initialized. Must be non-NULL.
+ * @param kcmd Buffer of TR01_AES256_KEY_LEN bytes containing the AES-256 key used for
+ *     command encryption. `kcmd` and `kres` must be equal.
+ * @param kres Buffer of TR01_AES256_KEY_LEN bytes containing the AES-256 key used for
+ *     response encryption. `kcmd` and `kres` must be equal.
  *
- * @return
- *     LT_OK on success, or an appropriate lt_ret_t error code on failure.
+ * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
 lt_ret_t mock_session_start(lt_handle_t *h, const uint8_t kcmd[TR01_AES256_KEY_LEN],
                             const uint8_t kres[TR01_AES256_KEY_LEN]);
 
 /**
- * Abort mocked Secure Session.
+ * @brief Abort mocked Secure Session.
  *
  * Removes all data relevant to the Secure Session and modifies the handle
  * as if the lt_session_abort was called, but does not actually simulate any communication.
  *
- * @param h
- *     Pointer to an lt_handle_t to be modified.
+ * @param h Pointer to an lt_handle_t to be modified.
  *
- * @return
- *     LT_OK on success, or an appropriate lt_ret_t error code on failure.
+ * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
 lt_ret_t mock_session_abort(lt_handle_t *h);
 
 /**
- * Mock whole L2 Frame containing the L3 Result as a reply to any Libtropic's L3 Command.
+ * @brief Mock whole L2 Frame containing the L3 Result as a reply to any Libtropic's L3 Command.
  *
  * You only need to provide plaintext part (RESULT field + any data if applicable). It will
  * be encrypted, tag will be added and inserted to an appropriate L2 Response frame.
  *
- * @warning Currently only Results which fits to a single chunk are supported, as chunking
+ * @warning Currently only Results that fit to a single chunk are supported, as chunking
  * is not implemented yet.
  *
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
@@ -105,7 +99,7 @@ lt_ret_t mock_session_abort(lt_handle_t *h);
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const size_t result_plaintext_size);
 
 /**
- * Mock replies to a L3 Command.
+ * @brief Mock replies to a L3 Command.
  *
  * There are two types of replies from TROPIC01 to each L3 Command chunk:
  *   1. reply to writing the chunk (using Encrypted_Cmd_Req L2 Request) -> only CHIP_READY (as to other L2 Requests)

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -56,7 +56,7 @@ lt_ret_t mock_init_communication(lt_handle_t *h, const uint8_t riscv_fw_ver[4]);
  * supplied AES-256 keys for L3 Result encryption. This does not simulate
  * comunication of Secure Session handshake, just prepares the handle.
  *
- * On success, *h is initialized as if the Secure Session handshake occured.
+ * On success, *h is initialized as if the Secure Session handshake occurred.
  *
  * @param h
  *     Pointer to an lt_handle_t that will be initialized. Must be non-NULL.

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -106,7 +106,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext, const s
  *   2. reply to Get_Response -> L2 Response with status REQ_OK (last chunk) or REQ_CONT (not the last chunk)
  *
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
- * @param chunk_count Count of the L3 Result chunks.
+ * @param chunk_count Count of the L3 Command chunks. Only single chunk supported now.
  */
 lt_ret_t mock_l3_command_responses(lt_handle_t *h, size_t chunk_count);
 

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -45,6 +45,20 @@ int lt_test_mock_attrs(lt_handle_t *h);
  */
 int lt_test_mock_invalid_in_crc(lt_handle_t *h);
 
+/**
+ * @brief Test for handling HARDWARE_FAIL return code.
+ * 
+ * Test steps:
+ * 1. Mock Secure Session initialization.
+ * 2. For each of Pairing_Key_Write, Pairing_Key_Invalidate, R_Config_Write, I_Config_Write, R_Mem_Data_Write:
+ *   a. Mock L3 Result with RESULT=HARDWARE_FAIL.
+ *   b. Call Libtropic function corresponding to the L3 Command and verify that Libtropic returns LT_L3_HARDWARE_FAIL. 
+ * 3. Mock Secure Session deinitialization.
+ * 
+ * @param h Handle for communication with TROPIC01
+ * 
+ * @return 0 on success, non-zero on failure.
+ */
 int lt_test_mock_hardware_fail(lt_handle_t *h);
 
 #ifdef __cplusplus

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -45,6 +45,8 @@ int lt_test_mock_attrs(lt_handle_t *h);
  */
 int lt_test_mock_invalid_in_crc(lt_handle_t *h);
 
+int lt_test_mock_hardware_fail(lt_handle_t *h);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -43,14 +43,14 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h);
 
 /**
  * @brief Test for handling HARDWARE_FAIL return code.
- * 
+ *
  * Test steps:
  * 1. Mock Secure Session initialization.
  * 2. For each of Pairing_Key_Write, Pairing_Key_Invalidate, R_Config_Write, I_Config_Write, R_Mem_Data_Write:
  *   a. Mock L3 Result with RESULT=HARDWARE_FAIL.
- *   b. Call Libtropic function corresponding to the L3 Command and verify that Libtropic returns LT_L3_HARDWARE_FAIL. 
+ *   b. Call Libtropic function corresponding to the L3 Command and verify that Libtropic returns LT_L3_HARDWARE_FAIL.
  * 3. Mock Secure Session deinitialization.
- * 
+ *
  * @param h Handle for communication with TROPIC01
  */
 void lt_test_mock_hardware_fail(lt_handle_t *h);

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -26,10 +26,8 @@ extern "C" {
  *   4. Deinitialize libtropic handle.
  *
  * @param h Handle for communication with TROPIC01
- *
- * @return 0 on success, non-zero on failure.
  */
-int lt_test_mock_attrs(lt_handle_t *h);
+void lt_test_mock_attrs(lt_handle_t *h);
 
 /**
  * @brief Test for handling invalid CRC in TROPIC01 responses.
@@ -40,10 +38,8 @@ int lt_test_mock_attrs(lt_handle_t *h);
  *  3. Verify that Libtropic correctly identifies the invalid CRC and returns an error.
  *
  * @param h Handle for communication with TROPIC01
- *
- * @return 0 on success, non-zero on failure.
  */
-int lt_test_mock_invalid_in_crc(lt_handle_t *h);
+void lt_test_mock_invalid_in_crc(lt_handle_t *h);
 
 /**
  * @brief Test for handling HARDWARE_FAIL return code.
@@ -56,10 +52,8 @@ int lt_test_mock_invalid_in_crc(lt_handle_t *h);
  * 3. Mock Secure Session deinitialization.
  * 
  * @param h Handle for communication with TROPIC01
- * 
- * @return 0 on success, non-zero on failure.
  */
-int lt_test_mock_hardware_fail(lt_handle_t *h);
+void lt_test_mock_hardware_fail(lt_handle_t *h);
 
 #ifdef __cplusplus
 }

--- a/tests/functional_mock/lt_test_mock_attrs.c
+++ b/tests/functional_mock/lt_test_mock_attrs.c
@@ -58,6 +58,6 @@ void lt_test_mock_attrs(lt_handle_t *h)
         }
 
         LT_LOG_INFO("Deinitializing handle");
-        LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));
+        LT_TEST_ASSERT(LT_OK, lt_deinit(h));
     }
 }

--- a/tests/functional_mock/lt_test_mock_attrs.c
+++ b/tests/functional_mock/lt_test_mock_attrs.c
@@ -25,7 +25,7 @@
 #include "lt_mock_helpers.h"
 #include "lt_test_common.h"
 
-int lt_test_mock_attrs(lt_handle_t *h)
+void lt_test_mock_attrs(lt_handle_t *h)
 {
     LT_LOG_INFO("----------------------------------------------");
     LT_LOG_INFO("lt_test_mock_attrs()");
@@ -60,6 +60,4 @@ int lt_test_mock_attrs(lt_handle_t *h)
         LT_LOG_INFO("Deinitializing handle");
         LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));
     }
-
-    return 0;
 }

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -47,6 +47,8 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
     memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
     mock_session_start(h, kcmd, kres);
 
+    // ----------------------------------------------------------------------------------------------------------
+
     LT_LOG_INFO("Mocking HARDWARE_FAIL in Pairing_Key_Write reply...");
     uint8_t dummy_key[4];
     for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++){
@@ -64,6 +66,8 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_write(h, dummy_key, slot));
     }
 
+    // ----------------------------------------------------------------------------------------------------------
+
     LT_LOG_INFO("Mocking HARDWARE_FAIL in Pairing_Key_Invalidate reply...");
     for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++){
         LT_LOG_INFO("Mocking for slot %d...", slot);
@@ -75,10 +79,55 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
             TR01_L3_RESULT_HARDWARE_FAIL,
         };
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_invalidate_plaintext, sizeof(pairing_key_invalidate_plaintext)));
-
-        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, dummy_key, sizeof(dummy_key)));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_invalidate(h, slot));
     }
+
+    // ----------------------------------------------------------------------------------------------------------
+
+    LT_LOG_INFO("Mocking HARDWARE_FAIL in R_Config_Write reply...");
+    // Mock replies to the command.
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+
+    // Mock command result itself.
+    uint8_t r_config_write_plaintext[] = {
+        TR01_L3_RESULT_HARDWARE_FAIL,
+    };
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, r_config_write_plaintext, sizeof(r_config_write_plaintext)));
+    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_r_config_write(h, TR01_CFG_START_UP_ADDR, 0x00)); // Dummy object
+
+    // ----------------------------------------------------------------------------------------------------------
+
+    LT_LOG_INFO("Mocking HARDWARE_FAIL in I_Config_Write reply...");
+    // Mock replies to the command.
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+
+    // Mock command result itself.
+    uint8_t i_config_write_plaintext[] = {
+        TR01_L3_RESULT_HARDWARE_FAIL,
+    };
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, i_config_write_plaintext, sizeof(i_config_write_plaintext)));
+    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_i_config_write(h, TR01_CFG_START_UP_ADDR, 0x00)); // Dummy object
+
+    // ----------------------------------------------------------------------------------------------------------
+
+    LT_LOG_INFO("Mocking HARDWARE_FAIL in R_Mem_Data_Write reply...");
+    // Mock replies to the command.
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+
+    // Mock command result itself.
+    uint8_t r_mem_data_write_plaintext[] = {
+        TR01_L3_RESULT_HARDWARE_FAIL,
+    };
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, r_mem_data_write_plaintext, sizeof(r_mem_data_write_plaintext)));
+
+    uint16_t random_r_mem_slot;
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_r_mem_slot, sizeof(random_r_mem_slot)));
+    random_r_mem_slot %= TR01_R_MEM_DATA_SLOT_MAX + 1;
+    uint8_t random_r_mem_data[16]; // Arbitrary size. Exact number not important, we just need some dummy data.
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, random_r_mem_data, sizeof(random_r_mem_data)));
+    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_r_mem_data_write(h, random_r_mem_slot, random_r_mem_data, sizeof(random_r_mem_data)));
+
+    // ----------------------------------------------------------------------------------------------------------
 
     LT_LOG_INFO("Deinitializing handle");
     LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -1,0 +1,87 @@
+/**
+ * @file lt_test_mock_hardware_fail.c
+ * @brief Test HARDWARE_FAIL L3 Result handling.
+ * @copyright Copyright (c) 2020-2025 Tropic Square s.r.o.
+ *
+ * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "libtropic.h"
+#include "libtropic_common.h"
+#include "libtropic_functional_tests.h"
+#include "libtropic_l2.h"
+#include "libtropic_logging.h"
+#include "libtropic_macros.h"
+#include "libtropic_port_mock.h"
+#include "lt_crc16.h"
+#include "lt_functional_mock_tests.h"
+#include "lt_l1.h"
+#include "lt_l2_api_structs.h"
+#include "lt_l2_frame_check.h"
+#include "lt_mock_helpers.h"
+#include "lt_test_common.h"
+#include "lt_port_wrap.h"
+#include "lt_l3_process.h"
+
+int lt_test_mock_hardware_fail(lt_handle_t *h)
+{
+    LT_LOG_INFO("----------------------------------------------");
+    LT_LOG_INFO("lt_test_mock_hardware_fail()");
+    LT_LOG_INFO("----------------------------------------------");
+
+    lt_mock_hal_reset(&h->l2);
+    LT_LOG_INFO("Mocking initialization...");
+    LT_TEST_ASSERT(LT_OK, mock_init_communication(h, (uint8_t[]){0x00, 0x00, 0x00, 0x02}));
+
+    LT_LOG_INFO("Initializing handle");
+    LT_TEST_ASSERT(LT_OK, lt_init(h));
+
+    LT_LOG_INFO("Setting up session...");
+    uint8_t kcmd[TR01_AES256_KEY_LEN];
+    uint8_t kres[TR01_AES256_KEY_LEN];
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, kcmd, sizeof(kcmd)));
+    memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
+    mock_session_start(h, kcmd, kres);
+
+    LT_LOG_INFO("Mocking HARDWARE_FAIL in Pairing_Key_Write reply...");
+    uint8_t dummy_key[4];
+    for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++){
+        LT_LOG_INFO("Mocking for slot %d...", slot);
+        // Mock replies to the command.
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+
+        // Mock command result itself.
+        uint8_t pairing_key_write_plaintext[] = {
+            TR01_L3_RESULT_HARDWARE_FAIL,
+        };
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_write_plaintext, sizeof(pairing_key_write_plaintext)));
+
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, dummy_key, sizeof(dummy_key)));
+        LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_write(h, dummy_key, slot));
+    }
+
+    LT_LOG_INFO("Mocking HARDWARE_FAIL in Pairing_Key_Invalidate reply...");
+    for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++){
+        LT_LOG_INFO("Mocking for slot %d...", slot);
+        // Mock replies to the command.
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+
+        // Mock command result itself.
+        uint8_t pairing_key_invalidate_plaintext[] = {
+            TR01_L3_RESULT_HARDWARE_FAIL,
+        };
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_invalidate_plaintext, sizeof(pairing_key_invalidate_plaintext)));
+
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, dummy_key, sizeof(dummy_key)));
+        LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_invalidate(h, slot));
+    }
+
+    LT_LOG_INFO("Deinitializing handle");
+    LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));
+    
+    return 0;
+}

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -22,10 +22,10 @@
 #include "lt_l1.h"
 #include "lt_l2_api_structs.h"
 #include "lt_l2_frame_check.h"
-#include "lt_mock_helpers.h"
-#include "lt_test_common.h"
-#include "lt_port_wrap.h"
 #include "lt_l3_process.h"
+#include "lt_mock_helpers.h"
+#include "lt_port_wrap.h"
+#include "lt_test_common.h"
 
 int lt_test_mock_hardware_fail(lt_handle_t *h)
 {
@@ -51,7 +51,7 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in Pairing_Key_Write reply...");
     uint8_t dummy_key[TR01_SHIPUB_LEN];
-    for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++){
+    for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++) {
         LT_LOG_INFO("Mocking for slot %d...", slot);
         // Mock replies to the command.
         LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
@@ -69,7 +69,7 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
     // ----------------------------------------------------------------------------------------------------------
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in Pairing_Key_Invalidate reply...");
-    for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++){
+    for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++) {
         LT_LOG_INFO("Mocking for slot %d...", slot);
         // Mock replies to the command.
         LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
@@ -78,7 +78,8 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
         uint8_t pairing_key_invalidate_plaintext[] = {
             TR01_L3_RESULT_HARDWARE_FAIL,
         };
-        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_invalidate_plaintext, sizeof(pairing_key_invalidate_plaintext)));
+        LT_TEST_ASSERT(LT_OK,
+                       mock_l3_result(h, pairing_key_invalidate_plaintext, sizeof(pairing_key_invalidate_plaintext)));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_invalidate(h, slot));
     }
 
@@ -93,7 +94,7 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, r_config_write_plaintext, sizeof(r_config_write_plaintext)));
-    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_r_config_write(h, TR01_CFG_START_UP_ADDR, 0x00)); // Dummy object
+    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_r_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
     // ----------------------------------------------------------------------------------------------------------
 
@@ -106,7 +107,7 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, i_config_write_plaintext, sizeof(i_config_write_plaintext)));
-    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_i_config_write(h, TR01_CFG_START_UP_ADDR, 0x00)); // Dummy object
+    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_i_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
     // ----------------------------------------------------------------------------------------------------------
 
@@ -123,9 +124,10 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
     uint16_t random_r_mem_slot;
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_r_mem_slot, sizeof(random_r_mem_slot)));
     random_r_mem_slot %= TR01_R_MEM_DATA_SLOT_MAX + 1;
-    uint8_t random_r_mem_data[16]; // Arbitrary size. Exact number not important, we just need some dummy data.
+    uint8_t random_r_mem_data[16];  // Arbitrary size. Exact number not important, we just need some dummy data.
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, random_r_mem_data, sizeof(random_r_mem_data)));
-    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_r_mem_data_write(h, random_r_mem_slot, random_r_mem_data, sizeof(random_r_mem_data)));
+    LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL,
+                   lt_r_mem_data_write(h, random_r_mem_slot, random_r_mem_data, sizeof(random_r_mem_data)));
 
     // ----------------------------------------------------------------------------------------------------------
 
@@ -134,6 +136,6 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Deinitializing handle");
     LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));
-    
+
     return 0;
 }

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -135,5 +135,5 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     LT_TEST_ASSERT(LT_OK, mock_session_abort(h));
 
     LT_LOG_INFO("Deinitializing handle");
-    LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));
+    LT_TEST_ASSERT(LT_OK, lt_deinit(h));
 }

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -45,7 +45,7 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
     uint8_t kres[TR01_AES256_KEY_LEN];
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, kcmd, sizeof(kcmd)));
     memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
-    mock_session_start(h, kcmd, kres);
+    LT_TEST_ASSERT(LT_OK, mock_session_start(h, kcmd, kres));
 
     // ----------------------------------------------------------------------------------------------------------
 

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -131,7 +131,7 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
 
     // ----------------------------------------------------------------------------------------------------------
 
-    LT_LOG_INFO("Terminating the Secure Sesion...");
+    LT_LOG_INFO("Terminating the Secure Session...");
     LT_TEST_ASSERT(LT_OK, mock_session_abort(h));
 
     LT_LOG_INFO("Deinitializing handle");

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -27,7 +27,7 @@
 #include "lt_port_wrap.h"
 #include "lt_test_common.h"
 
-int lt_test_mock_hardware_fail(lt_handle_t *h)
+void lt_test_mock_hardware_fail(lt_handle_t *h)
 {
     LT_LOG_INFO("----------------------------------------------");
     LT_LOG_INFO("lt_test_mock_hardware_fail()");
@@ -136,6 +136,4 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Deinitializing handle");
     LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));
-
-    return 0;
 }

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -50,7 +50,7 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
     // ----------------------------------------------------------------------------------------------------------
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in Pairing_Key_Write reply...");
-    uint8_t dummy_key[4];
+    uint8_t dummy_key[TR01_SHIPUB_LEN];
     for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++){
         LT_LOG_INFO("Mocking for slot %d...", slot);
         // Mock replies to the command.

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -129,6 +129,9 @@ int lt_test_mock_hardware_fail(lt_handle_t *h)
 
     // ----------------------------------------------------------------------------------------------------------
 
+    LT_LOG_INFO("Terminating the Secure Sesion...");
+    LT_TEST_ASSERT(LT_OK, mock_session_abort(h));
+
     LT_LOG_INFO("Deinitializing handle");
     LT_TEST_ASSERT(LT_OK, lt_deinit((lt_handle_t *)h));
     

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -17,7 +17,7 @@
 #include "lt_mock_helpers.h"
 #include "lt_test_common.h"
 
-int lt_test_mock_invalid_in_crc(lt_handle_t *h)
+void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 {
     LT_LOG_INFO("----------------------------------------------");
     LT_LOG_INFO("lt_test_mock_invalid_in_crc()");
@@ -47,6 +47,4 @@ int lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
     LT_LOG_INFO("Deinitializing handle");
     LT_TEST_ASSERT(LT_OK, lt_deinit(h));
-
-    return 0;
 }

--- a/tests/functional_mock/main.c.in
+++ b/tests/functional_mock/main.c.in
@@ -21,8 +21,6 @@
 
 int main(void)
 {
-    int ret = 0;
-
     // Disable buffering on stdout/stderr to simplify CI logs.
     LT_UNUSED(setvbuf(stdout, NULL, _IONBF, 0));
     LT_UNUSED(setvbuf(stderr, NULL, _IONBF, 0));
@@ -55,14 +53,11 @@ int main(void)
     LT_LOG_INFO("PRNG initialized with seed=%u", prng_seed);
 
     // Call the test function (each test will call lt_init() itself).
-    ret = @LIBTROPIC_MOCK_TEST_FUNCTION@(&__lt_handle__);
+    @LIBTROPIC_MOCK_TEST_FUNCTION@(&__lt_handle__);
 
     mbedtls_psa_crypto_free();
 
-    if (!ret) {
-        LT_LOG_INFO("Test successful!");
-    } else {
-        LT_LOG_ERROR("Test unsuccessful!");
-    }
-    return ret;
+    LT_LOG_INFO("Test finished!");
+
+    return 0;
 }


### PR DESCRIPTION
## Description

This PR adds several functions for mocking L3 communication and a HARDWARE_FAIL return code test which utilizes new L3 mocking functionality.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [x] Other (please describe): Update of functional mock tests

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage