### PR TITLE
ETR01SDK-385: Remove unused buffers for tag in lt_l3_api_structs.h

### DIFF
--- a/src/lt_l3_api_structs.h
+++ b/src/lt_l3_api_structs.h
@@ -49,7 +49,6 @@ struct lt_l3_ping_cmd_t {
      * The input data
      */
     uint8_t data_in[4096]; /**< Data in */
-    uint8_t tag[16];       /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -59,8 +58,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_ping_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_ping_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_ping_cmd_t, data_in) +
-        LT_MEMBER_SIZE(struct lt_l3_ping_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ping_cmd_t, data_in)
     )
 )
 /** \endcond */
@@ -78,7 +76,6 @@ struct lt_l3_ping_res_t {
      * The output data (loopback of the DATA_IN L3 Field).
      */
     uint8_t data_out[4096]; /**< Data out */
-    uint8_t tag[16];        /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -88,8 +85,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_ping_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_ping_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_ping_res_t, data_out) +
-        LT_MEMBER_SIZE(struct lt_l3_ping_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ping_res_t, data_out)
     )
 )
 /** \endcond */
@@ -128,7 +124,6 @@ struct lt_l3_pairing_key_write_cmd_t {
      * The X25519 public key to be written in the Pairing Key slot specified in the SLOT field.
      */
     uint8_t s_hipub[32]; /**< Public Key */
-    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -140,8 +135,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_cmd_t, slot) +
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_cmd_t, s_hipub) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_cmd_t, s_hipub)
     )
 )
 /** \endcond */
@@ -154,7 +148,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_pairing_key_write_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -163,8 +156,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_pairing_key_write_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_pairing_key_write_res_t, result)
     )
 )
 /** \endcond */
@@ -192,8 +184,7 @@ struct lt_l3_pairing_key_read_cmd_t {
      * @brief
      * The Pairing Key slot. Valid values are 0 - 3.
      */
-    uint16_t slot;   /**< Slot to Read */
-    uint8_t tag[16]; /**< L3 tag */
+    uint16_t slot; /**< Slot to Read */
 } __attribute__((packed));
 
 // clang-format off
@@ -203,8 +194,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_cmd_t, slot) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_cmd_t, slot)
     )
 )
 /** \endcond */
@@ -227,7 +217,6 @@ struct lt_l3_pairing_key_read_res_t {
      * The X25519 public key to be written in the Pairing Key slot specified in the SLOT field.
      */
     uint8_t s_hipub[32]; /**< Public Key */
-    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -238,8 +227,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_res_t, s_hipub) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_pairing_key_read_res_t, s_hipub)
     )
 )
 /** \endcond */
@@ -267,8 +255,7 @@ struct lt_l3_pairing_key_invalidate_cmd_t {
      * @brief
      * The Pairing Key slot. Valid values are 0 - 3.
      */
-    uint16_t slot;   /**< Slot to Invalidate */
-    uint8_t tag[16]; /**< L3 tag */
+    uint16_t slot; /**< Slot to Invalidate */
 } __attribute__((packed));
 
 // clang-format off
@@ -278,8 +265,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_cmd_t, slot) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_cmd_t, slot)
     )
 )
 /** \endcond */
@@ -292,7 +278,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_pairing_key_invalidate_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -301,8 +286,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_pairing_key_invalidate_res_t) == 
     (
         LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_pairing_key_invalidate_res_t, result)
     )
 )
 /** \endcond */
@@ -339,8 +323,7 @@ struct lt_l3_r_config_write_cmd_t {
      * @brief
      * The CO value to write in the computed address.
      */
-    uint32_t value;  /**< Configuration object value */
-    uint8_t tag[16]; /**< L3 tag */
+    uint32_t value; /**< Configuration object value */
 } __attribute__((packed));
 
 // clang-format off
@@ -352,8 +335,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_r_config_write_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_r_config_write_cmd_t, address) +
         LT_MEMBER_SIZE(struct lt_l3_r_config_write_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_write_cmd_t, value) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_write_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_config_write_cmd_t, value)
     )
 )
 /** \endcond */
@@ -366,7 +348,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_r_config_write_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -375,8 +356,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_r_config_write_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_r_config_write_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_write_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_write_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_config_write_res_t, result)
     )
 )
 /** \endcond */
@@ -404,7 +384,6 @@ struct lt_l3_r_config_read_cmd_t {
      * The CO address offset for TROPIC01 to compute the actual CO address.
      */
     uint16_t address; /**< Configuration object address */
-    uint8_t tag[16];  /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -414,8 +393,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_r_config_read_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_r_config_read_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_read_cmd_t, address) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_read_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_config_read_cmd_t, address)
     )
 )
 /** \endcond */
@@ -437,8 +415,7 @@ struct lt_l3_r_config_read_res_t {
      * @brief
      * The CO value TROPIC01 read from the computed address.
      */
-    uint32_t value;  /**< Configuration object value */
-    uint8_t tag[16]; /**< L3 tag */
+    uint32_t value; /**< Configuration object value */
 } __attribute__((packed));
 
 // clang-format off
@@ -449,8 +426,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_r_config_read_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_r_config_read_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_r_config_read_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_read_res_t, value) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_read_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_config_read_res_t, value)
     )
 )
 /** \endcond */
@@ -473,7 +449,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_r_config_erase_cmd_t {
     uint16_t cmd_size; /**< L3 command size */
     uint8_t cmd_id;    /**< Command Identifier */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -482,8 +457,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_r_config_erase_cmd_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_r_config_erase_cmd_t, cmd_size) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_erase_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_erase_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_config_erase_cmd_t, cmd_id)
     )
 )
 /** \endcond */
@@ -496,7 +470,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_r_config_erase_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -505,8 +478,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_r_config_erase_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_r_config_erase_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_erase_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_r_config_erase_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_config_erase_res_t, result)
     )
 )
 /** \endcond */
@@ -539,7 +511,6 @@ struct lt_l3_i_config_write_cmd_t {
      * The bit to write from 1 to 0. Valid values are 0-31.
      */
     uint8_t bit_index; /**< Bit to write. */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -550,8 +521,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_i_config_write_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_i_config_write_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_i_config_write_cmd_t, address) + 
-        LT_MEMBER_SIZE(struct lt_l3_i_config_write_cmd_t, bit_index) + 
-        LT_MEMBER_SIZE(struct lt_l3_i_config_write_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_i_config_write_cmd_t, bit_index)
     )
 )
 /** \endcond */
@@ -564,7 +534,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_i_config_write_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -573,8 +542,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_i_config_write_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_i_config_write_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_i_config_write_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_i_config_write_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_i_config_write_res_t, result)
     )
 )
 /** \endcond */
@@ -602,7 +570,6 @@ struct lt_l3_i_config_read_cmd_t {
      * The CO address offset for TROPIC01 to compute the actual CO address.
      */
     uint16_t address; /**< Configuration object address */
-    uint8_t tag[16];  /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -612,8 +579,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_i_config_read_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_i_config_read_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_i_config_read_cmd_t, address) +
-        LT_MEMBER_SIZE(struct lt_l3_i_config_read_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_i_config_read_cmd_t, address)
     )
 )
 /** \endcond */
@@ -635,8 +601,7 @@ struct lt_l3_i_config_read_res_t {
      * @brief
      * The CO value TROPIC01 read from the computed address.
      */
-    uint32_t value;  /**< Configuration object value */
-    uint8_t tag[16]; /**< L3 tag */
+    uint32_t value; /**< Configuration object value */
 } __attribute__((packed));
 
 // clang-format off
@@ -647,8 +612,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_i_config_read_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_i_config_read_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_i_config_read_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_i_config_read_res_t, value) +
-        LT_MEMBER_SIZE(struct lt_l3_i_config_read_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_i_config_read_res_t, value)
     )
 )
 /** \endcond */
@@ -687,7 +651,6 @@ struct lt_l3_r_mem_data_write_cmd_t {
      * @note The size is given by the maximal possible slot size across all Application FWs.
      */
     uint8_t data[475]; /**< Data to write */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -699,8 +662,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_cmd_t, udata_slot) +
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_cmd_t, data) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_cmd_t, data)
     )
 )
 /** \endcond */
@@ -713,7 +675,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_r_mem_data_write_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -722,8 +683,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_r_mem_data_write_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_write_res_t, result)
     )
 )
 /** \endcond */
@@ -751,7 +711,6 @@ struct lt_l3_r_mem_data_read_cmd_t {
      * The slot of the User Data partition. Valid values are 0 - 511.
      */
     uint16_t udata_slot; /**< Slot to read */
-    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -761,8 +720,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_cmd_t, udata_slot) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_cmd_t, udata_slot)
     )
 )
 /** \endcond */
@@ -785,7 +743,6 @@ struct lt_l3_r_mem_data_read_res_t {
      * The data stream read from the slot specified in the UDATA_SLOT L3 field.
      */
     uint8_t data[444]; /**< Data to read */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -796,8 +753,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_res_t, data) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_read_res_t, data)
     )
 )
 /** \endcond */
@@ -826,7 +782,6 @@ struct lt_l3_r_mem_data_erase_cmd_t {
      * The slot of the User Data partition. Valid values are 0 - 511.
      */
     uint16_t udata_slot; /**< Slot to erase */
-    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -836,8 +791,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_cmd_t, udata_slot) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_cmd_t, udata_slot)
     )
 )
 /** \endcond */
@@ -850,7 +804,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_r_mem_data_erase_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -859,8 +812,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_r_mem_data_erase_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_r_mem_data_erase_res_t, result)
     )
 )
 /** \endcond */
@@ -891,7 +843,6 @@ struct lt_l3_random_value_get_cmd_t {
      * The number of random bytes to get.
      */
     uint8_t n_bytes; /**< Number of bytes to get. */
-    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -901,8 +852,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_random_value_get_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_random_value_get_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_random_value_get_cmd_t, n_bytes) +
-        LT_MEMBER_SIZE(struct lt_l3_random_value_get_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_random_value_get_cmd_t, n_bytes)
     )
 )
 /** \endcond */
@@ -925,7 +875,6 @@ struct lt_l3_random_value_get_res_t {
      * The random data from TRNG2 in the number of bytes specified in the N_BYTES L3 Field.
      */
     uint8_t random_data[255]; /**< Random data */
-    uint8_t tag[16];          /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -936,8 +885,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_random_value_get_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_random_value_get_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_random_value_get_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_random_value_get_res_t, random_data) +
-        LT_MEMBER_SIZE(struct lt_l3_random_value_get_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_random_value_get_res_t, random_data)
     )
 )
 /** \endcond */
@@ -974,8 +922,7 @@ struct lt_l3_ecc_key_generate_cmd_t {
      * @brief
      * The Elliptic Curve the key is generated from.
      */
-    uint8_t curve;   /**< Elliptic Curve */
-    uint8_t tag[16]; /**< L3 tag */
+    uint8_t curve; /**< Elliptic Curve */
 } __attribute__((packed));
 
 // clang-format off
@@ -986,8 +933,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_cmd_t, slot) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_cmd_t, curve) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_cmd_t, curve)
     )
 )
 /** \endcond */
@@ -1000,7 +946,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_ecc_key_generate_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1009,8 +954,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_ecc_key_generate_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_generate_res_t, result)
     )
 )
 /** \endcond */
@@ -1057,7 +1001,6 @@ struct lt_l3_ecc_key_store_cmd_t {
      * The ECC Key to store. The key must be a member of the field given by the curve specified in the CURVE L3 Field.
      */
     uint8_t k[32];   /**< Key to store */
-    uint8_t tag[16]; /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1070,8 +1013,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_cmd_t, slot) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_cmd_t, curve) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_cmd_t, k) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_cmd_t, k)
     )
 )
 /** \endcond */
@@ -1084,7 +1026,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_ecc_key_store_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1093,8 +1034,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_ecc_key_store_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_store_res_t, result)
     )
 )
 /** \endcond */
@@ -1132,8 +1072,7 @@ struct lt_l3_ecc_key_read_cmd_t {
      * @brief
      * The slot to read the public ECC Key from. Valid values are 0 - 31.
      */
-    uint16_t slot;   /**< ECC Key slot */
-    uint8_t tag[16]; /**< L3 tag */
+    uint16_t slot; /**< ECC Key slot */
 } __attribute__((packed));
 
 // clang-format off
@@ -1143,8 +1082,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_cmd_t, slot) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_cmd_t, slot)
     )
 )
 /** \endcond */
@@ -1177,7 +1115,6 @@ struct lt_l3_ecc_key_read_res_t {
      * The public key from the ECC Key slot as specified in the SLOT L3 Field.
      */
     uint8_t pub_key[64]; /**< Public Key */
-    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1190,8 +1127,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_res_t, curve) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_res_t, origin) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_res_t, pub_key) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_read_res_t, pub_key)
     )
 )
 /** \endcond */
@@ -1218,8 +1154,7 @@ struct lt_l3_ecc_key_erase_cmd_t {
      * @brief
      * The slot to erase. Valid values are 0 - 31.
      */
-    uint16_t slot;   /**< ECC Key slot */
-    uint8_t tag[16]; /**< L3 tag */
+    uint16_t slot; /**< ECC Key slot */
 } __attribute__((packed));
 
 // clang-format off
@@ -1229,8 +1164,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_cmd_t, slot) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_cmd_t, slot)
     )
 )
 /** \endcond */
@@ -1243,7 +1177,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_ecc_key_erase_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1252,8 +1185,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_ecc_key_erase_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecc_key_erase_res_t, result)
     )
 )
 /** \endcond */
@@ -1291,7 +1223,6 @@ struct lt_l3_ecdsa_sign_cmd_t {
      * The hash of the message to sign (max size of 32 bytes).
      */
     uint8_t msg_hash[32]; /**< Hash of the Message to sign. */
-    uint8_t tag[16];      /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1303,8 +1234,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_cmd_t, slot) +
         LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_cmd_t, msg_hash) +
-        LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_cmd_t, msg_hash)
     )
 )
 /** \endcond */
@@ -1331,8 +1261,7 @@ struct lt_l3_ecdsa_sign_res_t {
      * @brief
      * ECDSA signature - The S part
      */
-    uint8_t s[32];   /**< ECDSA Signature - S part */
-    uint8_t tag[16]; /**< L3 tag */
+    uint8_t s[32]; /**< ECDSA Signature - S part */
 } __attribute__((packed));
 
 // clang-format off
@@ -1344,8 +1273,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_res_t, padding) +
         LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_res_t, r) +
-        LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_res_t, s) +
-        LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_ecdsa_sign_res_t, s)
     )
 )
 /** \endcond */
@@ -1387,7 +1315,6 @@ struct lt_l3_eddsa_sign_cmd_t {
      * The message to sign (max size of 4096 bytes).
      */
     uint8_t msg[4096]; /**< Message to sign. */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1399,8 +1326,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_cmd_t, slot) +
         LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_cmd_t, msg) +
-        LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_cmd_t, msg)
     )
 )
 /** \endcond */
@@ -1427,8 +1353,7 @@ struct lt_l3_eddsa_sign_res_t {
      * @brief
      * EdDSA signature - The S part
      */
-    uint8_t s[32];   /**< EDDSA Signature - S part */
-    uint8_t tag[16]; /**< L3 tag */
+    uint8_t s[32]; /**< EDDSA Signature - S part */
 } __attribute__((packed));
 
 // clang-format off
@@ -1440,8 +1365,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_res_t, padding) +
         LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_res_t, r) +
-        LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_res_t, s) +
-        LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_eddsa_sign_res_t, s)
     )
 )
 /** \endcond */
@@ -1479,7 +1403,6 @@ struct lt_l3_mcounter_init_cmd_t {
      * The initialization value of the Monotonic Counter.
      */
     uint32_t mcounter_val; /**< Initialization value. */
-    uint8_t tag[16];       /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1491,8 +1414,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_mcounter_init_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_mcounter_init_cmd_t, mcounter_index) +
         LT_MEMBER_SIZE(struct lt_l3_mcounter_init_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_init_cmd_t, mcounter_val) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_init_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mcounter_init_cmd_t, mcounter_val)
     )
 )
 /** \endcond */
@@ -1505,7 +1427,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_mcounter_init_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1514,8 +1435,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_mcounter_init_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_mcounter_init_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_init_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_init_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mcounter_init_res_t, result)
     )
 )
 /** \endcond */
@@ -1543,7 +1463,6 @@ struct lt_l3_mcounter_update_cmd_t {
      * The index of the Monotonic Counter to update. Valid values are 0 - 15.
      */
     uint16_t mcounter_index; /**< Index of Monotonic Counter */
-    uint8_t tag[16];         /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1553,8 +1472,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_mcounter_update_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_mcounter_update_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_update_cmd_t, mcounter_index) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_update_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mcounter_update_cmd_t, mcounter_index)
     )
 )
 /** \endcond */
@@ -1567,7 +1485,6 @@ LT_STATIC_ASSERT(
 struct lt_l3_mcounter_update_res_t {
     uint16_t res_size; /**< L3 result size */
     uint8_t result;    /**< Result status indication */
-    uint8_t tag[16];   /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1576,8 +1493,7 @@ LT_STATIC_ASSERT(
     sizeof(struct lt_l3_mcounter_update_res_t) ==
     (
         LT_MEMBER_SIZE(struct lt_l3_mcounter_update_res_t, res_size) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_update_res_t, result) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_update_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mcounter_update_res_t, result)
     )
 )
 /** \endcond */
@@ -1605,7 +1521,6 @@ struct lt_l3_mcounter_get_cmd_t {
      * The index of the Monotonic Counter to get the value of. Valid index values are 0 - 15.
      */
     uint16_t mcounter_index; /**< Index of Monotonic Counter */
-    uint8_t tag[16];         /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1615,8 +1530,7 @@ LT_STATIC_ASSERT(
     (
         LT_MEMBER_SIZE(struct lt_l3_mcounter_get_cmd_t, cmd_size) +
         LT_MEMBER_SIZE(struct lt_l3_mcounter_get_cmd_t, cmd_id) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_get_cmd_t, mcounter_index) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_get_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mcounter_get_cmd_t, mcounter_index)
     )
 )
 /** \endcond */
@@ -1639,7 +1553,6 @@ struct lt_l3_mcounter_get_res_t {
      * The value of the Monotonic Counter specified by the MCOUNTER_INDEX L3 Field.
      */
     uint32_t mcounter_val; /**< Initialization value. */
-    uint8_t tag[16];       /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1650,8 +1563,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_mcounter_get_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_mcounter_get_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_mcounter_get_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_get_res_t, mcounter_val) +
-        LT_MEMBER_SIZE(struct lt_l3_mcounter_get_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mcounter_get_res_t, mcounter_val)
     )
 )
 /** \endcond */
@@ -1690,7 +1602,6 @@ struct lt_l3_mac_and_destroy_cmd_t {
      * The data input for the MAC-and-Destroy sequence.
      */
     uint8_t data_in[32]; /**< Input data */
-    uint8_t tag[16];     /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1702,8 +1613,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_cmd_t, cmd_id) +
         LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_cmd_t, slot) +
         LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_cmd_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_cmd_t, data_in) +
-        LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_cmd_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_cmd_t, data_in)
     )
 )
 /** \endcond */
@@ -1726,7 +1636,6 @@ struct lt_l3_mac_and_destroy_res_t {
      * The data output from the MAC-and-Destroy sequence.
      */
     uint8_t data_out[32]; /**< Output data */
-    uint8_t tag[16];      /**< L3 tag */
 } __attribute__((packed));
 
 // clang-format off
@@ -1737,8 +1646,7 @@ LT_STATIC_ASSERT(
         LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_res_t, res_size) +
         LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_res_t, result) +
         LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_res_t, padding) +
-        LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_res_t, data_out) +
-        LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_res_t, tag)
+        LT_MEMBER_SIZE(struct lt_l3_mac_and_destroy_res_t, data_out)
     )
 )
 /** \endcond */


### PR DESCRIPTION
## Description

Each of these structures has a buffer for tag, but it seems to be unused. The structures are only used to initialize the fields from the User API doc in the handle’s l3.buff buffer and tag is added later by another function straight to the buffer.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---