### PR TITLE
ETR01SDK-493: Don't call SPI.begin and SPI.end methods in Arduino HAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Logging: Redundant/unused macros `LT_LOG`, `LT_LOG_RESULT`, `LT_LOG_VALUE`.
 - Arduino HAL: Removed `rng_seed` from `lt_dev_arduino_t`, as it should be user's responsibility to initialize the PRNG.
+- Arduino HAL: Removed `SPI.begin()` and `SPI.end()` calls (fixes [this](https://github.com/tropicsquare/libtropic-arduino/issues/15) issue).
 
 ## [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Logging: Redundant/unused macros `LT_LOG`, `LT_LOG_RESULT`, `LT_LOG_VALUE`.
 - Arduino HAL: Removed `rng_seed` from `lt_dev_arduino_t`, as it should be user's responsibility to initialize the PRNG.
-- Arduino HAL: Removed `SPI.begin()` and `SPI.end()` calls (fixes [this](https://github.com/tropicsquare/libtropic-arduino/issues/15) issue).
+- Arduino HAL: Removed `SPI.begin()` and `SPI.end()` calls (fixes [this](https://github.com/tropicsquare/libtropic-arduino/issues/15) issue). It is now expected that users initialize SPI in their code themselves.
 
 ## [3.0.0]
 

--- a/hal/arduino/libtropic_port_arduino.cpp
+++ b/hal/arduino/libtropic_port_arduino.cpp
@@ -23,7 +23,6 @@ lt_ret_t lt_port_init(lt_l2_state_t *s2)
     // Setup SPI
     pinMode(device->spi_cs_pin, OUTPUT);
     digitalWrite(device->spi_cs_pin, HIGH);
-    device->spi->begin();
 
     // Setup interrupt pin
 #if LT_USE_INT_PIN
@@ -38,7 +37,6 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
     lt_dev_arduino_t *device = (lt_dev_arduino_t *)(s2->device);
 
     digitalWrite(device->spi_cs_pin, HIGH);
-    device->spi->end();
 
     return LT_OK;
 }
@@ -128,8 +126,9 @@ int lt_port_log(const char *format, ...)
         for (size_t i = 0; i < len; ++i) {
             char c = log_buff[i];
             if (c == '\n') {
-                Serial.println(); // Let Arduino Library handle newlines properly.
-            } else {
+                Serial.println();  // Let Arduino Library handle newlines properly.
+            }
+            else {
                 Serial.write(c);
             }
         }

--- a/hal/arduino/libtropic_port_arduino.h
+++ b/hal/arduino/libtropic_port_arduino.h
@@ -28,8 +28,7 @@ typedef struct lt_dev_arduino_t {
 #endif
     /** @public @brief SPI settings. */
     SPISettings spi_settings;
-
-    /** @private @brief Pointer to the SPI class. */
+    /** @public @brief Pointer to the SPI class. */
     SPIClass *spi;
 } lt_dev_arduino_t;
 


### PR DESCRIPTION
## Description

Based on this issue: https://github.com/tropicsquare/libtropic-arduino/issues/15.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---