### PR TITLE
ETR01SDK-465: Mention deletion of R_MEM_DATA_SIZE_MAX in changelog for 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,8 +110,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Users should verify the signatures themselves e.g., using functions provided by their crypto library.
 - `lt_update_mode` function.
 - `R_MEM_DATA_SIZE_MAX` macro, as the value is different for some Application FW versions. Use the correct version of [User API or datasheet](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#datasheet-and-user-api) (based on the used Application FW) as the source of truth for these kind of constants.
-- 
-
 ## [2.0.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `session_state_t` to `lt_session_state_t`.
 - Renamed `LT_L2_SLEEP_KIND_SLEEP` to `TR01_L2_SLEEP_KIND_SLEEP`.
 - Renamed `LT_MODE_APP` to `TR01_MODE_APP`.
-- Renamed `LT_MODE_APP` to `TR01_MODE_APP`.
 - Renamed `LT_MODE_MAINTENANCE` to `TR01_MODE_MAINTENANCE`.
 - Renamed `GET_LOG_MAX_MSG_LEN` to `TR01_GET_LOG_MAX_MSG_LEN`.
 - Renamed `RANDOM_VALUE_GET_LEN_MAX` to `TR01_RANDOM_VALUE_GET_LEN_MAX`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - STM32 F439ZI HAL: Changed `rng_handle` type in `lt_dev_stm32_nucleo_f439zi_t` to a pointer (`RNG_HandleTypeDef*`).
 - New return value `LT_REBOOT_UNSUCCESSFUL` returned by `lt_reboot` function, which now checks if TROPIC01 is in correct mode after the reboot.
 - Examples: Refactored and cleaned up `lt_ex_show_chip_id_and_fwver` and `lt_ex_fw_update` logic to use the new version of the `lt_reboot` function.
-- Meaning of `lt_tr01_mode_t` enum values. Now, this enum is supposed to be used with the new `lt_get_tr01_mode` function.
+- Meaning and names of `lt_tr01_mode_t` enum values. Now, this enum is supposed to be used with the new `lt_get_tr01_mode` function.
 - CMake: Renamed `LT_CPU_FW_VERSION` to `LT_CPU_FW_UPDATE_DATA_VER` to make it more clear that it is used for the FW version to update to.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Signature verification was removed from the HW wallet example.
     - Users should verify the signatures themselves e.g., using functions provided by their crypto library.
 - `lt_update_mode` function.
+- `R_MEM_DATA_SIZE_MAX` macro, as the value is different for some Application FW versions. Use the correct version of [User API or datasheet](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#datasheet-and-user-api) (based on the used Application FW) as the source of truth for these kind of constants.
+- 
 
 ## [2.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Signature verification was removed from the HW wallet example.
     - Users should verify the signatures themselves e.g., using functions provided by their crypto library.
 - `lt_update_mode` function.
-- `R_MEM_DATA_SIZE_MAX` macro, as the value is different for some Application FW versions. Use the correct version of [User API or datasheet](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#datasheet-and-user-api) (based on the used Application FW) as the source of truth for these kind of constants.
+- `R_MEM_DATA_SIZE_MAX` macro because its value differs between Application FW versions. Use the appropriate [User API or datasheet](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#datasheet-and-user-api) (based on the Application FW in use) as the source of truth for such constants.
 ## [2.0.1]
 
 ### Added


### PR DESCRIPTION
## Description

We forgot to mention that the `R_MEM_DATA_SIZE_MAX` macro was removed.

There are also some other minor changelog fixes.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---