### PR TITLE
ETR01SDK-500: TCP HAL: refactor lt_port_init, lt_port_deinit and local functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   about if and how the LF is translated automatically (e.g., `stdio.h` implementation of major desktop platforms) or if you
   need to modify the behavior yourself (e.g., by modifiying `_write` syscall on STM32), or (in the case of the embedded platforms)
   you just need to configure your serial monitor correctly, so it expects only LF character (and not CR+LF pair).
+- TCP HAL: Fixed `lt_port_init()` cleanup, refactored local functions.
 
 ### Added
 - Logging: `lt_port_log` function for platform-specific logging mechanism; is used by the logging macros declared in `libtropic_logging.h`.

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -224,11 +224,8 @@ lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
 
     LT_LOG_DEBUG("-- Driving Chip Select to Low.");
     dev->tx_buffer.tag = LT_TCP_TAG_SPI_DRIVE_CSN_LOW;
-    if (communicate(dev, NULL, NULL) != LT_OK) {
-        return LT_FAIL;
-    }
 
-    return LT_OK;
+    return communicate(dev, NULL, NULL);
 }
 
 lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
@@ -237,11 +234,8 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
 
     LT_LOG_DEBUG("-- Driving Chip Select to High.");
     dev->tx_buffer.tag = LT_TCP_TAG_SPI_DRIVE_CSN_HIGH;
-    if (communicate(dev, NULL, NULL) != LT_OK) {
-        return LT_FAIL;
-    }
 
-    return LT_OK;
+    return communicate(dev, NULL, NULL);
 }
 
 lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
@@ -285,11 +279,7 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
     dev->rx_buffer.payload[2] = (ms & 0x00ff0000) >> 16;
     dev->rx_buffer.payload[3] = (ms & 0xff000000) >> 24;
 
-    if (communicate(dev, &payload_length, NULL) != LT_OK) {
-        return LT_FAIL;
-    }
-
-    return LT_OK;
+    return communicate(dev, &payload_length, NULL);
 }
 
 lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -280,7 +280,6 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
     LT_LOG_DEBUG("-- Waiting for the target.");
     dev->tx_buffer.tag = LT_TCP_TAG_WAIT;
     int payload_length = sizeof(uint32_t);
-    //*(uint32_t *)(&tx_buffer.PAYLOAD) = wait_time_usecs;
     dev->rx_buffer.payload[0] = ms & 0x000000ff;
     dev->rx_buffer.payload[1] = (ms & 0x0000ff00) >> 8;
     dev->rx_buffer.payload[2] = (ms & 0x00ff0000) >> 16;

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -30,12 +30,17 @@
 #endif
 
 /**
- * @brief Sends all data in the buffer through the socket.
+ * @brief Attempts to send all data in the buffer through the socket.
+ *
+ * This function may perform multiple send attempts (up to LT_TCP_TX_ATTEMPTS)
+ * if the initial send is incomplete, and fails if the full buffer cannot be
+ * sent within this limit.
  *
  * @param socket_fd   Socket file descriptor
  * @param buffer      Buffer to send
  * @param buffer_len  Length of the buffer
- * @return            0 on success, non-zero on failure
+ * @return            0 on success, non-zero on failure if not all data is sent
+ *                    after LT_TCP_TX_ATTEMPTS attempts
  */
 static int send_all(const int socket_fd, const uint8_t *buffer, const size_t buffer_len)
 {

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -29,55 +29,34 @@
 #error "Interrupt PIN not supported in the TCP port!"
 #endif
 
-static lt_ret_t connect_to_server(lt_dev_posix_tcp_t *dev)
-{
-    struct sockaddr_in server;
-
-    // Create socket
-    dev->socket_fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (dev->socket_fd < 0) {
-        LT_LOG_ERROR("Could not create socket: %s (%d).", strerror(errno), errno);
-        return LT_FAIL;
-    }
-    LT_LOG_DEBUG("Socket created.");
-
-    // Server information
-    memset(&server, 0, sizeof(server));
-    server.sin_family = AF_INET;
-    server.sin_addr.s_addr = dev->addr;
-    server.sin_port = htons(dev->port);
-
-    // Connect to the server
-    LT_LOG_DEBUG("Connecting to %s:%d.", inet_ntoa(server.sin_addr), dev->port);
-    if (connect(dev->socket_fd, (struct sockaddr *)(&server), sizeof(server)) < 0) {
-        LT_LOG_ERROR("Could not connect: %s (%d).", strerror(errno), errno);
-        return LT_FAIL;
-    }
-    LT_LOG_DEBUG("Connected to the server.");
-
-    return LT_OK;
-}
-
-static lt_ret_t send_all(int socket, uint8_t *buffer, size_t length)
+/**
+ * @brief Sends all data in the buffer through the socket.
+ *
+ * @param socket_fd   Socket file descriptor
+ * @param buffer      Buffer to send
+ * @param buffer_len  Length of the buffer
+ * @return            0 on success, non-zero on failure
+ */
+static int send_all(const int socket_fd, const uint8_t *buffer, const size_t buffer_len)
 {
     int nb_bytes_sent;
     int nb_bytes_sent_total = 0;
-    int nb_bytes_to_send = length;
-    uint8_t *ptr = buffer;
+    int nb_bytes_to_send = buffer_len;
+    uint8_t *ptr = (uint8_t *)buffer;
 
     // attempt several times to send the data
     for (int i = 0; i < LT_TCP_TX_ATTEMPTS; i++) {
         LT_LOG_DEBUG("Attempting to send data: attempt #%d.", i);
-        nb_bytes_sent = send(socket, ptr, nb_bytes_to_send, 0);
+        nb_bytes_sent = send(socket_fd, ptr, nb_bytes_to_send, 0);
         if (nb_bytes_sent <= 0) {
             LT_LOG_ERROR("Send failed: %s (%d).", strerror(errno), errno);
-            return LT_FAIL;
+            return -1;
         }
 
         nb_bytes_to_send -= nb_bytes_sent;
         if (nb_bytes_to_send == 0) {
-            LT_LOG_DEBUG("All %zu bytes sent successfully.", length);
-            return LT_OK;
+            LT_LOG_DEBUG("All %zu bytes sent successfully.", buffer_len);
+            return 0;
         }
 
         ptr += nb_bytes_sent;
@@ -85,21 +64,29 @@ static lt_ret_t send_all(int socket, uint8_t *buffer, size_t length)
     }
 
     // could not send all the data after several attempts
-    LT_LOG_ERROR("%d bytes sent instead of expected %zu ", nb_bytes_sent_total, length);
+    LT_LOG_ERROR("%d bytes sent instead of expected %zu ", nb_bytes_sent_total, buffer_len);
     LT_LOG_ERROR("after %d attempts.", LT_TCP_TX_ATTEMPTS);
 
-    return LT_FAIL;
+    return -1;
 }
 
-static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr, int *rx_payload_length_ptr)
+/**
+ * @brief Send and receive data to/from the TCP port.
+ *
+ * @param dev TCP HAL Device structure
+ * @param tx_payload_length_ptr Pointer to the length of the payload to send (excluding tag and length fields)
+ * @param rx_payload_length_ptr Pointer to the length of the payload to receive (excluding tag and length fields)
+ * @return 0 on success, non-zero on failure
+ */
+static int communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr, int *rx_payload_length_ptr)
 {
-    lt_ret_t ret;
     int nb_bytes_received;
     int nb_bytes_received_total = 0;
     int nb_bytes_to_receive = LT_TCP_TAG_AND_LENGTH_SIZE;
     uint8_t *rx_ptr = dev->rx_buffer.buff;
     // number of bytes to send
     int nb_bytes_to_send = LT_TCP_TAG_AND_LENGTH_SIZE;
+    int ret = 0;
 
     if (tx_payload_length_ptr != NULL) {
         nb_bytes_to_send += *tx_payload_length_ptr;
@@ -109,7 +96,7 @@ static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr,
     dev->tx_buffer.len = nb_bytes_to_send - LT_TCP_TAG_AND_LENGTH_SIZE;
 
     ret = send_all(dev->socket_fd, dev->tx_buffer.buff, nb_bytes_to_send);
-    if (ret != LT_OK) {
+    if (ret != 0) {
         return ret;
     }
 
@@ -119,11 +106,11 @@ static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr,
 
     if (nb_bytes_received < 0) {
         LT_LOG_ERROR("Receive failed: %s (%d).", strerror(errno), errno);
-        return LT_FAIL;
+        return -1;
     }
     else if (nb_bytes_received < nb_bytes_to_receive) {
         LT_LOG_ERROR("At least %d bytes are expected: %d.", nb_bytes_to_receive, nb_bytes_received);
-        return LT_FAIL;
+        return -1;
     }
 
     LT_LOG_DEBUG("Length field: %" PRIu16 ".", dev->rx_buffer.len);
@@ -140,7 +127,7 @@ static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr,
 
             if (nb_bytes_received < 0) {
                 LT_LOG_ERROR("Receive failed: %s (%d).", strerror(errno), errno);
-                return LT_FAIL;
+                return -1;
             }
 
             nb_bytes_received_total += nb_bytes_received;
@@ -154,23 +141,23 @@ static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr,
 
     if (nb_bytes_received_total != nb_bytes_to_receive) {
         LT_LOG_ERROR("Received %d bytes in total instead of %d.", nb_bytes_received_total, nb_bytes_to_receive);
-        return LT_FAIL;
+        return -1;
     }
 
     // server does not know the sent tag
     if ((lt_posix_tcp_tag_t)dev->rx_buffer.tag == LT_TCP_TAG_INVALID) {
         LT_LOG_ERROR("Tag %" PRIu8 " is not known by the server.", dev->tx_buffer.tag);
-        return LT_FAIL;
+        return -1;
     }
     // server does not know what to do with the sent tag
     else if ((lt_posix_tcp_tag_t)dev->rx_buffer.tag == LT_TCP_TAG_UNSUPPORTED) {
         LT_LOG_ERROR("Tag %" PRIu8 " is not supported by the server.", dev->tx_buffer.tag);
-        return LT_FAIL;
+        return -1;
     }
     // RX tag and TX tag should be identical
     else if (dev->rx_buffer.tag != dev->tx_buffer.tag) {
         LT_LOG_ERROR("Expected tag %" PRIu8 ", received %" PRIu8 ".", dev->rx_buffer.tag, dev->tx_buffer.tag);
-        return LT_FAIL;
+        return -1;
     }
 
     LT_LOG_DEBUG("Rx tag and tx tag match: %" PRIu8 ".", dev->rx_buffer.tag);
@@ -178,41 +165,39 @@ static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr,
         *rx_payload_length_ptr = nb_bytes_received_total - LT_TCP_TAG_AND_LENGTH_SIZE;
     }
 
-    return LT_OK;
-}
-
-static lt_ret_t server_connect(lt_dev_posix_tcp_t *dev)
-{
-    bzero(dev->tx_buffer.buff, LT_TCP_MAX_BUFFER_LEN);
-    bzero(dev->rx_buffer.buff, LT_TCP_MAX_BUFFER_LEN);
-
-    lt_ret_t ret = connect_to_server(dev);
-    if (ret != LT_OK) {
-        return ret;
-    }
-
-    return LT_OK;
-}
-
-static lt_ret_t server_disconnect(int socket_fd)
-{
-    LT_LOG_DEBUG("-- Server disconnect");
-    if (close(socket_fd)) {
-        LT_LOG_ERROR("close() failed: %s (%d)", strerror(errno), errno);
-        return LT_FAIL;
-    }
-
-    return LT_OK;
+    return 0;
 }
 
 lt_ret_t lt_port_init(lt_l2_state_t *s2)
 {
     lt_dev_posix_tcp_t *dev = (lt_dev_posix_tcp_t *)(s2->device);
 
-    lt_ret_t ret = server_connect(dev);
-    if (ret != LT_OK) {
-        return ret;
+    bzero(dev->tx_buffer.buff, LT_TCP_MAX_BUFFER_LEN);
+    bzero(dev->rx_buffer.buff, LT_TCP_MAX_BUFFER_LEN);
+
+    // Create socket
+    dev->socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (dev->socket_fd < 0) {
+        LT_LOG_ERROR("Could not create socket: %s (%d).", strerror(errno), errno);
+        return LT_FAIL;
     }
+    LT_LOG_DEBUG("Socket created.");
+
+    // Server information
+    struct sockaddr_in server;
+    memset(&server, 0, sizeof(server));
+    server.sin_family = AF_INET;
+    server.sin_addr.s_addr = dev->addr;
+    server.sin_port = htons(dev->port);
+
+    // Connect to the server
+    LT_LOG_DEBUG("Connecting to %s:%d.", inet_ntoa(server.sin_addr), dev->port);
+    if (connect(dev->socket_fd, (struct sockaddr *)(&server), sizeof(server)) < 0) {
+        LT_LOG_ERROR("Could not connect: %s (%d).", strerror(errno), errno);
+        close(dev->socket_fd);
+        return LT_FAIL;
+    }
+    LT_LOG_DEBUG("Connected to the server.");
 
     return LT_OK;
 }
@@ -220,9 +205,11 @@ lt_ret_t lt_port_init(lt_l2_state_t *s2)
 lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
 {
     lt_dev_posix_tcp_t *dev = (lt_dev_posix_tcp_t *)(s2->device);
-    lt_ret_t ret = server_disconnect(dev->socket_fd);
-    if (ret != LT_OK) {
-        return ret;
+
+    LT_LOG_DEBUG("-- Server disconnect");
+    if (close(dev->socket_fd)) {
+        LT_LOG_ERROR("close() failed: %s (%d)", strerror(errno), errno);
+        return LT_FAIL;
     }
 
     return LT_OK;
@@ -231,24 +218,33 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
 lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
 {
     lt_dev_posix_tcp_t *dev = (lt_dev_posix_tcp_t *)(s2->device);
+
     LT_LOG_DEBUG("-- Driving Chip Select to Low.");
     dev->tx_buffer.tag = LT_TCP_TAG_SPI_DRIVE_CSN_LOW;
-    return communicate(dev, NULL, NULL);
+    if (communicate(dev, NULL, NULL) != 0) {
+        return LT_FAIL;
+    }
+
+    return LT_OK;
 }
 
 lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
 {
     lt_dev_posix_tcp_t *dev = (lt_dev_posix_tcp_t *)(s2->device);
+
     LT_LOG_DEBUG("-- Driving Chip Select to High.");
     dev->tx_buffer.tag = LT_TCP_TAG_SPI_DRIVE_CSN_HIGH;
-    return communicate(dev, NULL, NULL);
+    if (communicate(dev, NULL, NULL) != 0) {
+        return LT_FAIL;
+    }
+
+    return LT_OK;
 }
 
 lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
 {
     LT_UNUSED(timeout_ms);
     lt_dev_posix_tcp_t *dev = (lt_dev_posix_tcp_t *)(s2->device);
-    lt_ret_t ret;
 
     if (offset + tx_data_length > TR01_L1_LEN_MAX) {
         return LT_L1_DATA_LEN_ERROR;
@@ -265,8 +261,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
     // copy tx_data to tx payload
     memcpy(&dev->tx_buffer.payload, s2->buff, tx_payload_length);
 
-    ret = communicate(dev, &tx_payload_length, &rx_payload_length);
-    if (ret != LT_OK) {
+    if (communicate(dev, &tx_payload_length, &rx_payload_length) != 0) {
         return LT_FAIL;
     }
 
@@ -278,8 +273,8 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
 lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
 {
     lt_dev_posix_tcp_t *dev = (lt_dev_posix_tcp_t *)(s2->device);
-    LT_LOG_DEBUG("-- Waiting for the target.");
 
+    LT_LOG_DEBUG("-- Waiting for the target.");
     dev->tx_buffer.tag = LT_TCP_TAG_WAIT;
     int payload_length = sizeof(uint32_t);
     //*(uint32_t *)(&tx_buffer.PAYLOAD) = wait_time_usecs;
@@ -288,7 +283,11 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
     dev->rx_buffer.payload[2] = (ms & 0x00ff0000) >> 16;
     dev->rx_buffer.payload[3] = (ms & 0xff000000) >> 24;
 
-    return communicate(dev, &payload_length, NULL);
+    if (communicate(dev, &payload_length, NULL) != 0) {
+        return LT_FAIL;
+    }
+
+    return LT_OK;
 }
 
 lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -47,7 +47,7 @@ static int send_all(const int socket_fd, const uint8_t *buffer, const size_t buf
     int nb_bytes_sent;
     int nb_bytes_sent_total = 0;
     int nb_bytes_to_send = buffer_len;
-    uint8_t *ptr = (uint8_t *)buffer;
+    const uint8_t *ptr = buffer;
 
     // attempt several times to send the data
     for (int i = 0; i < LT_TCP_TX_ATTEMPTS; i++) {


### PR DESCRIPTION
## Description

1. `server_connect`, `server_disconnect` and `connect_to_server` don’t have to be functions
2. `lt_port_init` should call `close()` if it fails

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---