### PR TITLE
ETR01SDK-499: lt_port_init cleanup refactor and SPI mode check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `lt_print_bytes` function now returns `LT_PARAM_ERR` when incorrect parameters are passed instead of `LT_FAIL`.
 - `lt_print_fw_header` function now returns `LT_PARAM_ERR` when incorrect bank ID is used instead of `LT_FAIL`.
+- Linux SPI HAL: If the SPI0 mode is not supported, cleanup and return with an error.
 
 ### Removed
 - Logging: Redundant/unused macros `LT_LOG`, `LT_LOG_RESULT`, `LT_LOG_VALUE`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `lt_print_bytes` function now returns `LT_PARAM_ERR` when incorrect parameters are passed instead of `LT_FAIL`.
 - `lt_print_fw_header` function now returns `LT_PARAM_ERR` when incorrect bank ID is used instead of `LT_FAIL`.
-- Linux SPI HAL: If the SPI0 mode is not supported, cleanup and return with an error.
+- Linux SPI HAL: If SPI mode 0 is not supported, cleanup and return with an error.
 
 ### Removed
 - Logging: Redundant/unused macros `LT_LOG`, `LT_LOG_RESULT`, `LT_LOG_VALUE`.

--- a/hal/linux/spi/libtropic_port_linux_spi.h
+++ b/hal/linux/spi/libtropic_port_linux_spi.h
@@ -47,8 +47,6 @@ typedef struct lt_dev_linux_spi_t {
     /** @private @brief GPIO request structure for interrupt pin. */
     struct gpio_v2_line_request gpioreq_int;
 #endif
-    /** @private @brief SPI mode. */
-    uint32_t mode;
 } lt_dev_linux_spi_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description

1. `lt_dev_linux_spi_t` has a private field `mode` for the SPI mode (CPOL and CPHA). However, because we know that TROPIC01 supports only SPI mode 0, we can hardcode it into the HAL and remove this field.
2. `lt_port_init` sets the `lt_dev_linux_spi_t. mode` to `SPI_MODE_0`, tries to configure the SPI controller with this mode, reads it back and checks that it was set to `SPI_MODE_0`. If not, it just prints a warning and continues with the execution. That is a problem - it should immediately return with error (and appropriate cleanup).
3. Refactored the cleanup in `lt_port_init` to use `goto` with labels at the end of the function.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---