### PR TITLE
ETR01SDK-524: Fix CMake policy on older cmakes

### DIFF
--- a/tests/functional/linux/spi_devkit/CMakeLists.txt
+++ b/tests/functional/linux/spi_devkit/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.21.0)
-cmake_policy(SET CMP0152 OLD) # Path resolution policy
+if (${CMAKE_VERSION} VERSION_GREATER "3.27")
+    cmake_policy(SET CMP0152 OLD) # Path resolution policy
+endif()
 
 ###########################################################################
 #                                                                         #

--- a/tests/functional/linux/usb_devkit/CMakeLists.txt
+++ b/tests/functional/linux/usb_devkit/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.21.0)
-cmake_policy(SET CMP0152 OLD) # Path resolution policy
+if (${CMAKE_VERSION} VERSION_GREATER "3.27")
+    cmake_policy(SET CMP0152 OLD) # Path resolution policy
+endif()
 
 ###########################################################################
 #                                                                         #

--- a/tests/functional/model/CMakeLists.txt
+++ b/tests/functional/model/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.21.0)
-cmake_policy(SET CMP0152 OLD) # Path resolution policy
+if (${CMAKE_VERSION} VERSION_GREATER "3.27")
+    cmake_policy(SET CMP0152 OLD) # Path resolution policy
+endif()
 
 ###########################################################################
 #                                                                         #


### PR DESCRIPTION
## Description

This PR just adds condition to apply CMP0152 on versions >3.27 in functional tests.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage
