### PR TITLE
ETR01SDK-498: Don't call lt_deinit if lt_init fails

### DIFF
--- a/docs/get_started/integrating_libtropic/how_to_use/index.md
+++ b/docs/get_started/integrating_libtropic/how_to_use/index.md
@@ -89,7 +89,6 @@ int main(void) {
     // first.
     lt_ret_t ret = lt_init(h);
     if (LT_OK != ret) {
-        lt_deinit(h);
         return -1;
     }
 

--- a/examples/linux/spi_devkit/fw_update/main.c
+++ b/examples/linux/spi_devkit/fw_update/main.c
@@ -93,7 +93,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/linux/spi_devkit/hello_world/main.c
+++ b/examples/linux/spi_devkit/hello_world/main.c
@@ -80,7 +80,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/linux/spi_devkit/identify_chip/main.c
+++ b/examples/linux/spi_devkit/identify_chip/main.c
@@ -66,7 +66,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -85,7 +85,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/linux/usb_devkit/hello_world/main.c
+++ b/examples/linux/usb_devkit/hello_world/main.c
@@ -72,7 +72,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/linux/usb_devkit/identify_chip/main.c
+++ b/examples/linux/usb_devkit/identify_chip/main.c
@@ -58,7 +58,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/model/hello_world/main.c
+++ b/examples/model/hello_world/main.c
@@ -77,7 +77,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/model/hw_wallet/main.c
+++ b/examples/model/hw_wallet/main.c
@@ -840,7 +840,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/model/mac_and_destroy/main.c
+++ b/examples/model/mac_and_destroy/main.c
@@ -570,7 +570,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (ret != LT_OK) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -251,7 +251,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
@@ -222,7 +222,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
@@ -219,7 +219,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -279,7 +279,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
@@ -250,7 +250,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
@@ -247,7 +247,6 @@ int main(void)
     lt_ret_t ret = lt_init(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -26,7 +26,8 @@ extern "C" {
 #endif
 
 /**
- * @brief Initialize handle and transport layer
+ * @brief Initialize handle and transport layer.
+ * @note If the function fails, `lt_deinit` must not be called. In this case, the function handles the cleanup itself.
  *
  * @param h           Handle for communication with TROPIC01
  *


### PR DESCRIPTION
## Description

Recent changes fixed behavior of `lt_init` if it fails - it performs the needed cleanup itself.

This PR removes all `lt_deinit` calls if `lt_init` fails.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

--