### PR TITLE
ETR01SDK-510: Fix static assertion

### DIFF
--- a/include/libtropic_macros.h
+++ b/include/libtropic_macros.h
@@ -13,10 +13,6 @@
 extern "C" {
 #endif
 
-/** @brief Wrapper for static assertion. */
-// #define LT_STATIC_ASSERT(x) _Static_assert((x), "Static assertion failed");
-#define LT_STATIC_ASSERT(x)
-
 /** @brief Get struct member size at compile-time. */
 #define LT_MEMBER_SIZE(type, member) (sizeof(((type *)0)->member))
 
@@ -47,12 +43,19 @@ extern "C" {
         ___a < ___b ? ___a : ___b; \
     })
 
+#ifndef __cplusplus
+
 /**
  * @brief Get max value from compile-time constants at compile-time.
  * @note C-only version.
  */
-#ifndef __cplusplus
 #define LT_COMPTIME_MAX(a, b) __builtin_choose_expr((a) > (b), a, b)
+
+/** @brief Wrapper for static assertion.
+ *  @note C-only version.
+ */
+#define LT_STATIC_ASSERT(x) _Static_assert((x), "Static assertion failed");
+
 #endif
 
 #ifdef __cplusplus
@@ -69,6 +72,12 @@ constexpr T LT_COMPTIME_MAX(T a, T b)
 {
     return (a > b) ? a : b;
 }
+
+/** @brief Wrapper for static assertion.
+ *  @note C++-only version.
+ */
+#define LT_STATIC_ASSERT(x) static_assert((x), "Static assertion failed");
+
 #endif
 
 #endif  // LT_LIBTROPIC_MACROS


### PR DESCRIPTION
## Description

This PR fixes definitions of `LT_STATIC_ASSERT` and provides separate version for C and C++.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage