### PR TITLE
ETR01SDK-526: Add warnings and clarifications to R-config API doc

### DIFF
--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -344,7 +344,11 @@ lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const uint8_t
 lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const uint8_t slot);
 
 /**
- * @brief Writes configuration object specified by `addr`
+ * @brief Writes configuration object specified by `addr`. Make sure to read the Configuration Objects Application Note
+ * (ODN_TR01_app_006) to see how to handle the R-config before proceeding.
+ *
+ * @warning Writing R-config before erasing it first can brick the TROPIC01 chip. Refer to Erratum
+ * OI_TR01_ERR_2026010800: R-Config write triggers permanent Alarm Mode.
  *
  * @param h           Handle for communication with TROPIC01
  * @param addr        Address of a config object
@@ -357,7 +361,8 @@ lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const uint8_t slot);
 lt_ret_t lt_r_config_write(lt_handle_t *h, const enum lt_config_obj_addr_t addr, const uint32_t obj);
 
 /**
- * @brief Reads configuration object specified by `addr`
+ * @brief Reads configuration object specified by `addr`. Make sure to read the Configuration Objects Application Note
+ * (ODN_TR01_app_006) to see how to handle the R-config before proceeding.
  *
  * @param h           Handle for communication with TROPIC01
  * @param addr        Address of a config object
@@ -371,7 +376,8 @@ lt_ret_t lt_r_config_write(lt_handle_t *h, const enum lt_config_obj_addr_t addr,
 lt_ret_t lt_r_config_read(lt_handle_t *h, const enum lt_config_obj_addr_t addr, uint32_t *obj);
 
 /**
- * @brief Erases all configuration objects
+ * @brief Erases all configuration objects. Make sure to read the Configuration Objects Application Note
+ * (ODN_TR01_app_006) to see how to handle the R-config before proceeding.
  *
  * @param h           Handle for communication with TROPIC01
  *
@@ -643,7 +649,11 @@ extern struct lt_config_obj_desc_t cfg_desc_table[LT_CONFIG_OBJ_CNT];
 const char *lt_ret_verbose(lt_ret_t ret);
 
 /**
- * @brief Writes the whole R-Config with the passed `config`.
+ * @brief Writes the whole R-Config with the passed `config`. Make sure to read the Configuration Objects Application
+ * Note (ODN_TR01_app_006) to see how to handle the R-config before proceeding.
+ *
+ * @warning Writing R-config before erasing it first can brick the TROPIC01 chip. Refer to Erratum
+ * OI_TR01_ERR_2026010800: R-Config write triggers permanent Alarm Mode.
  *
  * @param h           Handle for communication with TROPIC01
  * @param config      Array into which objects are read
@@ -655,7 +665,8 @@ const char *lt_ret_verbose(lt_ret_t ret);
 lt_ret_t lt_write_whole_R_config(lt_handle_t *h, const struct lt_config_t *config);
 
 /**
- * @brief Reads all of the R-Config objects into `config`.
+ * @brief Reads all of the R-Config objects into `config`. Make sure to read the Configuration Objects Application Note
+ * (ODN_TR01_app_006) to see how to handle the R-config before proceeding.
  *
  * @param h           Handle for communication with TROPIC01
  * @param config      Struct into which objects are readed


### PR DESCRIPTION
## Description

In this PR, I add links to CO appnote and R-config erratum to documentation of R-config API functions.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage
