### PR TITLE
ETR01SDK-475: add Linux SPI HAL with native CS handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing check of `lt_handle_t.l3.session_status` in `lt_in__ecc_key_generate()`.
 - CAL: support for OpenSSL.
 - CAL: support for WolfCrypt.
+- Linux HAL: added new HAL for Linux which utilizes spidev for chip select instead of GPIO.
 
 ### Fixed
 - `lt_print_bytes` function now returns `LT_PARAM_ERR` when incorrect parameters are passed instead of `LT_FAIL`.

--- a/docs/compatibility/host_platforms/linux.md
+++ b/docs/compatibility/host_platforms/linux.md
@@ -1,8 +1,8 @@
 # Linux
 Libtropic support on Linux is implemented with:
 
-- [Linux](#linux)
-  - [SPI and GPIO Linux Userspace API](#spi-and-gpio-linux-userspace-api)
+- [SPI and GPIO Linux Userspace API](#spi-and-gpio-linux-userspace-api)
+- [SPI and GPIO Linux Userspace API with native CS](#spi-and-gpio-linux-userspace-api-with-native-CS)
 
 HALs for these ports are available in the `libtropic/hal/linux/` directory.
 
@@ -13,3 +13,14 @@ This port uses the [SPI](https://docs.kernel.org/spi/spidev.html) and [GPIO](htt
 
 - [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/),
 - [Raspberry Pi 5](https://www.raspberrypi.com/products/raspberry-pi-5/).
+
+Examples for this port are in the `examples/linux/spi_devkit` directory.
+
+## SPI and GPIO Linux Userspace API with native CS
+This port uses the [SPI](https://docs.kernel.org/spi/spidev.html) and [GPIO](https://docs.kernel.org/userspace-api/gpio/chardev.html) Linux Userspace API.
+
+The main difference from the [SPI and GPIO Linux Userspace API](#spi-and-gpio-linux-userspace-api) port is that GPIO is used only for interrupt handling, as the chip select is handled natively by the SPI driver. The main benefit is that no additional GPIO is required and no GPIO is required at all if interrupts are not used. However, more data are transmitted each time, as this port has no custom control over chip select, meaning it needs to transfer whole buffer on each transaction.
+
+This port was tested on:
+
+- [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/),

--- a/docs/compatibility/host_platforms/linux.md
+++ b/docs/compatibility/host_platforms/linux.md
@@ -19,8 +19,8 @@ Examples for this port are in the `examples/linux/spi_devkit` directory.
 ## SPI and GPIO Linux Userspace API with native CS
 This port uses the [SPI](https://docs.kernel.org/spi/spidev.html) and [GPIO](https://docs.kernel.org/userspace-api/gpio/chardev.html) Linux Userspace API.
 
-The main difference from the [SPI and GPIO Linux Userspace API](#spi-and-gpio-linux-userspace-api) port is that GPIO is used only for interrupt handling, as the chip select is handled natively by the SPI driver. The main benefit is that no additional GPIO is required and no GPIO is required at all if interrupts are not used. However, more data are transmitted each time, as this port has no custom control over chip select, meaning it needs to transfer whole buffer on each transaction.
+The main difference from the [SPI and GPIO Linux Userspace API](#spi-and-gpio-linux-userspace-api) port is that the GPIO is used only for interrupt handling, as the chip select is handled natively by the SPI driver. The main benefit is that no additional GPIO pin is required and no GPIOs are required at all if interrupts are not used. However, more data are transmitted on each transaction, as this port has no custom control over chip select, meaning it needs to transfer whole buffer on each transaction.
 
 This port was tested on:
 
-- [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/),
+- [Raspberry Pi 4](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)

--- a/docs/compatibility/host_platforms/linux.md
+++ b/docs/compatibility/host_platforms/linux.md
@@ -2,7 +2,7 @@
 Libtropic support on Linux is implemented with:
 
 - [SPI and GPIO Linux Userspace API](#spi-and-gpio-linux-userspace-api)
-- [SPI and GPIO Linux Userspace API with native CS](#spi-and-gpio-linux-userspace-api-with-native-CS)
+- [SPI and GPIO Linux Userspace API with native CS](#spi-and-gpio-linux-userspace-api-with-native-cs)
 
 HALs for these ports are available in the `libtropic/hal/linux/` directory.
 

--- a/docs/compatibility/host_platforms/linux.md
+++ b/docs/compatibility/host_platforms/linux.md
@@ -17,6 +17,10 @@ This port uses the [SPI](https://docs.kernel.org/spi/spidev.html) and [GPIO](htt
 Examples for this port are in the `examples/linux/spi_devkit` directory.
 
 ## SPI and GPIO Linux Userspace API with native CS
+
+!!! warning
+    This port is experimental. It can be modified or removed in the next release without notice. As such, no examples are provided.
+
 This port uses the [SPI](https://docs.kernel.org/spi/spidev.html) and [GPIO](https://docs.kernel.org/userspace-api/gpio/chardev.html) Linux Userspace API.
 
 The main difference from the [SPI and GPIO Linux Userspace API](#spi-and-gpio-linux-userspace-api) port is that the GPIO is used only for interrupt handling, as the chip select is handled natively by the SPI driver. The main benefit is that no additional GPIO pin is required and no GPIOs are required at all if interrupts are not used. However, more data are transmitted on each transaction, as this port has no custom control over chip select, meaning it needs to transfer whole buffer on each transaction.

--- a/hal/linux/spi_native_cs/CMakeLists.txt
+++ b/hal/linux/spi_native_cs/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.21.0)
+
+set(LT_HAL_SRCS
+    ${CMAKE_CURRENT_SOURCE_DIR}/libtropic_port_linux_spi_native_cs.c
+)
+
+set(LT_HAL_INC_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# export generic names for parent to consume
+set(LT_HAL_SRCS ${LT_HAL_SRCS} PARENT_SCOPE)
+set(LT_HAL_INC_DIRS ${LT_HAL_INC_DIRS} PARENT_SCOPE)

--- a/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.c
+++ b/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.c
@@ -6,6 +6,8 @@
  * @note As this HAL controls CS using SPI driver natively,  whole buffer is transferred each time, which
  * introduces a small overhead.
  *
+ * @warning This HAL is experimental. It can be modified or removed in the next release without notice.
+ *
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 

--- a/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.c
+++ b/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.c
@@ -1,0 +1,315 @@
+/**
+ * @file libtropic_port_linux_spi_native_cs.c
+ * @copyright Copyright (c) 2020-2025 Tropic Square s.r.o.
+ * @brief Port for communication using Generic SPI UAPI with native CS handling and GPIO for interrupt handling.
+ *
+ * @note As this HAL controls CS using SPI driver natively,  whole buffer is transferred each time, which
+ * introduces a small overhead.
+ *
+ * @license For the license see LICENSE.md in the root directory of this source tree.
+ */
+
+// SPI-related includes
+#include <fcntl.h>
+#include <linux/spi/spidev.h>
+#include <linux/types.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+// GPIO-related includes
+#if LT_USE_INT_PIN
+#include <linux/gpio.h>
+#include <poll.h>
+#endif
+
+// Other
+#include <errno.h>
+#include <inttypes.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/random.h>
+
+#include "libtropic_common.h"
+#include "libtropic_logging.h"
+#include "libtropic_macros.h"
+#include "libtropic_port.h"
+#include "libtropic_port_linux_spi_native_cs.h"
+
+lt_ret_t lt_port_init(lt_l2_state_t *s2)
+{
+    lt_dev_linux_spi_native_cs_t *device = (lt_dev_linux_spi_native_cs_t *)(s2->device);
+    const uint32_t request_spi_mode = SPI_MODE_0;
+    lt_ret_t ret = LT_OK;
+
+    device->frame_in_progress = 0;
+    device->frame_completed = 0;
+
+// Initialize file descriptors to -1 so lt_port_deinit() can always execute safely.
+#if LT_USE_INT_PIN
+    device->gpio_fd = -1;
+    device->gpioreq_int.fd = -1;
+#endif
+    device->spi_fd = -1;
+
+    LT_LOG_DEBUG("Initializing SPI...\n");
+    LT_LOG_DEBUG("SPI speed: %d", device->spi_speed);
+    LT_LOG_DEBUG("SPI device: %s", device->spi_dev);
+#if LT_USE_INT_PIN
+    LT_LOG_DEBUG("GPIO device: %s", device->gpio_dev);
+    LT_LOG_DEBUG("GPIO interrupt pin: %d", device->gpio_int_num);
+#endif
+
+    device->spi_fd = open(device->spi_dev, O_RDWR);
+    if (device->spi_fd < 0) {
+        LT_LOG_ERROR("Can't open device!");
+        return LT_FAIL;
+    }
+
+    // Set the SPI mode.
+    if (ioctl(device->spi_fd, SPI_IOC_WR_MODE32, &request_spi_mode) < 0) {
+        LT_LOG_ERROR("Can't set SPI mode!");
+        ret = LT_FAIL;
+        goto spi_error;
+    }
+
+    // Read what SPI mode the device actually is in.
+    uint32_t read_spi_mode;
+    if (ioctl(device->spi_fd, SPI_IOC_RD_MODE32, &read_spi_mode) < 0) {
+        LT_LOG_ERROR("Can't get SPI mode!");
+        ret = LT_FAIL;
+        goto spi_error;
+    }
+    if (request_spi_mode != read_spi_mode) {
+        LT_LOG_ERROR("Device does not support requested mode 0x%" PRIx32, request_spi_mode);
+        ret = LT_FAIL;
+        goto spi_error;
+    }
+
+    if (ioctl(device->spi_fd, SPI_IOC_WR_MAX_SPEED_HZ, &device->spi_speed) < 0) {
+        LT_LOG_ERROR("Can't set max SPI speed.");
+        ret = LT_FAIL;
+        goto spi_error;
+    }
+
+#if LT_USE_INT_PIN
+    device->gpio_fd = open(device->gpio_dev, O_RDWR | O_CLOEXEC);
+    if (device->gpio_fd < 0) {
+        LT_LOG_ERROR("Can't open GPIO device!");
+        ret = LT_FAIL;
+        goto spi_error;
+    }
+
+    struct gpiochip_info info;
+    if (ioctl(device->gpio_fd, GPIO_GET_CHIPINFO_IOCTL, &info) < 0) {
+        LT_LOG_ERROR("GPIO_GET_CHIPINFO_IOCTL error!");
+        LT_LOG_ERROR("Error string: %s", strerror(errno));
+        ret = LT_FAIL;
+        goto gpio_error;
+    }
+
+    LT_LOG_DEBUG("GPIO chip information:");
+    LT_LOG_DEBUG("- info.name  = \"%s\"", info.name);
+    LT_LOG_DEBUG("- info.label = \"%s\"", info.label);
+    LT_LOG_DEBUG("- info.lines = \"%u\"", info.lines);
+
+    // Setup for INT pin (INPUT, RISING EDGE)
+    device->gpioreq_int.offsets[0] = device->gpio_int_num;
+    device->gpioreq_int.num_lines = 1;
+    // Configure as input with rising edge detection
+    device->gpioreq_int.config.flags = GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_EDGE_RISING;
+
+    if (ioctl(device->gpio_fd, GPIO_V2_GET_LINE_IOCTL, &device->gpioreq_int) < 0) {
+        LT_LOG_ERROR("GPIO_V2_GET_LINE_IOCTL (INT pin) error!");
+        LT_LOG_ERROR("Error string: %s", strerror(errno));
+        ret = LT_FAIL;
+        goto gpio_error;
+    }
+#endif
+
+    return LT_OK;
+
+#if LT_USE_INT_PIN
+gpio_error:
+    close(device->gpio_fd);
+    device->gpio_fd = -1;
+#endif
+
+spi_error:
+    close(device->spi_fd);
+    device->spi_fd = -1;
+
+    return ret;
+}
+
+lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
+{
+    lt_dev_linux_spi_native_cs_t *device = (lt_dev_linux_spi_native_cs_t *)(s2->device);
+
+    close(device->spi_fd);
+    device->spi_fd = -1;
+
+#if LT_USE_INT_PIN
+    close(device->gpioreq_int.fd);
+    close(device->gpio_fd);
+    device->gpioreq_int.fd = -1;
+    device->gpio_fd = -1;
+#endif
+
+    return LT_OK;
+}
+
+lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
+{
+    lt_dev_linux_spi_native_cs_t *device = (lt_dev_linux_spi_native_cs_t *)(s2->device);
+
+    device->frame_in_progress = 1;
+    device->frame_completed = 0;
+
+    return LT_OK;
+}
+
+lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
+{
+    lt_dev_linux_spi_native_cs_t *device = (lt_dev_linux_spi_native_cs_t *)(s2->device);
+
+    device->frame_in_progress = 0;
+
+    return LT_OK;
+}
+
+lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length, uint32_t timeout_ms)
+{
+    LT_UNUSED(offset);
+    LT_UNUSED(tx_data_length);
+    LT_UNUSED(timeout_ms);
+    lt_dev_linux_spi_native_cs_t *device = (lt_dev_linux_spi_native_cs_t *)(s2->device);
+
+    if (!device->frame_in_progress) {
+        LT_LOG_ERROR("lt_port_spi_transfer: No transfer in progress (spi_transfer called before csn_low)!");
+        return LT_L1_SPI_ERROR;
+    }
+
+    if (device->frame_completed) {
+        return LT_OK;
+    }
+
+    int ret = 0;
+    struct spi_ioc_transfer spi = {
+        .tx_buf = (unsigned long)s2->buff,
+        .rx_buf = (unsigned long)s2->buff,
+        .len = TR01_L1_LEN_MAX,  // We always read whole buffer at once.
+        .delay_usecs = 0,
+    };
+
+    ret = ioctl(device->spi_fd, SPI_IOC_MESSAGE(1), &spi);
+    if (ret >= 0) {
+        device->frame_completed = 1;
+        return LT_OK;
+    }
+    return LT_L1_SPI_ERROR;
+}
+
+lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
+{
+    LT_UNUSED(s2);
+
+    int ret = usleep(ms * 1000);
+    if (ret != 0) {
+        LT_LOG_ERROR("lt_port_delay: usleep() failed: %s (%d)", strerror(errno), ret);
+        return LT_L1_SPI_ERROR;
+    }
+
+    return LT_OK;
+}
+
+lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
+{
+    LT_UNUSED(s2);
+
+    ssize_t ret = getrandom(buff, count, 0);
+
+    if (ret < 0) {
+        LT_LOG_ERROR("lt_port_random_bytes: getrandom() failed (%s)!", strerror(errno));
+        return LT_FAIL;
+    }
+
+    if ((size_t)ret != count) {
+        LT_LOG_ERROR("lt_port_random_bytes: getrandom() generated %zd bytes instead of requested %zu bytes!", ret,
+                     count);
+        return LT_FAIL;
+    }
+
+    return LT_OK;
+}
+
+#if LT_USE_INT_PIN
+lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms)
+{
+    lt_dev_linux_spi_native_cs_t *device = (lt_dev_linux_spi_native_cs_t *)(s2->device);
+    struct pollfd pfd;
+    int ret;
+
+    // Set up the poll structure
+    pfd.fd = device->gpioreq_int.fd;
+    pfd.events = POLLIN | POLLPRI;  // Wait for data or priority event (GPIO edge)
+    pfd.revents = 0;
+
+    LT_LOG_DEBUG("lt_port_delay_on_int: Polling on INT pin (fd: %d) for %u ms...", pfd.fd, ms);
+
+    // Wait for the event or timeout
+    ret = poll(&pfd, 1, (int)ms);
+
+    if (ret < 0) {
+        LT_LOG_ERROR("lt_port_delay_on_int: poll() failed: %s", strerror(errno));
+        return LT_FAIL;
+    }
+
+    if (ret == 0) {
+        LT_LOG_WARN("lt_port_delay_on_int: Timeout waiting for INT pin.");
+        return LT_L1_INT_TIMEOUT;
+    }
+
+    // Event occurred, check if it's the right type
+    if (pfd.revents & (POLLIN | POLLPRI)) {
+        // Event is ready. We MUST read it to consume it, otherwise poll()
+        // will return immediately on the next call.
+        struct gpio_v2_line_event event;
+        ret = read(pfd.fd, &event, sizeof(event));
+
+        if (ret < 0) {
+            LT_LOG_ERROR("lt_port_delay_on_int: read() on INT pin failed: %s", strerror(errno));
+            return LT_FAIL;
+        }
+
+        if (ret != sizeof(event)) {
+            LT_LOG_ERROR("lt_port_delay_on_int: read() on INT pin returned unexpected size: %d", ret);
+            return LT_FAIL;
+        }
+
+        // Since we only configured for RISING_EDGE, any event is the one we want.
+        // event.id == GPIO_V2_LINE_EVENT_RISING_EDGE
+        LT_LOG_DEBUG("lt_port_delay_on_int: Interrupt received!");
+        return LT_OK;
+    }
+
+    LT_LOG_ERROR("lt_port_delay_on_int: Poll returned positive but no expected revents.");
+    return LT_FAIL;
+}
+#endif
+
+int lt_port_log(const char *format, ...)
+{
+    va_list args;
+    int ret;
+
+    va_start(args, format);
+    ret = vfprintf(stderr, format, args);
+    fflush(stderr);
+    va_end(args);
+
+    return ret;
+}

--- a/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.c
+++ b/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.c
@@ -220,7 +220,7 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
     int ret = usleep(ms * 1000);
     if (ret != 0) {
         LT_LOG_ERROR("lt_port_delay: usleep() failed: %s (%d)", strerror(errno), ret);
-        return LT_L1_SPI_ERROR;
+        return LT_FAIL;
     }
 
     return LT_OK;

--- a/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.h
+++ b/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.h
@@ -1,0 +1,77 @@
+#ifndef LIBTROPIC_PORT_LINUX_SPI_NATIVE_CS_H
+#define LIBTROPIC_PORT_LINUX_SPI_NATIVE_CS_H
+
+/**
+ * @file libtropic_port_linux_spi_native_cs.h
+ * @copyright Copyright (c) 2020-2025 Tropic Square s.r.o.
+ * @brief Port for communication using Generic SPI UAPI with native CS handling and GPIO UAPI for interrupt handling.
+ *
+ * @license For the license see LICENSE.md in the root directory of this source tree.
+ */
+
+#if LT_USE_INT_PIN
+#include <linux/gpio.h>
+#endif
+
+#include "libtropic_port.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Device structure for Linux SPI port with native CS handling.
+ *
+ * @note Public members are meant to be configured by the developer before passing the handle to
+ *       Libtropic.
+ */
+typedef struct lt_dev_linux_spi_native_cs_t {
+    /** @public @brief SPI speed in Hz. */
+    int spi_speed;
+    /** @public @brief Path to the SPI device. */
+    char spi_dev[LT_DEVICE_PATH_MAX_LEN];
+#if LT_USE_INT_PIN
+    /** @public @brief Path to the GPIO device. */
+    char gpio_dev[LT_DEVICE_PATH_MAX_LEN];
+    /** @public @brief Number of the GPIO pin to map interrupt pin to. */
+    int gpio_int_num;
+#endif
+
+    /** @private @brief SPI file descriptor. */
+    int spi_fd;
+#if LT_USE_INT_PIN
+    /** @private @brief GPIO file descriptor. */
+    int gpio_fd;
+    /** @private @brief GPIO request structure for interrupt pin. */
+    struct gpio_v2_line_request gpioreq_int;
+#endif
+
+    /** @private @brief True if frame transfer is in progress.
+     * This tracks the state of "virtual CS", which is toggled by lt_port_spi_csn_* functions.
+     * Those functions do not do anything except setting transfer variables, which allows
+     * us to track if the current frame was finished or Libtropic still reads data
+     * from preloaded buffer.
+     *
+     * This variable is useful only to keep track of actual lt_port_spi_transfer usage in Libtropic.
+     * If the L1 implementation in Libtropic would ever change to make this HAL incompatible,
+     * it would be immediately discovered.
+     */
+    int frame_in_progress;
+
+    /** @private @brief True if lt_port_spi_transfer was already called during current frame. If true,
+     * lt_port_spi_transfer does not do any communication and immediately returns.
+     *
+     * Normally, Libtropic transfers frame by parts. E.g., it first transfers 1 byte to receive CHIP_STATUS.
+     * This is possible thanks to separate CS handling. In this HAL, separate CS is not available and as such
+     * we have to transfer whole buffer (even though actual frame may be smaller) at once. Hence only single SPI
+     * transfer is done.
+     */
+    int frame_completed;
+
+} lt_dev_linux_spi_native_cs_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LIBTROPIC_PORT_LINUX_SPI_NATIVE_CS_H

--- a/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.h
+++ b/hal/linux/spi_native_cs/libtropic_port_linux_spi_native_cs.h
@@ -6,6 +6,8 @@
  * @copyright Copyright (c) 2020-2025 Tropic Square s.r.o.
  * @brief Port for communication using Generic SPI UAPI with native CS handling and GPIO UAPI for interrupt handling.
  *
+ * @warning This HAL is experimental. It can be modified or removed in the next release without notice.
+ *
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 

--- a/tests/functional/linux/spi_native_cs/CMakeLists.txt
+++ b/tests/functional/linux/spi_native_cs/CMakeLists.txt
@@ -1,0 +1,129 @@
+cmake_minimum_required(VERSION 3.21.0)
+if (${CMAKE_VERSION} VERSION_GREATER "3.27")
+    cmake_policy(SET CMP0152 OLD) # Path resolution policy
+endif()
+
+###########################################################################
+#                                                                         #
+#   Define project's name                                                 #
+#                                                                         #
+###########################################################################
+project(libtropic_functional_tests_linux_spi_native_cs
+        VERSION 0.1.0
+        DESCRIPTION "Functional tests in Linux environment using SPI driver with native CS"
+        LANGUAGES C)
+
+###########################################################################
+#                                                                         #
+#   Paths and setup                                                       #
+#                                                                         #
+###########################################################################
+file(REAL_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../_deps/ PATH_DEPS)
+file(REAL_PATH ../../../../ PATH_LIBTROPIC)
+file(REAL_PATH ../../src PATH_FN_TESTS)
+
+if (NOT EXISTS ${PATH_DEPS})
+    message(FATAL_ERROR "Dependencies not installed. Please run download_deps.sh!")
+endif()
+
+###########################################################################
+#                                                                         #
+#   Options and user configuration                                        #
+#                                                                         #
+###########################################################################
+
+if (NOT DEFINED LT_SPI_DEVKIT_SPI_PATH)
+    set(LT_SPI_DEVKIT_SPI_PATH "/dev/spidev0.0" CACHE STRING "Path to the SPI device to which the SPI devkit is connected.")
+endif()
+message(STATUS "Using SPI device: ${LT_SPI_DEVKIT_SPI_PATH}. You can change it by passing -DLT_SPI_DEVKIT_SPI_PATH=<path> to cmake.")
+
+if (NOT DEFINED LT_SPI_DEVKIT_GPIO_PATH)
+    set(LT_SPI_DEVKIT_GPIO_PATH "/dev/gpiochip0" CACHE STRING "Path to the GPIO device to which the SPI devkit's CS is connected.")
+endif()
+message(STATUS "Using GPIO device: ${LT_SPI_DEVKIT_GPIO_PATH}. You can change it by passing -DLT_SPI_DEVKIT_GPIO_PATH=<path> to cmake.")
+
+# Optional prefix to tests registered to CTest. Useful when running same test against
+# different chips to differentiate them by their name in JUnit output.
+if (NOT DEFINED CTEST_PREFIX)
+    set(CTEST_PREFIX "")
+endif()
+
+# This option will make CTest execute test binaries with Valgrind.
+option(LT_VALGRIND "Enable Valgrind" OFF)
+
+###########################################################################
+#                                                                         #
+#   Add libtropic library and set it up                                   #
+#                                                                         #
+###########################################################################
+
+# Add path to libtropic's repository root folder
+add_subdirectory(${PATH_FN_TESTS} "libtropic_functional_tests")
+
+###########################################################################
+#                                                                         #
+#   SOURCES                                                               #
+#   Define project sources.                                               #
+#                                                                         #
+###########################################################################
+
+# Add SPI HAL
+add_subdirectory("${PATH_LIBTROPIC}/hal/linux/spi_native_cs" "linux_spi_native_cs_hal")
+target_sources(tropic PRIVATE ${LT_HAL_SRCS})
+target_include_directories(tropic PUBLIC ${LT_HAL_INC_DIRS})
+
+set(SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.c
+)
+
+# Enable strict compile flags for main.c and Libtropic HAL sources
+if(LT_STRICT_COMPILATION)
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
+endif()
+
+###########################################################################
+#                                                                         #
+# FUNCTIONAL TESTS CONFIGURATION                                          #
+#                                                                         #
+# This section will automatically configure CTest for launching tests     #
+# defined in libtropic. Do NOT hardcode any test definitions here.        #
+# Define them in common CMakeLists.txt for functional tests.              #
+#                                                                         #
+###########################################################################
+# Enable CTest.
+enable_testing()
+
+# Loop through tests defined in libtropic and prepare environment.
+foreach(test_name IN LISTS LIBTROPIC_TEST_LIST)
+    # Create a correct macro from test name.
+    string(TOUPPER ${test_name} test_macro)
+    string(REPLACE " " "_" test_macro ${test_macro})
+
+    set(exe_name ${test_name})
+
+    # Define executable (separate for each test) and link dependencies.
+    add_executable(${exe_name} ${SOURCES})
+    target_link_libraries(${exe_name} PRIVATE libtropic_functional_tests)
+
+    # Choose correct test for the binary.
+    target_compile_definitions(${exe_name} PRIVATE ${test_macro})
+    target_compile_definitions(${exe_name} PRIVATE LT_SPI_DEVKIT_SPI_PATH=\"${LT_SPI_DEVKIT_SPI_PATH}\")
+    target_compile_definitions(${exe_name} PRIVATE LT_SPI_DEVKIT_GPIO_PATH=\"${LT_SPI_DEVKIT_GPIO_PATH}\")
+
+    if(CTEST_PREFIX STREQUAL "")
+        set(TEST_NAME_WITH_PREFIX ${test_name})
+    else()
+        set(TEST_NAME_WITH_PREFIX ${CTEST_PREFIX}_${test_name})
+    endif()
+
+    # Add CTest entry.
+    if (LT_VALGRIND)
+        add_test(NAME ${TEST_NAME_WITH_PREFIX}
+                COMMAND valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --error-exitcode=1 stdbuf -oL -eL ${CMAKE_CURRENT_BINARY_DIR}/${exe_name}
+        )
+    else()
+        add_test(NAME ${TEST_NAME_WITH_PREFIX}
+                COMMAND stdbuf -oL -eL ${CMAKE_CURRENT_BINARY_DIR}/${exe_name}
+        )
+    endif()
+endforeach()

--- a/tests/functional/linux/spi_native_cs/CMakeLists.txt
+++ b/tests/functional/linux/spi_native_cs/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 message(STATUS "Using SPI device: ${LT_SPI_DEV_PATH}. You can change it by passing -DLT_SPI_DEV_PATH=<path> to cmake.")
 
 if (NOT DEFINED LT_GPIO_DEV_PATH)
-    set(LT_GPIO_DEV_PATH "/dev/gpiochip0" CACHE STRING "Path to the GPIO device that provides the SPI devkit's interrupt (INT) line.")
+    set(LT_GPIO_DEV_PATH "/dev/gpiochip0" CACHE STRING "Path to the GPIO device that provides the TROPIC01's interrupt (INT) line.")
 endif()
 message(STATUS "Using GPIO device: ${LT_GPIO_DEV_PATH}. You can change it by passing -DLT_GPIO_DEV_PATH=<path> to cmake.")
 

--- a/tests/functional/linux/spi_native_cs/CMakeLists.txt
+++ b/tests/functional/linux/spi_native_cs/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 message(STATUS "Using SPI device: ${LT_SPI_DEVKIT_SPI_PATH}. You can change it by passing -DLT_SPI_DEVKIT_SPI_PATH=<path> to cmake.")
 
 if (NOT DEFINED LT_SPI_DEVKIT_GPIO_PATH)
-    set(LT_SPI_DEVKIT_GPIO_PATH "/dev/gpiochip0" CACHE STRING "Path to the GPIO device to which the SPI devkit's CS is connected.")
+    set(LT_SPI_DEVKIT_GPIO_PATH "/dev/gpiochip0" CACHE STRING "Path to the GPIO device that provides the SPI devkit's interrupt (INT) line.")
 endif()
 message(STATUS "Using GPIO device: ${LT_SPI_DEVKIT_GPIO_PATH}. You can change it by passing -DLT_SPI_DEVKIT_GPIO_PATH=<path> to cmake.")
 

--- a/tests/functional/linux/spi_native_cs/CMakeLists.txt
+++ b/tests/functional/linux/spi_native_cs/CMakeLists.txt
@@ -32,15 +32,15 @@ endif()
 #                                                                         #
 ###########################################################################
 
-if (NOT DEFINED LT_SPI_DEVKIT_SPI_PATH)
-    set(LT_SPI_DEVKIT_SPI_PATH "/dev/spidev0.0" CACHE STRING "Path to the SPI device to which the SPI devkit is connected.")
+if (NOT DEFINED LT_SPI_DEV_PATH)
+    set(LT_SPI_DEV_PATH "/dev/spidev0.0" CACHE STRING "Path to the SPI device to which the SPI devkit is connected.")
 endif()
-message(STATUS "Using SPI device: ${LT_SPI_DEVKIT_SPI_PATH}. You can change it by passing -DLT_SPI_DEVKIT_SPI_PATH=<path> to cmake.")
+message(STATUS "Using SPI device: ${LT_SPI_DEV_PATH}. You can change it by passing -DLT_SPI_DEV_PATH=<path> to cmake.")
 
-if (NOT DEFINED LT_SPI_DEVKIT_GPIO_PATH)
-    set(LT_SPI_DEVKIT_GPIO_PATH "/dev/gpiochip0" CACHE STRING "Path to the GPIO device that provides the SPI devkit's interrupt (INT) line.")
+if (NOT DEFINED LT_GPIO_DEV_PATH)
+    set(LT_GPIO_DEV_PATH "/dev/gpiochip0" CACHE STRING "Path to the GPIO device that provides the SPI devkit's interrupt (INT) line.")
 endif()
-message(STATUS "Using GPIO device: ${LT_SPI_DEVKIT_GPIO_PATH}. You can change it by passing -DLT_SPI_DEVKIT_GPIO_PATH=<path> to cmake.")
+message(STATUS "Using GPIO device: ${LT_GPIO_DEV_PATH}. You can change it by passing -DLT_GPIO_DEV_PATH=<path> to cmake.")
 
 # Optional prefix to tests registered to CTest. Useful when running same test against
 # different chips to differentiate them by their name in JUnit output.
@@ -107,8 +107,8 @@ foreach(test_name IN LISTS LIBTROPIC_TEST_LIST)
 
     # Choose correct test for the binary.
     target_compile_definitions(${exe_name} PRIVATE ${test_macro})
-    target_compile_definitions(${exe_name} PRIVATE LT_SPI_DEVKIT_SPI_PATH=\"${LT_SPI_DEVKIT_SPI_PATH}\")
-    target_compile_definitions(${exe_name} PRIVATE LT_SPI_DEVKIT_GPIO_PATH=\"${LT_SPI_DEVKIT_GPIO_PATH}\")
+    target_compile_definitions(${exe_name} PRIVATE LT_SPI_DEV_PATH=\"${LT_SPI_DEV_PATH}\")
+    target_compile_definitions(${exe_name} PRIVATE LT_GPIO_DEV_PATH=\"${LT_GPIO_DEV_PATH}\")
 
     if(CTEST_PREFIX STREQUAL "")
         set(TEST_NAME_WITH_PREFIX ${test_name})

--- a/tests/functional/linux/spi_native_cs/CMakeLists.txt
+++ b/tests/functional/linux/spi_native_cs/CMakeLists.txt
@@ -78,7 +78,7 @@ set(SOURCES
 
 # Enable strict compile flags for main.c and Libtropic HAL sources
 if(LT_STRICT_COMPILATION)
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
+    set_source_files_properties(${SOURCES} ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
 endif()
 
 ###########################################################################

--- a/tests/functional/linux/spi_native_cs/CMakeLists.txt
+++ b/tests/functional/linux/spi_native_cs/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 ###########################################################################
 
 if (NOT DEFINED LT_SPI_DEV_PATH)
-    set(LT_SPI_DEV_PATH "/dev/spidev0.0" CACHE STRING "Path to the SPI device to which the SPI devkit is connected.")
+    set(LT_SPI_DEV_PATH "/dev/spidev0.0" CACHE STRING "Path to the SPI device where TROPIC01 is connected.")
 endif()
 message(STATUS "Using SPI device: ${LT_SPI_DEV_PATH}. You can change it by passing -DLT_SPI_DEV_PATH=<path> to cmake.")
 

--- a/tests/functional/linux/spi_native_cs/main.c
+++ b/tests/functional/linux/spi_native_cs/main.c
@@ -1,0 +1,82 @@
+/**
+ * @file main.c
+ * @author Tropic Square s.r.o.
+ *
+ * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ */
+
+#include <string.h>
+#include <time.h>
+
+#include "libtropic.h"
+#include "libtropic_common.h"
+#include "libtropic_functional_tests.h"
+#include "libtropic_logging.h"
+#include "libtropic_port_linux_spi_native_cs.h"
+
+#if LT_USE_TREZOR_CRYPTO
+#include "libtropic_trezor_crypto.h"
+#elif LT_USE_MBEDTLS_V4
+#include "libtropic_mbedtls_v4.h"
+#include "psa/crypto.h"
+#elif LT_USE_OPENSSL
+#include "libtropic_openssl.h"
+#endif
+
+int main(void)
+{
+    int ret = 0;
+
+    // CFP initialization
+#if LT_USE_MBEDTLS_V4
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        LT_LOG_ERROR("PSA Crypto initialization failed, status=%d (psa_status_t)", status);
+        return -1;
+    }
+#endif
+
+    // Handle initialization
+    lt_handle_t lt_handle = {0};
+#if LT_SEPARATE_L3_BUFF
+    uint8_t l3_buffer[LT_SIZE_OF_L3_BUFF] __attribute__((aligned(16))) = {0};
+    lt_handle.l3.buff = l3_buffer;
+    lt_handle.l3.buff_len = sizeof(l3_buffer);
+#endif
+
+    // Device mappings
+    lt_dev_linux_spi_native_cs_t device = {0};
+    strcpy(device.spi_dev,
+           LT_SPI_DEVKIT_SPI_PATH);  // LT_SPI_DEVKIT_SPI_PATH is defined in CMakeLists.txt. Pass
+                                     // -DLT_SPI_DEVKIT_SPI_PATH=<path> to cmake if you want to change it.
+    device.spi_speed = 5000000;      // 5 MHz (change if needed).
+#if LT_USE_INT_PIN
+    strcpy(device.gpio_dev,
+           LT_SPI_DEVKIT_GPIO_PATH);  // LT_SPI_DEVKIT_GPIO_PATH is defined in CMakeLists.txt. Pass
+                                      // -DLT_SPI_DEVKIT_GPIO_PATH=<path> to cmake if you want to change it.
+    device.gpio_int_num = 5;  // GPIO 5 as on RPi shield.
+#endif
+    lt_handle.l2.device = &device;
+
+    // CAL context (selectable)
+#if LT_USE_TREZOR_CRYPTO
+    lt_ctx_trezor_crypto_t
+#elif LT_USE_MBEDTLS_V4
+    lt_ctx_mbedtls_v4_t
+#elif LT_USE_OPENSSL
+    lt_ctx_openssl_t
+#endif
+        crypto_ctx;
+    lt_handle.l3.crypto_ctx = &crypto_ctx;
+
+    // Test code (correct test function is selected automatically per binary).
+    // __lt_handle__ identifier is used by the test registry.
+    lt_handle_t *__lt_handle__ = &lt_handle;
+#include "lt_test_registry.c.inc"
+
+#if LT_USE_MBEDTLS_V4
+    mbedtls_psa_crypto_free();
+#endif
+
+    return ret;
+}

--- a/tests/functional/linux/spi_native_cs/main.c
+++ b/tests/functional/linux/spi_native_cs/main.c
@@ -54,7 +54,7 @@ int main(void)
     strcpy(device.gpio_dev,
            LT_SPI_DEVKIT_GPIO_PATH);  // LT_SPI_DEVKIT_GPIO_PATH is defined in CMakeLists.txt. Pass
                                       // -DLT_SPI_DEVKIT_GPIO_PATH=<path> to cmake if you want to change it.
-    device.gpio_int_num = 5;  // GPIO 5 as on RPi shield.
+    device.gpio_int_num = 5;          // GPIO 5 as on RPi shield.
 #endif
     lt_handle.l2.device = &device;
 


### PR DESCRIPTION
## Description

In this PR, I add a new HAL for Linux which utilizes native CS handling instead of using GPIO.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage
