### PR TITLE
ETR01SDK-529: Fix buffering of examples

### DIFF
--- a/examples/linux/spi_devkit/fw_update/main.c
+++ b/examples/linux/spi_devkit/fw_update/main.c
@@ -45,8 +45,8 @@ lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/linux/spi_devkit/fw_update/main.c
+++ b/examples/linux/spi_devkit/fw_update/main.c
@@ -45,7 +45,7 @@ lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/linux/spi_devkit/fw_update/main.c
+++ b/examples/linux/spi_devkit/fw_update/main.c
@@ -45,6 +45,11 @@ lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("==========================================\n");
     printf("==== TROPIC01 Firmware Update Example ====\n");
     printf("==========================================\n");

--- a/examples/linux/spi_devkit/hello_world/main.c
+++ b/examples/linux/spi_devkit/hello_world/main.c
@@ -32,7 +32,7 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/linux/spi_devkit/hello_world/main.c
+++ b/examples/linux/spi_devkit/hello_world/main.c
@@ -32,8 +32,8 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/linux/spi_devkit/hello_world/main.c
+++ b/examples/linux/spi_devkit/hello_world/main.c
@@ -32,6 +32,11 @@
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("======================================\n");
     printf("==== TROPIC01 Hello World Example ====\n");
     printf("======================================\n");

--- a/examples/linux/spi_devkit/identify_chip/main.c
+++ b/examples/linux/spi_devkit/identify_chip/main.c
@@ -18,8 +18,8 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/linux/spi_devkit/identify_chip/main.c
+++ b/examples/linux/spi_devkit/identify_chip/main.c
@@ -18,7 +18,7 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/linux/spi_devkit/identify_chip/main.c
+++ b/examples/linux/spi_devkit/identify_chip/main.c
@@ -18,6 +18,11 @@
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("==============================================\n");
     printf("==== TROPIC01 Chip Identification Example ====\n");
     printf("==============================================\n");

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -45,8 +45,8 @@ lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -45,7 +45,7 @@ lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -45,6 +45,11 @@ lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("==========================================\n");
     printf("==== TROPIC01 Firmware Update Example ====\n");
     printf("==========================================\n");

--- a/examples/linux/usb_devkit/hello_world/main.c
+++ b/examples/linux/usb_devkit/hello_world/main.c
@@ -32,7 +32,7 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/linux/usb_devkit/hello_world/main.c
+++ b/examples/linux/usb_devkit/hello_world/main.c
@@ -32,8 +32,8 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/linux/usb_devkit/hello_world/main.c
+++ b/examples/linux/usb_devkit/hello_world/main.c
@@ -32,6 +32,11 @@
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("======================================\n");
     printf("==== TROPIC01 Hello World Example ====\n");
     printf("======================================\n");

--- a/examples/linux/usb_devkit/identify_chip/main.c
+++ b/examples/linux/usb_devkit/identify_chip/main.c
@@ -18,8 +18,8 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/linux/usb_devkit/identify_chip/main.c
+++ b/examples/linux/usb_devkit/identify_chip/main.c
@@ -18,7 +18,7 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/linux/usb_devkit/identify_chip/main.c
+++ b/examples/linux/usb_devkit/identify_chip/main.c
@@ -18,6 +18,11 @@
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("==============================================\n");
     printf("==== TROPIC01 Chip Identification Example ====\n");
     printf("==============================================\n");

--- a/examples/model/hello_world/main.c
+++ b/examples/model/hello_world/main.c
@@ -31,7 +31,7 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/model/hello_world/main.c
+++ b/examples/model/hello_world/main.c
@@ -31,8 +31,8 @@
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/model/hello_world/main.c
+++ b/examples/model/hello_world/main.c
@@ -31,6 +31,11 @@
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("======================================\n");
     printf("==== TROPIC01 Hello World Example ====\n");
     printf("======================================\n");

--- a/examples/model/hw_wallet/main.c
+++ b/examples/model/hw_wallet/main.c
@@ -793,7 +793,7 @@ static int session3(lt_handle_t *h)
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/model/hw_wallet/main.c
+++ b/examples/model/hw_wallet/main.c
@@ -793,8 +793,8 @@ static int session3(lt_handle_t *h)
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/model/hw_wallet/main.c
+++ b/examples/model/hw_wallet/main.c
@@ -793,6 +793,11 @@ static int session3(lt_handle_t *h)
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("==========================================\n");
     printf("==== TROPIC01 Hardware Wallet Example ====\n");
     printf("==========================================\n");

--- a/examples/model/mac_and_destroy/main.c
+++ b/examples/model/mac_and_destroy/main.c
@@ -523,8 +523,8 @@ exit:
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
-    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 

--- a/examples/model/mac_and_destroy/main.c
+++ b/examples/model/mac_and_destroy/main.c
@@ -523,7 +523,7 @@ exit:
 
 int main(void)
 {
-    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care about
     // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/examples/model/mac_and_destroy/main.c
+++ b/examples/model/mac_and_destroy/main.c
@@ -523,6 +523,11 @@ exit:
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do in your app if you don't care about
+    // stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("==========================================\n");
     printf("==== TROPIC01 Mac and Destroy Example ====\n");
     printf("==========================================\n");

--- a/examples/model/separate_api/main.c
+++ b/examples/model/separate_api/main.c
@@ -33,6 +33,11 @@
 
 int main(void)
 {
+    // Cosmetics: Disable buffering to keep output in order. You do not need to do this in your app if you don't care
+    // about stdout/stderr output being shuffled or you use stdout only (or different output mechanism altogether).
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     printf("========================================\n");
     printf("====  TROPIC01 Separate API Example ====\n");
     printf("========================================\n");


### PR DESCRIPTION
## Description

In this PR, I fix buffering of examples on Linux and model.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage