### PR TITLE
ETR01SDK-535: Add LT_USB_DEVKIT_PATH length check to all examples

### DIFF
--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -77,8 +77,17 @@ int main(void)
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
     lt_dev_posix_usb_dongle_t device = {0};
-    strcpy(device.dev_path, LT_USB_DEVKIT_PATH);  // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass
-                                                  // -DLT_USB_DEVKIT_PATH=<path> to cmake if you want to change it.
+
+    // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
+    // to cmake if you want to change it.
+    int dev_path_len = snprintf(device.dev_path, sizeof(device.dev_path), "%s", LT_USB_DEVKIT_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.dev_path)) {
+        fprintf(stderr, "Error: LT_USB_DEVKIT_PATH is too long for device.dev_path buffer (limit is %zu bytes).\n",
+                sizeof(device.dev_path));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     device.baud_rate = 115200;
     lt_handle.l2.device = &device;
 

--- a/examples/linux/usb_devkit/hello_world/main.c
+++ b/examples/linux/usb_devkit/hello_world/main.c
@@ -64,8 +64,17 @@ int main(void)
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
     lt_dev_posix_usb_dongle_t device = {0};
-    strcpy(device.dev_path, LT_USB_DEVKIT_PATH);  // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass
-                                                  // -DLT_USB_DEVKIT_PATH=<path> to cmake if you want to change it.
+
+    // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
+    // to cmake if you want to change it.
+    int dev_path_len = snprintf(device.dev_path, sizeof(device.dev_path), "%s", LT_USB_DEVKIT_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.dev_path)) {
+        fprintf(stderr, "Error: LT_USB_DEVKIT_PATH is too long for device.dev_path buffer (limit is %zu bytes).\n",
+                sizeof(device.dev_path));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     device.baud_rate = 115200;
     lt_handle.l2.device = &device;
 

--- a/examples/linux/usb_devkit/identify_chip/main.c
+++ b/examples/linux/usb_devkit/identify_chip/main.c
@@ -50,8 +50,17 @@ int main(void)
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
     lt_dev_posix_usb_dongle_t device = {0};
-    strcpy(device.dev_path, LT_USB_DEVKIT_PATH);  // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass
-                                                  // -DLT_USB_DEVKIT_PATH=<path> to cmake if you want to change it.
+
+    // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
+    // to cmake if you want to change it.
+    int dev_path_len = snprintf(device.dev_path, sizeof(device.dev_path), "%s", LT_USB_DEVKIT_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.dev_path)) {
+        fprintf(stderr, "Error: LT_USB_DEVKIT_PATH is too long for device.dev_path buffer (limit is %zu bytes).\n",
+                sizeof(device.dev_path));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     device.baud_rate = 115200;
     lt_handle.l2.device = &device;
 


### PR DESCRIPTION
## Description

In this PR, I add a length check of the LT_USB_DEVKIT_PATH CMake option in USB DevKit examples.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage