### PR TITLE
doc: fix grammar and standardize support URLs across tutorials

### DIFF
--- a/docs/common/examples_descriptions/identify_chip.md
+++ b/docs/common/examples_descriptions/identify_chip.md
@@ -1,4 +1,4 @@
-This example demonstrates how to read and display the chip’s unique ID and firmware version information (bootloader, application and SPECT firmware versions). You will learn about following functions:
+This example demonstrates how to read and display the chip’s unique ID and firmware version information (bootloader, application and SPECT firmware versions). You will learn about the following functions:
 
 - `lt_reboot()`: L2 request to reboot to either Application or Maintenance Mode,
 - `lt_get_info_riscv_fw_ver()`, `lt_get_info_spect_fw_ver()`: L2 requests to read RISC-V CPU and SPECT firmware versions,

--- a/docs/tutorials/esp32/index.md
+++ b/docs/tutorials/esp32/index.md
@@ -16,7 +16,7 @@ For the purpose of these tutorials, we will use our TROPIC01 Arduino Shield:
 You can get TROPIC01 Arduino Shield and other devkits [here](https://www.tropicsquare.com/order-devkit).
 
 ### Your ESP32 Board
-Unfortunately, ESP32 boards and our Arduino shield are not a plug-and-play, so, please, prepare some jump wires and use the figure above with Arduino Shield Pinout to help you during the setup. Follow the connection instructions for your ESP32 board below:
+Unfortunately, ESP32 boards and our Arduino shield are not plug-and-play, so please prepare some jump wires and use the figure above with Arduino Shield Pinout to help you during the setup. Follow the connection instructions for your ESP32 board below:
 !!! example "Connection Instructions"
     === "ESP32-DevKitC-V4"
         ESP32-DevKitC-V4 pin layout [here](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32/_images/esp32_devkitC_v4_pinlayout.png).
@@ -99,4 +99,4 @@ See below for instructions based on your OS:
 3. [Hello, World!](hello_world.md)
 
 ## FAQ
-If you encounter any issues, please check the [FAQ](../../faq.md) before filing an issue or reaching out to our [support](https://support.desk.tropicsquare.com/).
+If you encounter any issues, please check the [FAQ](../../faq.md) before filing an issue or reaching out to our [support](https://support.tropicsquare.com/).

--- a/docs/tutorials/linux/spi/index.md
+++ b/docs/tutorials/linux/spi/index.md
@@ -61,4 +61,4 @@ After that, setup your system:
 3. [Hello, World!](hello_world.md)
 
 ## FAQ
-If you encounter any issues, please check the [FAQ](../../../faq.md) before filing an issue or reaching out to our [support](https://support.desk.tropicsquare.com/).
+If you encounter any issues, please check the [FAQ](../../../faq.md) before filing an issue or reaching out to our [support](https://support.tropicsquare.com/).

--- a/docs/tutorials/linux/usb_devkit/full_chain_verification.md
+++ b/docs/tutorials/linux/usb_devkit/full_chain_verification.md
@@ -73,7 +73,7 @@ After loading the certificates from the TROPIC01 chip, we will verify the certif
         TBA
 
 ### Understanding the Script
-The script demonstrates the important steps in the verification process:
+The script demonstrates almost all important steps in the verification process:
 
 1. Download revocation lists from the URLs specified in the certificates which we obtained from the TROPIC01.
 2. Check all certificates we obtained from the TROPIC01 using the chain and revocation lists we downloaded from the Tropic Square PKI website.

--- a/docs/tutorials/linux/usb_devkit/full_chain_verification.md
+++ b/docs/tutorials/linux/usb_devkit/full_chain_verification.md
@@ -6,11 +6,11 @@ In this tutorial, you will learn about one of the steps required to verify the a
     Detailed information about TROPIC01 device identity and related Tropic Square Public Key Infrastructure (PKI) is provided in the *Device Identity and PKI Application Note* (ODN_TR01_app_003) available on [GitHub](https://github.com/tropicsquare/tropic01/tree/main#application-notes). It is recommended to read this document before proceeding to understand the process described in this tutorial, as here we provide only minimal information to try the process of the certificate chain verification.
 
 !!! warning "Compatibility"
-    Only production chips contain full certificate chain. Sample chips are not supported by this tutorial. If you encounter problems in this tutorial, you probably have an incompatible chip. Find your TROPIC01's part number ([check the FAQ](../../../faq.md#what-is-the-part-number-pn-of-my-tropic01)) and check the [Catalog list](https://github.com/tropicsquare/tropic01#available-parts) to see if your chip is a production one.
+    Only production chips contain the full certificate chain. Sample chips are not supported by this tutorial. If you encounter problems in this tutorial, you probably have an incompatible chip. Find your TROPIC01's part number ([check the FAQ](../../../faq.md#what-is-the-part-number-pn-of-my-tropic01)) and check the [Catalog list](https://github.com/tropicsquare/tropic01#available-parts) to see if your chip is a production one.
 
-The TROPIC01 comes with its own unique cryptographic identity in the form of Secure Channel key pair and a certificate. The certificate is issued by Tropic Square PKI which provides a framework for verifying the origin of each TROPIC01 chip ever produced. In this tutorial, we will learn:
+The TROPIC01 comes with its own unique cryptographic identity in the form of a Secure Channel key pair and a certificate. The certificate is issued by Tropic Square PKI which provides a framework for verifying the origin of each TROPIC01 chip ever produced. In this tutorial, we will learn:
 
-- How to load the certificate chain from a TROPIC01 chip using `lt_get_info_cert_store()` function from the Libtropic API.
+- How to load the certificate chain from a TROPIC01 chip using the `lt_get_info_cert_store()` function from the Libtropic API.
 - How to verify all certificates in the chain using OpenSSL CLI with a provided script.
 
 ## Load the Certificates
@@ -49,7 +49,6 @@ First, we will load the certificates from your TROPIC01 using a provided C appli
     === ":fontawesome-brands-windows: Windows"
         TBA
 
-
 ## Verify the Certificates
 After loading the certificates from the TROPIC01 chip, we will verify the certificates using a provided script.
 
@@ -73,19 +72,16 @@ After loading the certificates from the TROPIC01 chip, we will verify the certif
     === ":fontawesome-brands-windows: Windows"
         TBA
 
-
 ### Understanding the Script
-The script demonstrates almost all important steps in the verification process:
+The script demonstrates the important steps in the verification process:
 
 1. Download revocation lists from the URLs specified in the certificates which we obtained from the TROPIC01.
 2. Check all certificates we obtained from the TROPIC01 using the chain and revocation lists we downloaded from the Tropic Square PKI website.
 3. Check the root certificate (simplified, no out-of-band check provided).
 
-Authenticity check of the root certificate in the step 3 is not fully implemented. The root certificate can be obtained from the chip, we provide it in this repository and it is also available in the Tropic Square PKI website. **Do not blindly trust this certificate** file from GitHub alone. To protect against repository compromise, the trust has to be established by verifying the certificate fingerprint through an independent channel. Tropic Square customers can obtain the verified fingerprint via direct contact with [Customer Support](https://support.tropicsquare.com).
+Authenticity check of the root certificate in step 3 is not fully implemented. The root certificate can be obtained from the chip, we provide it in this repository and it is also available on the Tropic Square PKI website. **Do not blindly trust this certificate** file from GitHub alone. To protect against repository compromise, the trust has to be established by verifying the certificate fingerprint through an independent channel. Tropic Square customers can obtain the verified fingerprint via direct contact with [Customer Support](https://support.tropicsquare.com).
 
 The script contains comments about each step, so refer to the code of the script for more details about the implementation. It is also recommended to study the *Device Identity and PKI Application Note* (ODN_TR01_app_003) (available [on GitHub](https://github.com/tropicsquare/tropic01/tree/main#application-notes)) to fully understand the principles described in this tutorial.
 
 !!! note "Alternative implementation of the verification"
     The script verifies the TROPIC01 certificates against certificate authority certificates downloaded from the Tropic Square PKI website. As the same certificates are present also in the TROPIC01 itself, those can be used instead. The importance of verifying the root certificate independently remains the key part of the process.
-
-

--- a/docs/tutorials/linux/usb_devkit/index.md
+++ b/docs/tutorials/linux/usb_devkit/index.md
@@ -22,7 +22,7 @@ First, install the dependencies and prepare the repository:
         - `sudo apt update && sudo apt install build-essential`
     3. Get the Libtropic repository:
         - Using git: `git clone https://github.com/tropicsquare/libtropic.git`
-        - Or you can [download latest release](https://github.com/tropicsquare/libtropic/releases/latest).
+        - Or you can [download the latest release](https://github.com/tropicsquare/libtropic/releases/latest).
 
 After that, setup your system:
 !!! example "System Setup Instructions"
@@ -45,4 +45,4 @@ After that, setup your system:
 4. [Full Chain Verification](full_chain_verification.md)
 
 ## FAQ
-If you encounter any issues, please check the [FAQ](../../../faq.md) before filing an issue or reaching out to our [support](https://support.desk.tropicsquare.com/).
+If you encounter any issues, please check the [FAQ](../../../faq.md) before filing an issue or reaching out to our [support](https://support.tropicsquare.com/).

--- a/docs/tutorials/stm32/index.md
+++ b/docs/tutorials/stm32/index.md
@@ -67,7 +67,7 @@ First, install the dependencies and prepare the repository:
                 - Fedora: `sudo dnf install gtkterm`
         6. Get the Libtropic repository:
             - Using git: `git clone https://github.com/tropicsquare/libtropic.git`
-            - Or you can [download latest release](https://github.com/tropicsquare/libtropic/releases/latest).
+            - Or you can [download the latest release](https://github.com/tropicsquare/libtropic/releases/latest).
 
     === ":fontawesome-brands-apple: macOS"
         TBA
@@ -107,4 +107,4 @@ After that, setup your system:
 3. [Hello, World!](hello_world.md)
 
 ## FAQ
-If you encounter any issues, please check the [FAQ](../../faq.md) before filing an issue or reaching out to our [support](https://support.desk.tropicsquare.com/).
+If you encounter any issues, please check the [FAQ](../../faq.md) before filing an issue or reaching out to our [support](https://support.tropicsquare.com/).


### PR DESCRIPTION
## Summary
- Add missing articles ("the", "a") across tutorial documentation
- Fix grammar issues (e.g., "plug-and-play" usage, prepositions)
- Standardize support URL to `support.tropicsquare.com` (remove `desk.` prefix)
- Fix capitalization of "Libtropic"
- Remove extra blank lines

## Files Changed
- `docs/common/examples_descriptions/identify_chip.md`
- `docs/tutorials/esp32/index.md`
- `docs/tutorials/linux/spi/index.md`
- `docs/tutorials/linux/usb_devkit/full_chain_verification.md`
- `docs/tutorials/linux/usb_devkit/index.md`
- `docs/tutorials/model/hw_wallet_example.md`
- `docs/tutorials/stm32/index.md`