### PR TITLE
ETR01SDK-542: Add SPI GPIO device length check

### DIFF
--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -77,12 +77,27 @@ int main(void)
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
     lt_dev_linux_spi_t device = {0};
-    strcpy(device.gpio_dev,
-           LT_GPIO_DEV_PATH);  // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
-                               // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
-    strcpy(device.spi_dev,
-           LT_SPI_DEV_PATH);     // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
-                                 // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+
+    // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
+    int dev_path_len = snprintf(device.gpio_dev, sizeof(device.gpio_dev), "%s", LT_GPIO_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.gpio_dev)) {
+        fprintf(stderr, "Error: LT_GPIO_DEV_PATH is too long for device.gpio_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.gpio_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
+    // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+    dev_path_len = snprintf(device.spi_dev, sizeof(device.spi_dev), "%s", LT_SPI_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.spi_dev)) {
+        fprintf(stderr, "Error: LT_SPI_DEV_PATH is too long for device.spi_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.spi_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     device.spi_speed = 5000000;  // 5 MHz (change if needed).
     device.gpio_cs_num = 25;     // GPIO 25 as on RPi shield.
 #if LT_USE_INT_PIN

--- a/examples/linux/spi/hello_world/main.c
+++ b/examples/linux/spi/hello_world/main.c
@@ -64,12 +64,27 @@ int main(void)
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
     lt_dev_linux_spi_t device = {0};
-    strcpy(device.gpio_dev,
-           LT_GPIO_DEV_PATH);  // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
-                               // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
-    strcpy(device.spi_dev,
-           LT_SPI_DEV_PATH);     // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
-                                 // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+
+    // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
+    int dev_path_len = snprintf(device.gpio_dev, sizeof(device.gpio_dev), "%s", LT_GPIO_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.gpio_dev)) {
+        fprintf(stderr, "Error: LT_GPIO_DEV_PATH is too long for device.gpio_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.gpio_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
+    // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+    dev_path_len = snprintf(device.spi_dev, sizeof(device.spi_dev), "%s", LT_SPI_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.spi_dev)) {
+        fprintf(stderr, "Error: LT_SPI_DEV_PATH is too long for device.spi_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.spi_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     device.spi_speed = 5000000;  // 5 MHz (change if needed).
     device.gpio_cs_num = 25;     // GPIO 25 as on RPi shield.
 #if LT_USE_INT_PIN

--- a/examples/linux/spi/identify_chip/main.c
+++ b/examples/linux/spi/identify_chip/main.c
@@ -50,12 +50,27 @@ int main(void)
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
     lt_dev_linux_spi_t device = {0};
-    strcpy(device.gpio_dev,
-           LT_GPIO_DEV_PATH);  // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
-                               // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
-    strcpy(device.spi_dev,
-           LT_SPI_DEV_PATH);     // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
-                                 // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+
+    // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
+    int dev_path_len = snprintf(device.gpio_dev, sizeof(device.gpio_dev), "%s", LT_GPIO_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.gpio_dev)) {
+        fprintf(stderr, "Error: LT_GPIO_DEV_PATH is too long for device.gpio_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.gpio_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
+    // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+    dev_path_len = snprintf(device.spi_dev, sizeof(device.spi_dev), "%s", LT_SPI_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.spi_dev)) {
+        fprintf(stderr, "Error: LT_SPI_DEV_PATH is too long for device.spi_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.spi_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     device.spi_speed = 5000000;  // 5 MHz (change if needed).
     device.gpio_cs_num = 25;     // GPIO 25 as on RPi shield.
 #if LT_USE_INT_PIN

--- a/tests/functional/linux/spi/CMakeLists.txt
+++ b/tests/functional/linux/spi/CMakeLists.txt
@@ -78,7 +78,7 @@ set(SOURCES
 
 # Enable strict compile flags for main.c and Libtropic HAL sources
 if(LT_STRICT_COMPILATION)
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
 endif()
 
 ###########################################################################

--- a/tests/functional/linux/spi/main.c
+++ b/tests/functional/linux/spi/main.c
@@ -31,7 +31,8 @@
 #define CRYPTO_CTX_TYPE lt_ctx_wolfcrypt_t
 #endif
 
-static int cleanup(void) {
+static int cleanup(void)
+{
     int ret = 0;
 
 #if LT_USE_MBEDTLS_V4
@@ -81,8 +82,8 @@ int main(void)
     int dev_path_len = snprintf(device.gpio_dev, sizeof(device.gpio_dev), "%s", LT_GPIO_DEV_PATH);
     if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.gpio_dev)) {
         LT_LOG_ERROR("Error: LT_GPIO_DEV_PATH is too long for device.gpio_dev buffer (limit is %zu bytes).\n",
-                sizeof(device.gpio_dev));
-        LT_UNUSED(cleanup()); // Not caring about return val - we fail anyway.
+                     sizeof(device.gpio_dev));
+        LT_UNUSED(cleanup());  // Not caring about return val - we fail anyway.
         return -1;
     }
 
@@ -90,8 +91,8 @@ int main(void)
     dev_path_len = snprintf(device.spi_dev, sizeof(device.spi_dev), "%s", LT_SPI_DEV_PATH);
     if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.spi_dev)) {
         LT_LOG_ERROR("Error: LT_SPI_DEV_PATH is too long for device.spi_dev buffer (limit is %zu bytes).\n",
-                sizeof(device.spi_dev));
-        LT_UNUSED(cleanup()); // Not caring about return val - we fail anyway.
+                     sizeof(device.spi_dev));
+        LT_UNUSED(cleanup());  // Not caring about return val - we fail anyway.
         return -1;
     }
 

--- a/tests/functional/linux/spi/main.c
+++ b/tests/functional/linux/spi/main.c
@@ -60,12 +60,27 @@ int main(void)
 
     // Device mappings
     lt_dev_linux_spi_t device = {0};
-    strcpy(device.gpio_dev,
-           LT_GPIO_DEV_PATH);  // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
-                               // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
-    strcpy(device.spi_dev,
-           LT_SPI_DEV_PATH);     // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
-                                 // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+
+    // LT_GPIO_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_GPIO_DEV_PATH=<path> to cmake if you want to change it.
+    int dev_path_len = snprintf(device.gpio_dev, sizeof(device.gpio_dev), "%s", LT_GPIO_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.gpio_dev)) {
+        fprintf(stderr, "Error: LT_GPIO_DEV_PATH is too long for device.gpio_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.gpio_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
+    // LT_SPI_DEV_PATH is defined in CMakeLists.txt. Pass
+    // -DLT_SPI_DEV_PATH=<path> to cmake if you want to change it.
+    dev_path_len = snprintf(device.spi_dev, sizeof(device.spi_dev), "%s", LT_SPI_DEV_PATH);
+    if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.spi_dev)) {
+        fprintf(stderr, "Error: LT_SPI_DEV_PATH is too long for device.spi_dev buffer (limit is %zu bytes).\n",
+                sizeof(device.spi_dev));
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     device.spi_speed = 5000000;  // 5 MHz (change if needed).
     device.gpio_cs_num = 25;     // GPIO 25 as on RPi shield.
 #if LT_USE_INT_PIN

--- a/tests/functional/linux/spi/main.c
+++ b/tests/functional/linux/spi/main.c
@@ -81,7 +81,7 @@ int main(void)
     // LT_GPIO_DEV_PATH is defined in CMakeLists.txt.
     int dev_path_len = snprintf(device.gpio_dev, sizeof(device.gpio_dev), "%s", LT_GPIO_DEV_PATH);
     if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.gpio_dev)) {
-        LT_LOG_ERROR("Error: LT_GPIO_DEV_PATH is too long for device.gpio_dev buffer (limit is %zu bytes).\n",
+        LT_LOG_ERROR("Error: LT_GPIO_DEV_PATH is too long for device.gpio_dev buffer (limit is %zu bytes).",
                      sizeof(device.gpio_dev));
         LT_UNUSED(cleanup());  // Not caring about return val - we fail anyway.
         return -1;
@@ -90,7 +90,7 @@ int main(void)
     // LT_SPI_DEV_PATH is defined in CMakeLists.txt.
     dev_path_len = snprintf(device.spi_dev, sizeof(device.spi_dev), "%s", LT_SPI_DEV_PATH);
     if (dev_path_len < 0 || (size_t)dev_path_len >= sizeof(device.spi_dev)) {
-        LT_LOG_ERROR("Error: LT_SPI_DEV_PATH is too long for device.spi_dev buffer (limit is %zu bytes).\n",
+        LT_LOG_ERROR("Error: LT_SPI_DEV_PATH is too long for device.spi_dev buffer (limit is %zu bytes).",
                      sizeof(device.spi_dev));
         LT_UNUSED(cleanup());  // Not caring about return val - we fail anyway.
         return -1;


### PR DESCRIPTION
## Description

In this PR, I add length check to examples and tests on Linux SPI.

As paths were changed in ETR01SDK-542, the base for this PR is the implementation branch. The base should be changed automatically when the 542 is merged.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage