### PR TITLE
ETR01SDK-523: Refactor clang format settings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,18 +1,44 @@
-# Tested with Ubuntu clang-format version 14.0.0-1ubuntu1.1
-
-BreakBeforeBinaryOperators: All
-
-ColumnLimit: 120
-
+# Language conformance: C11
+# Using Cpp as a language is ok here, since there is no separate C formatter.
+# It is common to use Cpp for C code formatting in clang-format.
+Language: Cpp
+Standard: Cpp11
 BasedOnStyle: Google
 
+# --- BRACE STYLE ---
+# "Functions... opening brace on new line" 
+# "if, for, while... opening brace on the same line" 
 BreakBeforeBraces: Stroustrup
 
+# --- INDENTATION & WIDTH ---
+ColumnLimit: 120
+
+# "You shall indent the code with 4 spaces" 
 IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
 
+# --- POINTERS ---
+# Google defaults to Left, but guidelines show Right (void *p) 
 PointerAlignment: Right
+DerivePointerAlignment: false
 
-# # Insert New line at EOF if missing
-#InsertNewlineAtEOF: true
-# # Set EOL to LF unconditionally
-#LineEnding: LF
+# --- SPECIFIC TROPIC SQUARE RULES ---
+# "You shall place braces around the single statement" 
+# Valid since Clang-Format 15
+InsertBraces: true
+
+# "You shall put spaces after... if, switch..." 
+SpaceBeforeParens: ControlStatements
+# "You shall not add spaces around (inside) parenthesized expressions" 
+SpacesInParentheses: false
+
+# "Space on each side of most binary and ternary operators" 
+# Note: "SpacesInBinaryOperators" is implicit in Google style, no key needed.
+SpaceBeforeAssignmentOperators: true
+
+# Misc Cleanup
+SortIncludes: true
+IndentCaseLabels: true
+BreakBeforeBinaryOperators: All

--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -6,11 +6,15 @@ on:
       - develop
     paths:
       - '**.c'
+      - '**.cpp'
       - '**.h'
+      - '**.hpp'
   pull_request:
     paths:
       - '**.c'
+      - '**.cpp'
       - '**.h'
+      - '**.hpp'
 
 jobs:
   check-format:
@@ -31,7 +35,7 @@ jobs:
             echo "Formatting issue in $f"
             exit_code=1
           fi
-        done < <(find . -type f \( -name '*.c' -o -name '*.h' \) ! -path './vendor/*' ! -path './vendor/**' ! -path '*Vendor/*' ! -path '*_deps/*' ! -path './.git/*' -print0)
+        done < <(find . -type f \( -name '*.c' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) ! -path './vendor/*' ! -path './vendor/**' ! -path '*Vendor/*' ! -path '*_deps/*' ! -path './.git/*' -print0)
 
         if [ $exit_code -ne 0 ]; then
           echo "Clang-format check failed."

--- a/examples/model/mac_and_destroy/main.c
+++ b/examples/model/mac_and_destroy/main.c
@@ -121,7 +121,9 @@ static psa_status_t hmac_sha256(const uint8_t *key, const size_t key_len, const 
                              PSA_HASH_LENGTH(PSA_ALG_SHA_256), &output_len);
 
 cleanup:
-    if (key_id != 0) psa_destroy_key(key_id);
+    if (key_id != 0) {
+        psa_destroy_key(key_id);
+    }
     psa_reset_key_attributes(&attributes);
     return status;
 }

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1487,7 +1487,9 @@ static const char *lt_ret_strs[] = {"LT_OK",
 
 const char *lt_ret_verbose(lt_ret_t ret)
 {
-    if (ret < LT_RET_T_LAST_VALUE) return lt_ret_strs[ret];
+    if (ret < LT_RET_T_LAST_VALUE) {
+        return lt_ret_strs[ret];
+    }
 
     return "FATAL ERROR, unknown return value";
 }

--- a/src/lt_asn1_der.c
+++ b/src/lt_asn1_der.c
@@ -145,7 +145,9 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
     LT_ASN1_DER_GET_NEXT_BYTE(ctx, &b);
 
     rv = parse_length(ctx, &len);
-    if (rv != LT_OK) return rv;
+    if (rv != LT_OK) {
+        return rv;
+    }
 
     uint16_t start = ctx->past;
 
@@ -160,7 +162,9 @@ static lt_ret_t parse_object(struct parse_ctx_t *ctx)
         case LT_ASN1DER_SEQUENCE:
             while (ctx->past < start + len - 1) {
                 rv = parse_object(ctx);
-                if (rv != LT_OK) return rv;
+                if (rv != LT_OK) {
+                    return rv;
+                }
             }
 
             if (start + len != ctx->past) {
@@ -279,10 +283,14 @@ lt_ret_t asn1der_find_object(const uint8_t *stream, uint16_t len, int32_t obj_id
 
     while (ctx.past < ctx.len - 1) {
         lt_ret_t rv = parse_object(&ctx);
-        if (rv != LT_OK) return rv;
+        if (rv != LT_OK) {
+            return rv;
+        }
     };
 
-    if (!ctx.found) return LT_CERT_ITEM_NOT_FOUND;
+    if (!ctx.found) {
+        return LT_CERT_ITEM_NOT_FOUND;
+    }
 
     return LT_OK;
 }

--- a/tests/functional/src/lt_test_rev_get_info_req_app.c
+++ b/tests/functional/src/lt_test_rev_get_info_req_app.c
@@ -46,12 +46,13 @@ void lt_test_rev_get_info_req_app(lt_handle_t *h)
         LT_TEST_ASSERT(1, (store.cert_len[i] != 0));
         LT_LOG_INFO("Size in bytes: %" PRIu16, store.cert_len[i]);
 
-        for (int j = 0; j < store.cert_len[i]; j += 16)
+        for (int j = 0; j < store.cert_len[i]; j += 16) {
             LT_LOG_INFO("%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8
                         "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8,
                         cert[j], cert[j + 1], cert[j + 2], cert[j + 3], cert[j + 4], cert[j + 5], cert[j + 6],
                         cert[j + 7], cert[j + 8], cert[j + 9], cert[j + 10], cert[j + 11], cert[j + 12], cert[j + 13],
                         cert[j + 14], cert[j + 15]);
+        }
         LT_LOG_INFO();
     }
     LT_LOG_LINE();

--- a/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
+++ b/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
@@ -180,12 +180,13 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
         LT_TEST_ASSERT(1, (store.cert_len[i] != 0));
         LT_LOG_INFO("Size in bytes: %" PRIu16, store.cert_len[i]);
 
-        for (int j = 0; j < store.cert_len[i]; j += 16)
+        for (int j = 0; j < store.cert_len[i]; j += 16) {
             LT_LOG_INFO("%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8
                         "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8 "%02" PRIx8,
                         cert[j], cert[j + 1], cert[j + 2], cert[j + 3], cert[j + 4], cert[j + 5], cert[j + 6],
                         cert[j + 7], cert[j + 8], cert[j + 9], cert[j + 10], cert[j + 11], cert[j + 12], cert[j + 13],
                         cert[j + 14], cert[j + 15]);
+        }
         LT_LOG_INFO();
     }
     LT_LOG_LINE();

--- a/tests/functional/src/lt_test_rev_mac_and_destroy.c
+++ b/tests/functional/src/lt_test_rev_mac_and_destroy.c
@@ -38,14 +38,19 @@ static int pin_check(lt_handle_t *h, uint8_t *pin, uint16_t pin_len, lt_mac_and_
     LT_TEST_ASSERT(LT_OK, lt_hmac_sha256(w, sizeof(w), pin, pin_len, k_i));
 
     LT_LOG_INFO("Decrypting (XOR) c_i using k_i...");
-    for (uint8_t j = 0; j < TR01_MAC_AND_DESTROY_DATA_SIZE; j++) s[j] = ciphertexts[slot][j] ^ k_i[j];
+    for (uint8_t j = 0; j < TR01_MAC_AND_DESTROY_DATA_SIZE; j++) {
+        s[j] = ciphertexts[slot][j] ^ k_i[j];
+    }
 
     LT_LOG_INFO("Computing t' = KDF(s, \"0\")...");
     LT_TEST_ASSERT(LT_OK, lt_hmac_sha256(s, TR01_MAC_AND_DESTROY_DATA_SIZE, (uint8_t *)"0", 1, t_));
 
     LT_LOG_INFO("Checking if t' != t...");
-    for (uint8_t i = 0; i < sizeof(t_); i++)
-        if (t_[i] != t[i]) return 1;
+    for (uint8_t i = 0; i < sizeof(t_); i++) {
+        if (t_[i] != t[i]) {
+            return 1;
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Description

Changes `.clang-format` to fulfil the Tropic Square C coding guideline.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---