### PR TITLE
ETR01SDK-544: Fix strict compilation target paths

### DIFF
--- a/tests/functional/esp32/common.cmake
+++ b/tests/functional/esp32/common.cmake
@@ -84,7 +84,7 @@ set(SOURCES
 
 # Enable strict compile flags for main.c and Libtropic HAL sources
 if(LT_STRICT_COMPILATION)
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
+    set_source_files_properties(${SOURCES} ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
 endif()
 
 ###########################################################################

--- a/tests/functional/linux/spi/CMakeLists.txt
+++ b/tests/functional/linux/spi/CMakeLists.txt
@@ -78,7 +78,7 @@ set(SOURCES
 
 # Enable strict compile flags for main.c and Libtropic HAL sources
 if(LT_STRICT_COMPILATION)
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
+    set_source_files_properties(${SOURCES} ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
 endif()
 
 ###########################################################################

--- a/tests/functional/linux/usb_devkit/CMakeLists.txt
+++ b/tests/functional/linux/usb_devkit/CMakeLists.txt
@@ -72,7 +72,7 @@ set(SOURCES
 
 # Enable strict compile flags for main.c and Libtropic HAL sources
 if(LT_STRICT_COMPILATION)
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
+    set_source_files_properties(${SOURCES} ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
 endif()
 
 ###########################################################################

--- a/tests/functional/model/CMakeLists.txt
+++ b/tests/functional/model/CMakeLists.txt
@@ -81,7 +81,7 @@ set(SOURCES
 
 # Enable strict compile flags for main.c and Libtropic HAL sources.
 if(LT_STRICT_COMPILATION)
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/main.c ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
+    set_source_files_properties(${SOURCES} ${LT_HAL_SRCS} PROPERTIES COMPILE_OPTIONS "${LT_STRICT_COMPILATION_FLAGS}")   
 endif()
 
 ###########################################################################


### PR DESCRIPTION
## Description

In this PR I fix paths of files on which we apply strict compilation flags.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage