### PR TITLE
ETR01SDK-430: Fixed `l3_chunk` size in `lt_l2_encrypted_cmd_*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0]
+
+### Changed
+- Size of `l3_struct` member of `lt_l2_encrypted_cmd_req_t` and `lt_l2_encrypted_cmd_rsp_t` structs to `TR01_L2_CHUNK_MAX_DATA_SIZE`.
+
+### Added
+
+### Fixed
+
+### Removed
+
 ## [3.1.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.2.0]
 
 ### Changed
-- Size of `l3_struct` member of `lt_l2_encrypted_cmd_req_t` and `lt_l2_encrypted_cmd_rsp_t` structs to `TR01_L2_CHUNK_MAX_DATA_SIZE`.
 
 ### Added
 
 ### Fixed
+- Size of `l3_chunk` member of `lt_l2_encrypted_cmd_req_t` and `lt_l2_encrypted_cmd_rsp_t` structs to `TR01_L2_CHUNK_MAX_DATA_SIZE`.
 
 ### Removed
 

--- a/src/lt_l2_api_structs.h
+++ b/src/lt_l2_api_structs.h
@@ -223,7 +223,7 @@ struct lt_l2_encrypted_cmd_req_t {
     uint8_t req_id;  /**< Request ID byte */
     uint8_t req_len; /**< Length byte */
     /** Contains a chunk of encrypted command */
-    uint8_t l3_chunk[255];
+    uint8_t l3_chunk[TR01_L2_CHUNK_MAX_DATA_SIZE];
     uint8_t crc[2]; /**< Checksum */
 } __attribute__((packed));
 
@@ -254,7 +254,7 @@ struct lt_l2_encrypted_cmd_rsp_t {
      * The size of the RES_CIPHERTEXT L3 Field in bytes.
      */
     /** Contains a chunk of encrypted command */
-    uint8_t l3_chunk[255];
+    uint8_t l3_chunk[TR01_L2_CHUNK_MAX_DATA_SIZE];
     uint8_t crc[2]; /**< Checksum */
 } __attribute__((packed));
 


### PR DESCRIPTION
## Description

Use correct size of the `l3_chunk` member according to the TROPIC01 API.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [ ] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage