### PR TITLE
ETR01SDK-185: Big endian compatibility

### DIFF
--- a/docs/compatibility/host_platforms/index.md
+++ b/docs/compatibility/host_platforms/index.md
@@ -11,3 +11,7 @@ All HAL files can be found in the `libtropic/hal/` directory.
 
 !!! tip
     Cannot see your platform in the list above? Refer to [Adding a New Host Platform](../../for_contributors/adding_host_platform.md) section with instructions on how to add a support for it.
+
+!!! warning "Warning: Endianness"
+    Currently, the Libtropic code is compatible with little-endian machines only due to handling
+    of integers in packed structures.

--- a/docs/for_contributors/adding_host_platform.md
+++ b/docs/for_contributors/adding_host_platform.md
@@ -1,5 +1,10 @@
 # Adding a New Host Platform
-Libtropic is written to be *platform-independent*, so no changes to the main code base are needed when adding support for a new host platform. However, to define how communication on the L1 Layer will work, a new Hardware Abstraction Layer (HAL) must be implemented. Currently available HALs are located in `hal/`.
+Libtropic is written to be *platform-independent*, so it is possible to add support for a new host platform by creating a new Hardware Abstraction Layer (HAL). The HAL implements low-level functionality, mainly communication on the L1 Layer. Currently available HALs are located in `hal/`.
+
+!!! warning "Warning: Endianness"
+    Currently, the Libtropic code is compatible with little-endian machines only due to handling
+    of integers in packed structures. If your platform uses different endianness, it cannot be
+    supported for now without patching the code base.
 
 ## Guide
 This guide will walk you through adding support for a new platform. In this guide, we will add a support for a microcontroller called `my_mcu` on a board `my_board`. The directory structure will be different if you create a port e.g., for an operating system. In that case, please get inspired by existing ports (POSIX, Linux).


### PR DESCRIPTION
## Description

In this PR, I add warning messages about endianness.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage