### PR TITLE
ETR01SDK-555: CI for Valgrind is broken on GitHub

### DIFF
--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -25,7 +25,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install clang-format
-      run: sudo apt install -y clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format
 
     - name: Get files and check format
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential ninja-build
             ./tests/functional/model/download_deps.sh
             ./scripts/tropic01_model/install_linux.sh

--- a/.github/workflows/functional_mock_tests.yml
+++ b/.github/workflows/functional_mock_tests.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential ninja-build
             pip install jsonschema jinja2
 

--- a/.github/workflows/functional_mock_tests.yml
+++ b/.github/workflows/functional_mock_tests.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential valgrind ninja-build
             pip install jsonschema jinja2
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential ninja-build
             ./tests/functional/model/download_deps.sh
             ./scripts/tropic01_model/install_linux.sh
@@ -69,6 +70,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential valgrind ninja-build
             ./tests/functional/model/download_deps.sh
             ./scripts/tropic01_model/install_linux.sh

--- a/.github/workflows/linux_build_examples.yml
+++ b/.github/workflows/linux_build_examples.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential ninja-build
             pip3 install jsonschema
 

--- a/.github/workflows/model_run_examples.yml
+++ b/.github/workflows/model_run_examples.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential valgrind ninja-build
             ./tests/functional/model/download_deps.sh
             ./scripts/tropic01_model/install_linux.sh

--- a/.github/workflows/release_new_version.yml
+++ b/.github/workflows/release_new_version.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install doxygen graphviz
             pip install -r docs/requirements.txt
 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential cppcheck
 
       - name: Checkout Repository

--- a/.github/workflows/stm32_build_examples.yml
+++ b/.github/workflows/stm32_build_examples.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install cmake build-essential ninja-build gcc-arm-none-eabi
             pip3 install jsonschema
 


### PR DESCRIPTION
## Description

In this PR I try to fix broken Valgrind CI.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage