### PR TITLE
ETR01SDK-536: Allow lt_init even if App FW is not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Size of `l3_chunk` member of `lt_l2_encrypted_cmd_req_t` and `lt_l2_encrypted_cmd_rsp_t` structs to `TR01_L2_CHUNK_MAX_DATA_SIZE`.
 - `hal/`: don't include `libtropic_port.h` in HAL headers if not used.
+- `lt_init()` is successful even if TROPIC01 has invalid Application FW, so Libtropic can be used in Start-up Mode.
 
 ### Removed
 

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -69,8 +69,10 @@ lt_ret_t lt_init(lt_handle_t *h)
     }
 
     // Initialize the TROPIC01 attributes based on its Application FW.
+    // We allow LT_REBOOT_UNSUCCESSFUL, because TROPIC01 might contain invalid Application FW, but
+    // should not be restricted from using Libtropic in Start-up Mode.
     ret = lt_init_tr01_attrs(h);
-    if (ret != LT_OK) {
+    if (ret != LT_OK && ret != LT_REBOOT_UNSUCCESSFUL) {
         goto crypto_ctx_cleanup;
     }
 

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -116,6 +116,7 @@ set(LIBTROPIC_MOCK_TEST_LIST
     lt_test_mock_attrs
     lt_test_mock_invalid_in_crc
     lt_test_mock_hardware_fail
+    lt_test_mock_invalid_app_fw_init
 )
 
 ###########################################################################

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -55,6 +55,18 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h);
  */
 void lt_test_mock_hardware_fail(lt_handle_t *h);
 
+/**
+ * @brief Test for checking that lt_init suceeds if Application FW cannot be booted.
+ *
+ * Test steps:
+ *  1. Mock responses to simulate a scenario where Application FW cannot be booted, i.e. TROPIC01 stays
+ *     in Start-up Mode.
+ *  2. Call lt_init and verify that it succeeds.
+ *
+ * @param h Handle for communication with TROPIC01
+ */
+void lt_test_mock_invalid_app_fw_init(lt_handle_t *h);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/functional_mock/lt_test_mock_invalid_app_fw_init.c
+++ b/tests/functional_mock/lt_test_mock_invalid_app_fw_init.c
@@ -1,0 +1,62 @@
+/**
+ * @file lt_test_mock_invalid_app_fw_init.c
+ * @brief Test for checking that lt_init suceeds if Application FW cannot be booted.
+ * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
+ *
+ * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ */
+
+#include "libtropic.h"
+#include "libtropic_common.h"
+#include "libtropic_logging.h"
+#include "libtropic_port_mock.h"
+#include "lt_functional_mock_tests.h"
+#include "lt_l1.h"
+#include "lt_l2_api_structs.h"
+#include "lt_l2_frame_check.h"
+#include "lt_mock_helpers.h"
+#include "lt_test_common.h"
+
+void lt_test_mock_invalid_app_fw_init(lt_handle_t *h)
+{
+    LT_LOG_INFO("----------------------------------------------");
+    LT_LOG_INFO("lt_test_mock_invalid_app_fw_init()");
+    LT_LOG_INFO("----------------------------------------------");
+
+    const uint8_t chip_startup_mode = (TR01_L1_CHIP_MODE_READY_bit | TR01_L1_CHIP_MODE_STARTUP_bit);
+    const uint8_t lt_get_tr01_mode_mocked_response[] = {chip_startup_mode, TR01_L2_STATUS_NO_RESP};
+
+    lt_mock_hal_reset(&h->l2);
+
+    // 1. Mock lt_init() -> lt_init_tr01_attrs() -> lt_get_tr01_mode() response.
+    LT_LOG_INFO("Mocking Get_Response response...");
+    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, lt_get_tr01_mode_mocked_response,
+                                                       sizeof(lt_get_tr01_mode_mocked_response)));
+
+    // 2. Mock lt_init() -> lt_init_tr01_attrs() -> lt_reboot() response.
+    LT_LOG_INFO("Mocking Startup_Req response...");
+    struct lt_l2_startup_rsp_t startup_req_resp = {
+        .chip_status = (TR01_L1_CHIP_MODE_READY_bit | TR01_L1_CHIP_MODE_STARTUP_bit),  // Start-up Mode
+        .status = TR01_L2_STATUS_REQUEST_OK,
+        .rsp_len = TR01_L2_STARTUP_RSP_LEN,
+        .crc = {0}  // CRC added below.
+    };
+    // Add CRC to the Startup_Req response.
+    add_resp_crc(&startup_req_resp);
+
+    LT_TEST_ASSERT(
+        LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_startup_mode, sizeof(chip_startup_mode)));
+    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&startup_req_resp,
+                                                       calc_mocked_resp_len(&startup_req_resp)));
+
+    // 3. Mock lt_init() -> lt_init_tr01_attrs() -> lt_reboot() -> lt_get_tr01_mode() response.
+    LT_LOG_INFO("Mocking Get_Response response...");
+    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, lt_get_tr01_mode_mocked_response,
+                                                       sizeof(lt_get_tr01_mode_mocked_response)));
+
+    LT_LOG_INFO("Initializing handle");
+    LT_TEST_ASSERT(LT_OK, lt_init(h));
+
+    LT_LOG_INFO("Deinitializing handle");
+    LT_TEST_ASSERT(LT_OK, lt_deinit(h));
+}


### PR DESCRIPTION
## Description

Fixes the scenario where there is an invalid App FW in TROPIC01 and user wants to use Libtropic in Start-up Mode only.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---