### PR TITLE
ETR01SDK-566: Add test that does lt_init again after lt_deinit

### DIFF
--- a/tests/functional/src/CMakeLists.txt
+++ b/tests/functional/src/CMakeLists.txt
@@ -313,6 +313,7 @@ set(LIBTROPIC_TEST_LIST
     lt_test_rev_random_value_get
     lt_test_rev_mac_and_destroy
     lt_test_rev_get_log_req
+    lt_test_rev_init_after_deinit
 )
 
 # Export test list to parent project (usually platform-specific implementation)
@@ -365,6 +366,7 @@ set(TEST_SRCS
     ${PATH_LIBTROPIC}/tests/functional/src/lt_test_rev_random_value_get.c
     ${PATH_LIBTROPIC}/tests/functional/src/lt_test_rev_mac_and_destroy.c
     ${PATH_LIBTROPIC}/tests/functional/src/lt_test_rev_get_log_req.c
+    ${PATH_LIBTROPIC}/tests/functional/src/lt_test_rev_init_after_deinit.c
 )
 
 set(TEST_DIRS

--- a/tests/functional/src/libtropic_functional_tests.h
+++ b/tests/functional/src/libtropic_functional_tests.h
@@ -373,6 +373,22 @@ void lt_test_rev_mac_and_destroy(lt_handle_t *h);
  */
 void lt_test_rev_get_log_req(lt_handle_t *h);
 
+/**
+ * @brief Tests calling lt_init after lt_deinit.
+ *
+ * Test steps:
+ *  1. Initialize the handle.
+ *  2. Start Secure Session with pairing key slot 0.
+ *  3. Generate random data and send a Ping command.
+ *  4. Compare sent and received message.
+ *  5. Abort Secure Session.
+ *  6. Deinitialize the handle.
+ *  7. Repeat steps 1-6 to test reinitialization after deinitialization.
+ *
+ * @param h     Handle for communication with TROPIC01
+ */
+void lt_test_rev_init_after_deinit(lt_handle_t *h);
+
 /** @} */  // end of libtropic_funct_tests group
 
 #ifdef __cplusplus

--- a/tests/functional/src/lt_test_rev_init_after_deinit.c
+++ b/tests/functional/src/lt_test_rev_init_after_deinit.c
@@ -1,0 +1,60 @@
+/**
+ * @file lt_test_rev_init_after_deinit.c
+ * @brief Test calling lt_init after lt_deinit.
+ * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
+ *
+ * @license For the license see LICENSE.md in the root directory of this source tree.
+ */
+
+#include <inttypes.h>
+#include <string.h>
+
+#include "libtropic.h"
+#include "libtropic_common.h"
+#include "libtropic_functional_tests.h"
+#include "libtropic_logging.h"
+#include "lt_port_wrap.h"
+#include "lt_test_common.h"
+
+void lt_test_rev_init_after_deinit(lt_handle_t *h)
+{
+    LT_LOG_INFO("----------------------------------------------");
+    LT_LOG_INFO("lt_test_rev_init_after_deinit()");
+    LT_LOG_INFO("----------------------------------------------");
+
+    uint8_t ping_msg_out[TR01_PING_LEN_MAX], ping_msg_in[TR01_PING_LEN_MAX];
+    uint16_t ping_msg_len;
+
+    for (int i = 0; i < 2; i++) {
+        LT_LOG_INFO("Iteration #%d", i + 1);
+
+        LT_LOG_INFO("Initializing handle");
+        LT_TEST_ASSERT(LT_OK, lt_init(h));
+
+        LT_LOG_INFO("Starting Secure Session with key %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+        LT_TEST_ASSERT(LT_OK,
+                       lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
+                                                               TR01_PAIRING_KEY_SLOT_INDEX_0));
+
+        LT_LOG_INFO("Generating random data length <= %d...", (int)TR01_PING_LEN_MAX);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &ping_msg_len, sizeof(ping_msg_len)));
+        ping_msg_len %= TR01_PING_LEN_MAX + 1;  // 0-4096
+
+        LT_LOG_INFO("Generating %" PRIu16 " random bytes...", ping_msg_len);
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, ping_msg_out, ping_msg_len));
+
+        LT_LOG_INFO("Sending Ping command...");
+        LT_TEST_ASSERT(LT_OK, lt_ping(h, ping_msg_out, ping_msg_in, ping_msg_len));
+
+        LT_LOG_INFO("Comparing sent and received message...");
+        LT_TEST_ASSERT(0, memcmp(ping_msg_out, ping_msg_in, ping_msg_len));
+
+        LT_LOG_INFO("Aborting Secure Session...");
+        LT_TEST_ASSERT(LT_OK, lt_session_abort(h));
+
+        LT_LOG_INFO("Deinitializing handle");
+        LT_TEST_ASSERT(LT_OK, lt_deinit(h));
+
+        LT_LOG_LINE();
+    }
+}


### PR DESCRIPTION
## Description

Tests sequence "lt_init->Secure Session->Ping->lt_deinit " twice in a row.

Locally tested with other CFPs + Valgrind/ASan.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [x] Other (please describe): New test

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---