### PR TITLE
ETR01SDK-561: use memzero after generating random numbers by the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Size of `l3_chunk` member of `lt_l2_encrypted_cmd_req_t` and `lt_l2_encrypted_cmd_rsp_t` structs to `TR01_L2_CHUNK_MAX_DATA_SIZE`.
 - `hal/`: don't include `libtropic_port.h` in HAL headers if not used.
 - `lt_init()` is successful even if TROPIC01 has invalid Application FW, so Libtropic can be used in Start-up Mode.
+- STM32: securely wipe secrets when generating random numbers.
 
 ### Removed
 

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/mbedtls_v4/mbedtls_platform.c
@@ -4,6 +4,7 @@
 #include "main.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_time.h"
+#include "mbedtls/platform_util.h"
 #include "stm32f4xx_hal.h"
 
 mbedtls_ms_time_t mbedtls_ms_time(void)
@@ -24,11 +25,13 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
+    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            return PSA_ERROR_INSUFFICIENT_ENTROPY;
+            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -39,5 +42,7 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-    return 0;
+cleanup:
+    mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+    return ret;
 }

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/examples/stm32/nucleo_f439zi/hello_world/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_f439zi/hello_world/Src/mbedtls_v4/mbedtls_platform.c
@@ -4,6 +4,7 @@
 #include "main.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_time.h"
+#include "mbedtls/platform_util.h"
 #include "stm32f4xx_hal.h"
 
 mbedtls_ms_time_t mbedtls_ms_time(void)
@@ -24,11 +25,13 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
+    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            return PSA_ERROR_INSUFFICIENT_ENTROPY;
+            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -39,5 +42,7 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-    return 0;
+cleanup:
+    mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+    return ret;
 }

--- a/examples/stm32/nucleo_f439zi/hello_world/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_f439zi/hello_world/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/examples/stm32/nucleo_f439zi/identify_chip/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_f439zi/identify_chip/Src/mbedtls_v4/mbedtls_platform.c
@@ -4,6 +4,7 @@
 #include "main.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_time.h"
+#include "mbedtls/platform_util.h"
 #include "stm32f4xx_hal.h"
 
 mbedtls_ms_time_t mbedtls_ms_time(void)
@@ -24,11 +25,13 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
+    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            return PSA_ERROR_INSUFFICIENT_ENTROPY;
+            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -39,5 +42,7 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-    return 0;
+cleanup:
+    mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+    return ret;
 }

--- a/examples/stm32/nucleo_f439zi/identify_chip/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_f439zi/identify_chip/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/examples/stm32/nucleo_l432kc/hello_world/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_l432kc/hello_world/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/examples/stm32/nucleo_l432kc/identify_chip/Src/mbedtls_v4/mbedtls_platform.c
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
+++ b/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
@@ -20,6 +20,7 @@
 #include "libtropic_logging.h"
 #include "libtropic_macros.h"
 #include "libtropic_port.h"
+#include "libtropic_secure_memzero.h"
 #include "stm32f4xx_hal.h"
 
 #define LT_STM32_F439ZI_GPIO_OUTPUT_CHECK_ATTEMPTS 10
@@ -30,15 +31,14 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     size_t bytes_left = count;
     uint8_t *buff_ptr = buff;
     int ret;
-    lt_ret_t lt_ret = LT_OK;
     uint32_t random_data;
 
     while (bytes_left) {
         ret = HAL_RNG_GenerateRandomNumber(device->rng_handle, &random_data);
         if (ret != HAL_OK) {
             LT_LOG_ERROR("HAL_RNG_GenerateRandomNumber failed, ret=%d", ret);
-            lt_ret = LT_FAIL;
-            goto cleanup;
+            lt_secure_memzero(&random_data, sizeof(random_data));
+            return LT_FAIL;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -47,9 +47,8 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
         buff_ptr += cpy_cnt;
     }
 
-cleanup:
-    explicit_bzero(&random_data, sizeof(random_data));
-    return lt_ret;
+    lt_secure_memzero(&random_data, sizeof(random_data));
+    return LT_OK;
 }
 
 lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)

--- a/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
+++ b/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.c
@@ -30,13 +30,15 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     size_t bytes_left = count;
     uint8_t *buff_ptr = buff;
     int ret;
+    lt_ret_t lt_ret = LT_OK;
     uint32_t random_data;
 
     while (bytes_left) {
         ret = HAL_RNG_GenerateRandomNumber(device->rng_handle, &random_data);
         if (ret != HAL_OK) {
             LT_LOG_ERROR("HAL_RNG_GenerateRandomNumber failed, ret=%d", ret);
-            return LT_FAIL;
+            lt_ret = LT_FAIL;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -45,7 +47,9 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
         buff_ptr += cpy_cnt;
     }
 
-    return LT_OK;
+cleanup:
+    explicit_bzero(&random_data, sizeof(random_data));
+    return lt_ret;
 }
 
 lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)

--- a/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.c
+++ b/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.c
@@ -27,13 +27,15 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
     size_t bytes_left = count;
     uint8_t *buff_ptr = buff;
     int ret;
+    lt_ret_t lt_ret = LT_OK;
     uint32_t random_data;
 
     while (bytes_left) {
         ret = HAL_RNG_GenerateRandomNumber(device->rng_handle, &random_data);
         if (ret != HAL_OK) {
             LT_LOG_ERROR("HAL_RNG_GenerateRandomNumber failed, ret=%d", ret);
-            return LT_FAIL;
+            lt_ret = LT_FAIL;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +44,9 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
         buff_ptr += cpy_cnt;
     }
 
-    return LT_OK;
+cleanup:
+    explicit_bzero(&random_data, sizeof(random_data));
+    return lt_ret;
 }
 
 lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)

--- a/tests/functional/stm32/nucleo_f439zi/Src/mbedtls_v4/mbedtls_platform.c
+++ b/tests/functional/stm32/nucleo_f439zi/Src/mbedtls_v4/mbedtls_platform.c
@@ -4,6 +4,7 @@
 #include "main.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/platform_time.h"
+#include "mbedtls/platform_util.h"
 #include "stm32f4xx_hal.h"
 
 mbedtls_ms_time_t mbedtls_ms_time(void)
@@ -24,11 +25,13 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
+    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            return PSA_ERROR_INSUFFICIENT_ENTROPY;
+            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -39,5 +42,7 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-    return 0;
+cleanup:
+    mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+    return ret;
 }

--- a/tests/functional/stm32/nucleo_f439zi/Src/mbedtls_v4/mbedtls_platform.c
+++ b/tests/functional/stm32/nucleo_f439zi/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/tests/functional/stm32/nucleo_f439zi/Src/wolfcrypt/wolfcrypt_platform.c
+++ b/tests/functional/stm32/nucleo_f439zi/Src/wolfcrypt/wolfcrypt_platform.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/memory.h>
 
 #include "main.h"
 #include "stm32f4xx_hal.h"
@@ -10,11 +11,13 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = sz;
+    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            return RNG_FAILURE_E;
+            ret = RNG_FAILURE_E;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -23,5 +26,7 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
         output += cpy_cnt;
     }
 
-    return 0;
+cleanup:
+    wc_ForceZero(&random_data, sizeof(random_data));
+    return ret;
 }

--- a/tests/functional/stm32/nucleo_f439zi/Src/wolfcrypt/wolfcrypt_platform.c
+++ b/tests/functional/stm32/nucleo_f439zi/Src/wolfcrypt/wolfcrypt_platform.c
@@ -11,13 +11,12 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = sz;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = RNG_FAILURE_E;
-            goto cleanup;
+            wc_ForceZero(&random_data, sizeof(random_data));
+            return RNG_FAILURE_E;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -26,7 +25,6 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
         output += cpy_cnt;
     }
 
-cleanup:
     wc_ForceZero(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/tests/functional/stm32/nucleo_l432kc/Src/mbedtls_v4/mbedtls_platform.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/mbedtls_v4/mbedtls_platform.c
@@ -25,13 +25,12 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = output_size;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = PSA_ERROR_INSUFFICIENT_ENTROPY;
-            goto cleanup;
+            mbedtls_platform_zeroize(&random_data, sizeof(random_data));
+            return PSA_ERROR_INSUFFICIENT_ENTROPY;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -42,7 +41,6 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags, size_t *e
 
     *estimate_bits = 8 * output_size;
 
-cleanup:
     mbedtls_platform_zeroize(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/tests/functional/stm32/nucleo_l432kc/Src/wolfcrypt/wolfcrypt_platform.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/wolfcrypt/wolfcrypt_platform.c
@@ -11,13 +11,12 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = sz;
-    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            ret = RNG_FAILURE_E;
-            goto cleanup;
+            wc_ForceZero(&random_data, sizeof(random_data));
+            return RNG_FAILURE_E;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -26,7 +25,6 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
         output += cpy_cnt;
     }
 
-cleanup:
     wc_ForceZero(&random_data, sizeof(random_data));
-    return ret;
+    return 0;
 }

--- a/tests/functional/stm32/nucleo_l432kc/Src/wolfcrypt/wolfcrypt_platform.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/wolfcrypt/wolfcrypt_platform.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/memory.h>
 
 #include "main.h"
 #include "stm32l4xx_hal.h"
@@ -10,11 +11,13 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
     HAL_StatusTypeDef hal_status = HAL_OK;
     uint32_t random_data;
     size_t bytes_left = sz;
+    int ret = 0;
 
     while (bytes_left) {
         hal_status = HAL_RNG_GenerateRandomNumber(&RNGHandle, &random_data);
         if (hal_status != HAL_OK) {
-            return RNG_FAILURE_E;
+            ret = RNG_FAILURE_E;
+            goto cleanup;
         }
 
         size_t cpy_cnt = bytes_left < sizeof(random_data) ? bytes_left : sizeof(random_data);
@@ -23,5 +26,7 @@ int wolfcrypt_custom_seed_gen(unsigned char *output, unsigned int sz)
         output += cpy_cnt;
     }
 
-    return 0;
+cleanup:
+    wc_ForceZero(&random_data, sizeof(random_data));
+    return ret;
 }


### PR DESCRIPTION
## Description

Adds secure wipe of secrets when generating random numbers on STM32.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [x] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---