### PR TITLE
ETR01SDK-554: Remove libtropic_port.h include from HAL headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Size of `l3_chunk` member of `lt_l2_encrypted_cmd_req_t` and `lt_l2_encrypted_cmd_rsp_t` structs to `TR01_L2_CHUNK_MAX_DATA_SIZE`.
+- `hal/`: don't include `libtropic_port.h` in HAL headers if not used.
 
 ### Removed
 

--- a/hal/arduino/libtropic_port_arduino.h
+++ b/hal/arduino/libtropic_port_arduino.h
@@ -12,8 +12,6 @@
 #include <Arduino.h>
 #include <SPI.h>
 
-#include "libtropic_port.h"
-
 /**
  * @brief Device structure for Arduino port.
  *

--- a/hal/mock/libtropic_port_mock.h
+++ b/hal/mock/libtropic_port_mock.h
@@ -9,7 +9,9 @@
  * @license For the license see file LICENSE.txt file in the root directory of this source tree.
  */
 
-#include "libtropic_port.h"
+#include <stddef.h>
+
+#include "libtropic_common.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.h
+++ b/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.h
@@ -9,7 +9,6 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
-#include "libtropic_port.h"
 #include "stm32f4xx_hal.h"
 
 /**

--- a/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.h
+++ b/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.h
@@ -9,7 +9,6 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
-#include "libtropic_port.h"
 #include "stm32l4xx_hal.h"
 
 /**


### PR DESCRIPTION
## Description

Some HALs include libtropic_port.h even though they don’t use it.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---