### PR TITLE
ETR01SDK-562: Recover previous TROPIC01 mode in lt_init_tr01_attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Size of `l3_chunk` member of `lt_l2_encrypted_cmd_req_t` and `lt_l2_encrypted_cmd_rsp_t` structs to `TR01_L2_CHUNK_MAX_DATA_SIZE`.
 - `hal/`: don't include `libtropic_port.h` in HAL headers if not used.
 - `lt_init()` is successful even if TROPIC01 has invalid Application FW, so Libtropic can be used in Start-up Mode.
+- `lt_init_tr01_attrs()` reboots back to Start-up Mode if TROPIC01 was in this mode before executing the function.
 
 ### Removed
 

--- a/src/lt_tr01_attrs.c
+++ b/src/lt_tr01_attrs.c
@@ -8,6 +8,8 @@
 
 #include "lt_tr01_attrs.h"
 
+#include <stdbool.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_logging.h"
@@ -24,9 +26,11 @@ lt_ret_t lt_init_tr01_attrs(lt_handle_t *h)
     }
 #endif
 
-    lt_ret_t ret;
+    lt_ret_t ret = LT_OK;
     lt_tr01_mode_t tr01_mode;
     uint8_t riscv_fw_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+    bool reboot_to_startup_mode = false;  // Used to track if we need to reboot back to Start-up Mode
+                                          // at the end of this function.
 
     // 1. Set some default dummy values for the attributes
     h->tr01_attrs.r_mem_udata_slot_size_max = 0;
@@ -43,12 +47,14 @@ lt_ret_t lt_init_tr01_attrs(lt_handle_t *h)
         if (ret != LT_OK) {
             return ret;
         }
+
+        reboot_to_startup_mode = true;
     }
 
     // 4. Read Application FW version
     ret = lt_get_info_riscv_fw_ver(h, riscv_fw_ver);
     if (ret != LT_OK) {
-        return ret;
+        goto exit;
     }
 
     // 5. Check if the Application FW version is supported by the current version of libtropic
@@ -59,7 +65,8 @@ lt_ret_t lt_init_tr01_attrs(lt_handle_t *h)
         (riscv_fw_ver[3] == LT_LATEST_RISCV_FW_VER_MAJOR &&
          riscv_fw_ver[2] == LT_LATEST_RISCV_FW_VER_MINOR &&
          riscv_fw_ver[1] > LT_LATEST_RISCV_FW_VER_PATCH)) {
-        return LT_APP_FW_TOO_NEW;
+        ret = LT_APP_FW_TOO_NEW;
+        goto exit;
     }
 
     // 6. Initialize the TROPIC01 attributes structure
@@ -71,5 +78,16 @@ lt_ret_t lt_init_tr01_attrs(lt_handle_t *h)
         h->tr01_attrs.r_mem_udata_slot_size_max = 475;
     }
 
-    return LT_OK;
+// 7. Reboot back to Start-up Mode if we had to reboot in step 3.
+exit:
+    if (reboot_to_startup_mode) {
+        lt_ret_t mtnc_reboot_ret = lt_reboot(h, TR01_MAINTENANCE_REBOOT);
+        if (mtnc_reboot_ret != LT_OK) {
+            LT_LOG_ERROR("Failed to reboot back to Start-up Mode, ret=%s",
+                         lt_ret_verbose(mtnc_reboot_ret));
+            return (ret == LT_OK) ? mtnc_reboot_ret : ret;  // return the first error that occurred.
+        }
+    }
+
+    return ret;
 }


### PR DESCRIPTION
## Description

`lt_init_tr01_attrs` reboots back to Start-up Mode if TROPIC01 was in this mode before calling the function.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [ ] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [ ] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---