### PR TITLE
ETR01SDK-571: Simplify lt_init_tr01_attrs

### DIFF
--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -33,7 +33,8 @@ extern "C" {
  *
  * @param h           Handle for communication with TROPIC01
  *
- * @retval            LT_OK Function executed successfully
+ * @retval            LT_OK Function executed successfully and TROPIC01 is running Application FW, if
+ *                          it is valid.
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get
  * verbose encoding of returned value
  *

--- a/src/lt_tr01_attrs.c
+++ b/src/lt_tr01_attrs.c
@@ -25,33 +25,18 @@ lt_ret_t lt_init_tr01_attrs(lt_handle_t *h)
 #endif
 
     lt_ret_t ret;
-    lt_tr01_mode_t tr01_mode;
     uint8_t riscv_fw_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE];
 
     // 1. Set some default dummy values for the attributes
     h->tr01_attrs.r_mem_udata_slot_size_max = 0;
 
-    // 2. Get current TROPIC01's mode
-    ret = lt_get_tr01_mode(h, &tr01_mode);
-    if (ret != LT_OK) {
-        return ret;
-    }
-
-    // 3. Reboot if TROPIC01 is not executing Application FW.
-    if (tr01_mode != LT_TR01_APPLICATION) {
-        ret = lt_reboot(h, TR01_REBOOT);
-        if (ret != LT_OK) {
-            return ret;
-        }
-    }
-
-    // 4. Read Application FW version
+    // 2. Read Application FW version
     ret = lt_get_info_riscv_fw_ver(h, riscv_fw_ver);
     if (ret != LT_OK) {
         return ret;
     }
 
-    // 5. Check if the Application FW version is supported by the current version of libtropic
+    // 3. Check if the Application FW version is supported by the current version of libtropic
     // TODO: handle FW versions older than 1.0.0
     if (riscv_fw_ver[3] > LT_LATEST_RISCV_FW_VER_MAJOR ||
         (riscv_fw_ver[3] == LT_LATEST_RISCV_FW_VER_MAJOR &&
@@ -62,7 +47,7 @@ lt_ret_t lt_init_tr01_attrs(lt_handle_t *h)
         return LT_APP_FW_TOO_NEW;
     }
 
-    // 6. Initialize the TROPIC01 attributes structure
+    // 4. Initialize the TROPIC01 attributes structure
     // this is the most crucial part - has to be efficient and logically correct
     if (riscv_fw_ver[3] < 2) {
         h->tr01_attrs.r_mem_udata_slot_size_max = 444;

--- a/src/lt_tr01_attrs.h
+++ b/src/lt_tr01_attrs.h
@@ -15,6 +15,8 @@
 
 /**
  * @brief Initializes the lt_tr01_attrs_t structure based on the read Application FW version.
+ * @warning This function expects that TROPIC01 is executing Application FW, otherwise Get_Info_Req for
+ * the Application FW version will fail.
  *
  * @param h   Handle for communication with TROPIC01
  * @retval    LT_OK Function executed successfully

--- a/tests/functional_mock/lt_test_mock_invalid_app_fw_init.c
+++ b/tests/functional_mock/lt_test_mock_invalid_app_fw_init.c
@@ -28,12 +28,12 @@ void lt_test_mock_invalid_app_fw_init(lt_handle_t *h)
 
     lt_mock_hal_reset(&h->l2);
 
-    // 1. Mock lt_init() -> lt_init_tr01_attrs() -> lt_get_tr01_mode() response.
+    // 1. Mock lt_init() -> lt_get_tr01_mode() response.
     LT_LOG_INFO("Mocking Get_Response response...");
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, lt_get_tr01_mode_mocked_response,
                                                        sizeof(lt_get_tr01_mode_mocked_response)));
 
-    // 2. Mock lt_init() -> lt_init_tr01_attrs() -> lt_reboot() response.
+    // 2. Mock lt_init() -> lt_reboot() response.
     LT_LOG_INFO("Mocking Startup_Req response...");
     struct lt_l2_startup_rsp_t startup_req_resp = {
         .chip_status = (TR01_L1_CHIP_MODE_READY_bit | TR01_L1_CHIP_MODE_STARTUP_bit),  // Start-up Mode
@@ -49,7 +49,7 @@ void lt_test_mock_invalid_app_fw_init(lt_handle_t *h)
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&startup_req_resp,
                                                        calc_mocked_resp_len(&startup_req_resp)));
 
-    // 3. Mock lt_init() -> lt_init_tr01_attrs() -> lt_reboot() -> lt_get_tr01_mode() response.
+    // 3. Mock lt_init() -> lt_reboot() -> lt_get_tr01_mode() response.
     LT_LOG_INFO("Mocking Get_Response response...");
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, lt_get_tr01_mode_mocked_response,
                                                        sizeof(lt_get_tr01_mode_mocked_response)));


### PR DESCRIPTION
## Description

- Simplifies `lt_init_tr01_attrs` (no rebooting), it now expects that TROPIC01 is running App FW.
- Handles rebooting in `lt_init` before App FW attributes initialization.
- Adds some clarification comments.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---