### PR TITLE
ETR01SDK-572: fix dead links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We love contributions! To make contributing simple for both sides, please:
 - Create a branch from the develop branch and do the changes:
     - Make sure to follow specifics in our [Coding Style](#coding-style).
     - Make sure to use [Code Formatter](#code-formatter), otherwise the PR check will fail and cannot be merged.
-    - Make sure the branch passes [Tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/functional_tests/) against model -- otherwise, the PR check will fail.
+    - Make sure the branch passes [functional tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_tests/) against TROPIC01 Model and [functional mock tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_mock_tests/) — otherwise, the PR check will fail. In the case of functional tests, they are run against the TROPIC01 Model only, but it is preferable if you can run them against real hardware too.
     - Make sure to run [Static Analysis](#static-analysis).
     - Make sure your [Commit Messages](#commit-messages) follow our guidelines.
 - Create pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We love contributions! To make contributing simple for both sides, please:
 - Create a branch from the develop branch and do the changes:
     - Make sure to follow specifics in our [Coding Style](#coding-style).
     - Make sure to use [Code Formatter](#code-formatter), otherwise the PR check will fail and cannot be merged.
-    - Make sure the branch passes [functional tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_tests/) against TROPIC01 Model and [functional mock tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_mock_tests/), otherwise, the PR check will fail. In the case of functional tests, they are run against the TROPIC01 Model only, but it is preferable if you can run them against real hardware too.
+    - Make sure the branch passes [functional tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_tests/) against TROPIC01 Model and [functional mock tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_mock_tests/), otherwise, the PR check will fail.
     - Make sure to run [Static Analysis](#static-analysis).
     - Make sure your [Commit Messages](#commit-messages) follow our guidelines.
 - Create pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We love contributions! To make contributing simple for both sides, please:
 - Create a branch from the develop branch and do the changes:
     - Make sure to follow specifics in our [Coding Style](#coding-style).
     - Make sure to use [Code Formatter](#code-formatter), otherwise the PR check will fail and cannot be merged.
-    - Make sure the branch passes [functional tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_tests/) against TROPIC01 Model and [functional mock tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_mock_tests/) — otherwise, the PR check will fail. In the case of functional tests, they are run against the TROPIC01 Model only, but it is preferable if you can run them against real hardware too.
+    - Make sure the branch passes [functional tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_tests/) against TROPIC01 Model and [functional mock tests](https://tropicsquare.github.io/libtropic/latest/for_contributors/tests/functional_mock_tests/), otherwise, the PR check will fail. In the case of functional tests, they are run against the TROPIC01 Model only, but it is preferable if you can run them against real hardware too.
     - Make sure to run [Static Analysis](#static-analysis).
     - Make sure your [Commit Messages](#commit-messages) follow our guidelines.
 - Create pull request.


### PR DESCRIPTION
## Description

Fixes dead link to tests documentation in CONTRIBUTING.md.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---