### PR TITLE
ETR01SDK-577: Fix type of baudrate_prescaler in STM32 HALs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hal/`: don't include `libtropic_port.h` in HAL headers if not used.
 - `lt_init()` is successful even if TROPIC01 has invalid Application FW, so Libtropic can be used in Start-up Mode.
 - STM32: securely wipe secrets when generating random numbers.
+- STM32: change type of `baudrate_prescaler` (inside `lt_dev_stm32_nucleo_f439zi_t` and `lt_dev_stm32_nucleo_l432kc_t`) to `uint32_t`.
 
 ### Removed
 

--- a/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.h
+++ b/hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.h
@@ -27,7 +27,7 @@ typedef struct lt_dev_stm32_nucleo_f439zi_t {
      *
      * @note If set to zero, it will default to SPI_BAUDRATEPRESCALER_32.
      */
-    uint16_t baudrate_prescaler;
+    uint32_t baudrate_prescaler;
 
     /** @brief @public GPIO pin used for chip select. Use STM32 macro (GPIO_PIN_XX). */
     uint16_t spi_cs_gpio_pin;

--- a/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.h
+++ b/hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.h
@@ -27,7 +27,7 @@ typedef struct lt_dev_stm32_nucleo_l432kc_t {
      *
      * @note If set to zero, it will default to SPI_BAUDRATEPRESCALER_32.
      */
-    uint16_t baudrate_prescaler;
+    uint32_t baudrate_prescaler;
 
     /** @brief @public GPIO pin used for chip select. Use STM32 macro (GPIO_PIN_XX). */
     uint16_t spi_cs_gpio_pin;


### PR DESCRIPTION
## Description

Changes the type of `baudrate_prescaler` (inside `lt_dev_stm32_nucleo_f439zi_t` and `lt_dev_stm32_nucleo_l432kc_t`) to `uint32_t`.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---