### PR TITLE
ETR01SDK-575: Fix raw SPI data logging

### DIFF
--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -20,7 +20,7 @@
 
 #ifdef LT_PRINT_SPI_DATA
 #include "libtropic_port.h"
-enum lt_spi_dir_t {LT_L1_SPI_DIR_MISO, LT_L1_SPI_DIR_MOSI};
+enum lt_spi_dir_t { LT_L1_SPI_DIR_MISO, LT_L1_SPI_DIR_MOSI };
 static void print_spi_data_hex(const uint8_t *data, const size_t len, enum lt_spi_dir_t dir)
 {
     if ((!data) || (len == 0)) {

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -20,20 +20,22 @@
 
 #ifdef LT_PRINT_SPI_DATA
 #include "libtropic_port.h"
-#define LT_L1_SPI_DIR_MISO 0
-#define LT_L1_SPI_DIR_MOSI 1
-static void print_spi_data_hex(const uint8_t *data, uint8_t len, uint8_t dir)
+enum lt_spi_dir_t {LT_L1_SPI_DIR_MISO, LT_L1_SPI_DIR_MOSI};
+static void print_spi_data_hex(const uint8_t *data, const size_t len, enum lt_spi_dir_t dir)
 {
     if ((!data) || (len == 0)) {
+        LT_LOG_ERROR("Can't print SPI data, invalid argument(s)!");
         return;
     }
-    lt_port_log("SPI     %s", dir ? ">> TX  " : "<< RX  ");
+
+    lt_port_log("SPI     %s", dir == LT_L1_SPI_DIR_MOSI ? ">> TX  " : "<< RX  ");
     for (size_t i = 0; i < len; i++) {
         lt_port_log("%02" PRIX8 " ", data[i]);
         if ((i + 1) % 32 == 0) {
             lt_port_log("\n               ");
         }
     }
+
     lt_port_log("\n");
 }
 #endif

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -19,7 +19,7 @@
 #include "lt_port_wrap.h"
 
 #ifdef LT_PRINT_SPI_DATA
-#include "stdio.h"
+#include "libtropic_port.h"
 #define LT_L1_SPI_DIR_MISO 0
 #define LT_L1_SPI_DIR_MOSI 1
 static void print_hex_chunks(const uint8_t *data, uint8_t len, uint8_t dir)
@@ -27,14 +27,14 @@ static void print_hex_chunks(const uint8_t *data, uint8_t len, uint8_t dir)
     if ((!data) || (len == 0)) {
         return;
     }
-    printf("%s", dir ? "  >>  TX: " : "  <<  RX: ");
+    lt_port_log("SPI     %s", dir ? ">> TX  " : "<< RX  ");
     for (size_t i = 0; i < len; i++) {
-        printf("%02" PRIX8 " ", data[i]);
+        lt_port_log("%02" PRIX8 " ", data[i]);
         if ((i + 1) % 32 == 0) {
-            printf("\n          ");
+            lt_port_log("\n               ");
         }
     }
-    printf("\n");
+    lt_port_log("\n");
 }
 #endif
 

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -22,7 +22,7 @@
 #include "libtropic_port.h"
 #define LT_L1_SPI_DIR_MISO 0
 #define LT_L1_SPI_DIR_MOSI 1
-static void print_hex_chunks(const uint8_t *data, uint8_t len, uint8_t dir)
+static void print_spi_data_hex(const uint8_t *data, uint8_t len, uint8_t dir)
 {
     if ((!data) || (len == 0)) {
         return;
@@ -134,7 +134,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
                 return ret;
             }
 #ifdef LT_PRINT_SPI_DATA
-            print_hex_chunks(s2->buff, s2->buff[2] + 5, LT_L1_SPI_DIR_MISO);
+            print_spi_data_hex(s2->buff, s2->buff[2] + 5, LT_L1_SPI_DIR_MISO);
 #endif
             return LT_OK;
 
@@ -197,7 +197,7 @@ lt_ret_t lt_l1_write(lt_l2_state_t *s2, const uint16_t len, const uint32_t timeo
         return ret;
     }
 #ifdef LT_PRINT_SPI_DATA
-    print_hex_chunks(s2->buff, len, LT_L1_SPI_DIR_MOSI);
+    print_spi_data_hex(s2->buff, len, LT_L1_SPI_DIR_MOSI);
 #endif
     ret = lt_l1_spi_transfer(s2, 0, len, timeout_ms);
     if (ret != LT_OK) {

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -21,7 +21,7 @@
 #ifdef LT_PRINT_SPI_DATA
 #include "libtropic_port.h"
 enum lt_spi_dir_t { LT_L1_SPI_DIR_MISO, LT_L1_SPI_DIR_MOSI };
-static void print_spi_data_hex(const uint8_t *data, const size_t len, enum lt_spi_dir_t dir)
+static void print_spi_data_hex(const uint8_t *data, const size_t len, const enum lt_spi_dir_t dir)
 {
     if ((!data) || (len == 0)) {
         LT_LOG_ERROR("Can't print SPI data, invalid argument(s)!");


### PR DESCRIPTION
## Description

In this PR, I refactor the function for SPI logging:

- used `lt_port_log` instead of `printf` for better portability,
- logging prefix and format is unified with other logging macros (spacing),
- changed name of the function to better describe what it does.

For the next release, we can think about how to integrate this function in logging macros. Probably after we are sure how to structure logging levels.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage