### PR TITLE
ETR01SDK-568: Add STM32U5xx HAL documentation

### DIFF
--- a/docs/compatibility/host_platforms/stm32.md
+++ b/docs/compatibility/host_platforms/stm32.md
@@ -4,6 +4,7 @@ Currently supported STM32 platforms are:
 - NUCLEO-F439ZI
 - NUCLEO-L432KC
     - Using interrupt pin (`LT_USE_INT_PIN`) is not supported for this platform.
+- STM32U5xx series MCUs
 
 HALs for these ports are available in the `libtropic/hal/stm32/` directory.
 

--- a/docs/compatibility/host_platforms/stm32.md
+++ b/docs/compatibility/host_platforms/stm32.md
@@ -4,7 +4,8 @@ Currently supported STM32 platforms are:
 - NUCLEO-F439ZI
 - NUCLEO-L432KC
     - Using interrupt pin (`LT_USE_INT_PIN`) is not supported for this platform.
-- STM32U5xx series MCUs
+- STM32U5xx series MCUs, tested with:
+    - NUCLEO-U545RE-Q
 
 HALs for these ports are available in the `libtropic/hal/stm32/` directory.
 


### PR DESCRIPTION
## Description

Adds documentatio for the STM32U5xx HAL.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---