### PR TITLE
fix,docs: fix license sentence in doxygen file headers

### DIFF
--- a/docs/for_contributors/tests/functional_mock_tests.md
+++ b/docs/for_contributors/tests/functional_mock_tests.md
@@ -97,7 +97,7 @@ Change the lines marked with `TODO`.
  * @brief TODO: FILL ME
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include "libtropic.h"

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
@@ -4,7 +4,7 @@
  * ESP32-C3-DevKit-RUST-1.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/hello_world/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/hello_world/main/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic with the ESP32-C3-DevKit-RUST-1.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/identify_chip/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/identify_chip/main/main.c
@@ -4,7 +4,7 @@
  * ESP32-C3-DevKit-RUST-1.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <inttypes.h>

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
@@ -4,7 +4,7 @@
  * ESP32-DevKitC-V4.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/esp32/ESP32-DevKitC-V4/hello_world/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/hello_world/main/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic with the ESP32-DevKitC-V4.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/esp32/ESP32-DevKitC-V4/identify_chip/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/identify_chip/main/main.c
@@ -4,7 +4,7 @@
  * ESP32-DevKitC-V4.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <inttypes.h>

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
@@ -4,7 +4,7 @@
  * ESP32-S3-DevKitC-1.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/esp32/ESP32-S3-DevKitC-1/hello_world/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/hello_world/main/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic with the ESP32-S3-DevKitC-1.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/esp32/ESP32-S3-DevKitC-1/identify_chip/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/identify_chip/main/main.c
@@ -4,7 +4,7 @@
  * ESP32-S3-DevKitC-1.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <inttypes.h>

--- a/examples/linux/spi/full_chain_verification/main.c
+++ b/examples/linux/spi/full_chain_verification/main.c
@@ -4,7 +4,7 @@
  * verification example.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -4,7 +4,7 @@
  * SPI.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/linux/spi/hello_world/main.c
+++ b/examples/linux/spi/hello_world/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic with Linux SPI.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/linux/spi/identify_chip/main.c
+++ b/examples/linux/spi/identify_chip/main.c
@@ -4,7 +4,7 @@
  * Linux SPI.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/linux/usb_devkit/full_chain_verification/main.c
+++ b/examples/linux/usb_devkit/full_chain_verification/main.c
@@ -4,7 +4,7 @@
  * verification example.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -4,7 +4,7 @@
  * USB devkit.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/linux/usb_devkit/hello_world/main.c
+++ b/examples/linux/usb_devkit/hello_world/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic with the USB devkit.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/linux/usb_devkit/identify_chip/main.c
+++ b/examples/linux/usb_devkit/identify_chip/main.c
@@ -4,7 +4,7 @@
  * USB devkit.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/examples/model/hello_world/main.c
+++ b/examples/model/hello_world/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic with the model.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <arpa/inet.h>

--- a/examples/model/separate_api/main.c
+++ b/examples/model/separate_api/main.c
@@ -3,7 +3,7 @@
  * @brief Simple example of using Libtropic's Separate API with the model.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <arpa/inet.h>

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -4,7 +4,7 @@
  * Nucleo F439ZI board.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the UART/UART_Printf example from STM32 example library
  * which was created by the MCD Application Team.

--- a/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic on STM32 Nucleo F439ZI board.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the UART/UART_Printf example from STM32 example library
  * which was created by the MCD Application Team.

--- a/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
@@ -4,7 +4,7 @@
  * STM32 Nucleo F439ZI board.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the UART/UART_Printf example from STM32 example library
  * which was created by the MCD Application Team.

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -4,7 +4,7 @@
  * Nucleo L432KC board.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the SPI/SPI_FullDuplex_ComPolling example from STM32 example
  * library which was created by the MCD Application Team.

--- a/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
@@ -3,7 +3,7 @@
  * @brief Simple "Hello, World!" example of using Libtropic on STM32 Nucleo L432KC board.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the SPI/SPI_FullDuplex_ComPolling example from STM32 example
  * library which was created by the MCD Application Team.

--- a/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
@@ -4,7 +4,7 @@
  * STM32 Nucleo L432KC board.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the SPI/SPI_FullDuplex_ComPolling example from STM32 example
  * library which was created by the MCD Application Team.

--- a/hal/mock/libtropic_port_mock.c
+++ b/hal/mock/libtropic_port_mock.c
@@ -3,7 +3,7 @@
  * @brief Mock HAL implementation (only for testing purposes).
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include "libtropic_port_mock.h"

--- a/hal/mock/libtropic_port_mock.h
+++ b/hal/mock/libtropic_port_mock.h
@@ -6,7 +6,7 @@
  * @brief Mock HAL implementation (only for testing purposes).
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stddef.h>

--- a/tests/functional/linux/spi/main.c
+++ b/tests/functional/linux/spi/main.c
@@ -2,7 +2,7 @@
  * @file main.c
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <string.h>

--- a/tests/functional/linux/spi_native_cs/main.c
+++ b/tests/functional/linux/spi_native_cs/main.c
@@ -2,7 +2,7 @@
  * @file main.c
  * @author Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <string.h>

--- a/tests/functional/linux/usb_devkit/main.c
+++ b/tests/functional/linux/usb_devkit/main.c
@@ -2,7 +2,7 @@
  * @file main.c
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <string.h>

--- a/tests/functional/model/main.c
+++ b/tests/functional/model/main.c
@@ -3,7 +3,7 @@
  * @brief Common entrypoint for running functional tests against TROPIC01 model.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <arpa/inet.h>

--- a/tests/functional/stm32/nucleo_f439zi/Src/main.c
+++ b/tests/functional/stm32/nucleo_f439zi/Src/main.c
@@ -3,7 +3,7 @@
  * @brief Wrapper project for running Libtropic functional test suite on Nucleo F439ZI.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the UART/UART_Printf example from STM32 example library
  * which was created by the MCD Application Team.

--- a/tests/functional/stm32/nucleo_l432kc/Src/main.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/main.c
@@ -3,7 +3,7 @@
  * @brief Wrapper project for running Libtropic functional test suite on Nucleo L432KC.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  *
  * This example project is based on the SPI/SPI_FullDuplex_ComPolling example from STM32 example
  * library which was created by the MCD Application Team.

--- a/tests/functional/stm32/nucleo_u545re_q/Src/main.c
+++ b/tests/functional/stm32/nucleo_u545re_q/Src/main.c
@@ -1,0 +1,361 @@
+/**
+ * @file main.c
+ * @brief Wrapper project for running Libtropic functional test suite on Nucleo U545RE-Q.
+ * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
+ *
+ * @license For the license see LICENSE.md in the root directory of this source tree.
+ *
+ * This file was generated using Stm32CubeMX and modified by Tropic Square to run Libtropic functional
+ * tests. The original notice:
+ *
+ * Copyright (c) 2026 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file in the root directory of
+ * this software component. If no LICENSE file comes with this software, it is provided AS-IS.
+ */
+/* Includes ------------------------------------------------------------------*/
+#include "main.h"
+
+#include <inttypes.h>
+#include <string.h>
+
+#include "libtropic.h"
+#include "libtropic_functional_tests.h"
+#include "libtropic_logging.h"
+#include "libtropic_port_stm32u5xx.h"
+#include "lt_test_common.h"
+
+#if LT_USE_TREZOR_CRYPTO
+#include "libtropic_trezor_crypto.h"
+#define CRYPTO_CTX_TYPE lt_ctx_trezor_crypto_t
+#elif LT_USE_MBEDTLS_V4
+#include "libtropic_mbedtls_v4.h"
+#include "psa/crypto.h"
+#define CRYPTO_CTX_TYPE lt_ctx_mbedtls_v4_t
+#elif LT_USE_WOLFCRYPT
+#include "libtropic_wolfcrypt.h"
+#include "wolfssl/wolfcrypt/error-crypt.h"
+#include "wolfssl/wolfcrypt/wc_port.h"
+#define CRYPTO_CTX_TYPE lt_ctx_wolfcrypt_t
+#endif
+
+/* Private variables ---------------------------------------------------------*/
+/* RNG handle declaration */
+RNG_HandleTypeDef hrng;
+
+/* UART handle declaration */
+UART_HandleTypeDef huart1;
+
+/* Private function prototypes -----------------------------------------------*/
+void SystemClock_Config(void);
+static void SystemPower_Config(void);
+static void MX_GPIO_Init(void);
+static void MX_ICACHE_Init(void);
+static void MX_RNG_Init(void);
+static void MX_USART1_UART_Init(void);
+
+#if defined(__ICCARM__)
+/* New definition from EWARM V9, compatible with EWARM8 */
+int iar_fputc(int ch);
+#define PUTCHAR_PROTOTYPE int iar_fputc(int ch)
+#elif defined(__CC_ARM) || defined(__ARMCC_VERSION)
+/* ARM Compiler 5/6*/
+#define PUTCHAR_PROTOTYPE int fputc(int ch, FILE *f)
+#elif defined(__GNUC__)
+#define PUTCHAR_PROTOTYPE int __io_putchar(int ch)
+#endif /* __ICCARM__ */
+
+/* Private user code ---------------------------------------------------------*/
+/* USER CODE BEGIN 0 */
+
+/* USER CODE END 0 */
+
+/**
+ * @brief  The application entry point.
+ * @retval int
+ */
+int main(void)
+{
+    /* MCU Configuration--------------------------------------------------------*/
+
+    /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+    HAL_Init();
+
+    /* Configure the System Power */
+    SystemPower_Config();
+
+    /* Configure the system clock */
+    SystemClock_Config();
+
+    /* Initialize all configured peripherals */
+    MX_GPIO_Init();
+    MX_ICACHE_Init();
+    MX_RNG_Init();
+    MX_USART1_UART_Init();
+
+    /* libtropic related code BEGIN */
+    /* libtropic related code BEGIN */
+    /* libtropic related code BEGIN */
+    /* libtropic related code BEGIN */
+    /* libtropic related code BEGIN */
+
+    /* Cryptographic function provider initialization. */
+#if LT_USE_MBEDTLS_V4
+    psa_status_t status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        LT_LOG_ERROR("PSA Crypto initialization failed, status=%d (psa_status_t)", status);
+        return -1;
+    }
+#elif LT_USE_WOLFCRYPT
+    int ret = wolfCrypt_Init();
+    if (ret != 0) {
+        LT_LOG_ERROR("WolfCrypt initialization failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
+        return ret;
+    }
+#endif
+
+    /* Libtropic handle initialization */
+    lt_handle_t lt_handle = {0};
+
+    /* Device mappings */
+    lt_dev_stm32u5xx_t device = {0};
+
+    device.spi_instance = SPI1;
+    device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_2;
+    device.spi_cs_gpio_bank = GPIOC;
+    device.spi_cs_gpio_pin = GPIO_PIN_9;
+    device.rng_handle = &hrng;
+
+#ifdef LT_USE_INT_PIN
+    device.int_gpio_bank = GPIOC;
+    device.int_gpio_pin = GPIO_PIN_8;
+#endif
+
+    lt_handle.l2.device = &device;
+
+    /* Crypto abstraction layer (CAL) context (selectable). */
+    CRYPTO_CTX_TYPE crypto_ctx;
+    lt_handle.l3.crypto_ctx = &crypto_ctx;
+
+    /* Test code (correct test function is selected automatically per binary)
+       __lt_handle__ identifier is used by the test registry. */
+    lt_handle_t *__lt_handle__ = &lt_handle;
+#include "lt_test_registry.c.inc"
+
+    /* Cryptographic function provider deinitialization. */
+#if LT_USE_MBEDTLS_V4
+    mbedtls_psa_crypto_free();
+#elif LT_USE_WOLFCRYPT
+    ret = wolfCrypt_Cleanup();
+    if (ret != 0) {
+        LT_LOG_ERROR("WolfCrypt cleanup failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
+        return ret;
+    }
+#endif
+
+    /* Inform the test runner that the test finished */
+    LT_FINISH_TEST();
+
+    /* libtropic related code END */
+    /* libtropic related code END */
+    /* libtropic related code END */
+    /* libtropic related code END */
+    /* libtropic related code END */
+
+    /* Not strictly necessary, but we deinitialize RNG here to demonstrate proper usage. */
+    if (HAL_RNG_DeInit(&hrng) != HAL_OK) {
+        Error_Handler();
+    }
+
+    while (1) {
+    }
+}
+
+/**
+ * @brief System Clock Configuration
+ * @retval None
+ */
+void SystemClock_Config(void)
+{
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+
+    /** Configure the main internal regulator output voltage
+     */
+    if (HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1) != HAL_OK) {
+        Error_Handler();
+    }
+
+    /** Initializes the CPU, AHB and APB buses clocks
+     */
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_HSI;
+    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
+    RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
+    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLMBOOST = RCC_PLLMBOOST_DIV1;
+    RCC_OscInitStruct.PLL.PLLM = 1;
+    RCC_OscInitStruct.PLL.PLLN = 10;
+    RCC_OscInitStruct.PLL.PLLP = 2;
+    RCC_OscInitStruct.PLL.PLLQ = 2;
+    RCC_OscInitStruct.PLL.PLLR = 1;
+    RCC_OscInitStruct.PLL.PLLRGE = RCC_PLLVCIRANGE_0;
+    RCC_OscInitStruct.PLL.PLLFRACN = 0;
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        Error_Handler();
+    }
+
+    /** Initializes the CPU, AHB and APB buses clocks
+     */
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 |
+                                  RCC_CLOCKTYPE_PCLK2 | RCC_CLOCKTYPE_PCLK3;
+    RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+    RCC_ClkInitStruct.APB3CLKDivider = RCC_HCLK_DIV1;
+
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK) {
+        Error_Handler();
+    }
+}
+
+/**
+ * @brief Power Configuration
+ * @retval None
+ */
+static void SystemPower_Config(void)
+{
+    /*
+     * Switch to SMPS regulator instead of LDO
+     */
+    if (HAL_PWREx_ConfigSupply(PWR_SMPS_SUPPLY) != HAL_OK) {
+        Error_Handler();
+    }
+}
+
+/**
+ * @brief ICACHE Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_ICACHE_Init(void)
+{
+    /** Enable instruction cache in 1-way (direct mapped cache)
+     */
+    if (HAL_ICACHE_ConfigAssociativityMode(ICACHE_1WAY) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_ICACHE_Enable() != HAL_OK) {
+        Error_Handler();
+    }
+}
+
+/**
+ * @brief RNG Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_RNG_Init(void)
+{
+    hrng.Instance = RNG;
+    hrng.Init.ClockErrorDetection = RNG_CED_ENABLE;
+    if (HAL_RNG_Init(&hrng) != HAL_OK) {
+        Error_Handler();
+    }
+}
+
+/**
+ * @brief USART1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_USART1_UART_Init(void)
+{
+    huart1.Instance = USART1;
+    huart1.Init.BaudRate = 115200;
+    huart1.Init.WordLength = UART_WORDLENGTH_8B;
+    huart1.Init.StopBits = UART_STOPBITS_1;
+    huart1.Init.Parity = UART_PARITY_NONE;
+    huart1.Init.Mode = UART_MODE_TX_RX;
+    huart1.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+    huart1.Init.OverSampling = UART_OVERSAMPLING_16;
+    huart1.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+    huart1.Init.ClockPrescaler = UART_PRESCALER_DIV1;
+    huart1.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_NO_INIT;
+    if (HAL_UART_Init(&huart1) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_UARTEx_SetTxFifoThreshold(&huart1, UART_TXFIFO_THRESHOLD_1_8) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_UARTEx_SetRxFifoThreshold(&huart1, UART_RXFIFO_THRESHOLD_1_8) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_UARTEx_DisableFifoMode(&huart1) != HAL_OK) {
+        Error_Handler();
+    }
+}
+
+/**
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_GPIO_Init(void)
+{
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+}
+
+/**
+ * @brief  Retargets the C library printf function to the USART.
+ * @param  None
+ * @retval None
+ */
+PUTCHAR_PROTOTYPE
+{
+    /*  Translates LF to CFLF, as this is what most serial monitors expect
+        by default
+    */
+    if (ch == '\n') {
+        HAL_UART_Transmit(&huart1, (uint8_t *)"\r\n", 2, 0xFFFF);
+    }
+    else {
+        HAL_UART_Transmit(&huart1, (uint8_t *)&ch, 1, 0xFFFF);
+    }
+
+    return ch;
+}
+
+/**
+ * @brief  This function is executed in case of error occurrence.
+ * @retval None
+ */
+void Error_Handler(void)
+{
+    __disable_irq();
+    while (1) {
+    }
+}
+#ifdef USE_FULL_ASSERT
+/**
+ * @brief  Reports the name of the source file and the source line number
+ *         where the assert_param error has occurred.
+ * @param  file: pointer to the source file name
+ * @param  line: assert_param error line source number
+ * @retval None
+ */
+void assert_failed(uint8_t *file, uint32_t line)
+{
+    /* User can add his own implementation to report the file name and line number,
+       ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+
+    /* Infinite loop */
+    while (1) {
+    }
+}
+#endif /* USE_FULL_ASSERT */

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -3,7 +3,7 @@
  * @brief Helper functions for functional mock tests.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include "lt_mock_helpers.h"

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -6,7 +6,7 @@
  * @brief Helper functions for functional mock tests.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdint.h>

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -6,7 +6,7 @@
  * @brief Declaration of functional mock test functions.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include "libtropic_common.h"

--- a/tests/functional_mock/lt_test_mock_attrs.c
+++ b/tests/functional_mock/lt_test_mock_attrs.c
@@ -3,7 +3,7 @@
  * @brief Test for checking if TROPIC01 attributes are set correctly based on RISC-V FW version.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <inttypes.h>

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -3,7 +3,7 @@
  * @brief Test HARDWARE_FAIL L3 Result handling.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <inttypes.h>

--- a/tests/functional_mock/lt_test_mock_invalid_app_fw_init.c
+++ b/tests/functional_mock/lt_test_mock_invalid_app_fw_init.c
@@ -3,7 +3,7 @@
  * @brief Test for checking that lt_init suceeds if Application FW cannot be booted.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include "libtropic.h"

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -3,7 +3,7 @@
  * @brief Test for handling invalid CRC in TROPIC01 responses.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include "libtropic.h"

--- a/tests/functional_mock/main.c.in
+++ b/tests/functional_mock/main.c.in
@@ -3,7 +3,7 @@
  * @brief Main file for running functional mock tests.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
- * @license For the license see file LICENSE.txt file in the root directory of this source tree.
+ * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
 #include <stdio.h>


### PR DESCRIPTION
## Description

Fixes the sentence with license in the doxygen file headers.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---