### PR TITLE
fix(stm32 tests): disable servers when calling openocd

### DIFF
--- a/tests/functional/stm32/nucleo_f439zi/run_test.sh
+++ b/tests/functional/stm32/nucleo_f439zi/run_test.sh
@@ -88,11 +88,19 @@ trap 'cleanup' EXIT
 # ---- Flash the device ----
 if [ -z "$STLINK_SERIAL_NUMBER" ]; then
     echo "OpenOCD will autodiscover STLink programming interface."
-    openocd -f board/stm32f429discovery.cfg -c "program $BINARY_PATH verify reset exit"
+    openocd -f board/stm32f429discovery.cfg \
+        -c "gdb_port disabled" \
+        -c "telnet_port disabled" \
+        -c "tcl_port disabled" \
+        -c "program $BINARY_PATH verify reset exit"
 else
-    OPENOCD_SERIAL_NUMBER_ARG=
     echo "OpenOCD will use STLink serial number $STLINK_SERIAL_NUMBER for programming."
-    openocd -f board/stm32f429discovery.cfg -c "adapter serial $STLINK_SERIAL_NUMBER" -c "program $BINARY_PATH verify reset exit"
+    openocd -f board/stm32f429discovery.cfg \
+        -c "gdb_port disabled" \
+        -c "telnet_port disabled" \
+        -c "tcl_port disabled" \
+        -c "adapter serial $STLINK_SERIAL_NUMBER" \
+        -c "program $BINARY_PATH verify reset exit"
 fi
 
 # ---- Wait for serial reader to finish ----

--- a/tests/functional/stm32/nucleo_l432kc/run_test.sh
+++ b/tests/functional/stm32/nucleo_l432kc/run_test.sh
@@ -88,11 +88,19 @@ trap 'cleanup' EXIT
 # ---- Flash the device ----
 if [ -z "$STLINK_SERIAL_NUMBER" ]; then
     echo "OpenOCD will autodiscover STLink programming interface."
-    openocd -f board/st_nucleo_l4.cfg -c "program $BINARY_PATH verify reset exit"
+    openocd -f board/st_nucleo_l4.cfg \
+        -c "gdb_port disabled" \
+        -c "telnet_port disabled" \
+        -c "tcl_port disabled" \
+        -c "program $BINARY_PATH verify reset exit"
 else
-    OPENOCD_SERIAL_NUMBER_ARG=
     echo "OpenOCD will use STLink serial number $STLINK_SERIAL_NUMBER for programming."
-    openocd -f board/st_nucleo_l4.cfg -c "adapter serial $STLINK_SERIAL_NUMBER" -c "program $BINARY_PATH verify reset exit"
+    openocd -f board/st_nucleo_l4.cfg \
+        -c "gdb_port disabled" \
+        -c "telnet_port disabled" \
+        -c "tcl_port disabled" \
+        -c "adapter serial $STLINK_SERIAL_NUMBER" \
+        -c "program $BINARY_PATH verify reset exit"
 fi
 
 # ---- Wait for serial reader to finish ----

--- a/tests/functional/stm32/nucleo_u545re_q/run_test.sh
+++ b/tests/functional/stm32/nucleo_u545re_q/run_test.sh
@@ -91,11 +91,19 @@ trap 'cleanup' EXIT
 # ---- Flash the device ----
 if [ -z "$STLINK_SERIAL_NUMBER" ]; then
     echo "OpenOCD will autodiscover STLink programming interface."
-    openocd -f "$SCRIPT_DIR/nucleo-u5xx.cfg" -c "program $BINARY_PATH verify reset exit"
+    openocd -f "$SCRIPT_DIR/nucleo-u5xx.cfg" \
+        -c "gdb_port disabled" \
+        -c "telnet_port disabled" \
+        -c "tcl_port disabled" \
+        -c "program $BINARY_PATH verify reset exit"
 else
-    OPENOCD_SERIAL_NUMBER_ARG=
     echo "OpenOCD will use STLink serial number $STLINK_SERIAL_NUMBER for programming."
-    openocd -f "$SCRIPT_DIR/nucleo-u5xx.cfg" -c "adapter serial $STLINK_SERIAL_NUMBER" -c "program $BINARY_PATH verify reset exit"
+    openocd -f "$SCRIPT_DIR/nucleo-u5xx.cfg" \
+        -c "gdb_port disabled" \
+        -c "telnet_port disabled" \
+        -c "tcl_port disabled" \
+        -c "adapter serial $STLINK_SERIAL_NUMBER" \
+        -c "program $BINARY_PATH verify reset exit"
 fi
 
 # ---- Wait for serial reader to finish ----


### PR DESCRIPTION
## Description

- Disables gdb, telnet and tcl servers when launching openocd in STM32 tests.
- Removes the unused `OPENOCD_SERIAL_NUMBER_ARG` variable in the scripts.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---