### PR TITLE
ETR01SDK-563: Mention that lt_deinit and lt_init has to be called after FW update

### DIFF
--- a/docs/common/examples_descriptions/fw_update.md
+++ b/docs/common/examples_descriptions/fw_update.md
@@ -3,6 +3,9 @@ This example explains the firmware update process for both ABAB and ACAB silicon
 - How to read the current firmware versions.
 - How to update the firmware using `lt_do_mutable_fw_update()`.
 
+    !!! info "Updating FW with `lt_do_mutable_fw_update()` in Your Application"
+        If you are using `lt_do_mutable_fw_update()` in your application to update TROPIC01's FW, make sure to reinitialize the handle (`lt_handle_t`) after the function returns successfully, i.e. call `lt_deinit()` and `lt_init()`.
+
 !!! info "TROPIC01 Firmware"
     For more information about the firmware itself, refer to the [TROPIC01 Firmware](/reference/tropic01_fw.md) section.
 

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -794,6 +794,8 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id,
 
 /**
  * @brief Performs mutable firmware update on ABAB and ACAB silicon revisions.
+ * @important After this functions returns successfully, the handle (`lt_handle_t`) has to be
+ * initialized again (i.e. calling `lt_deinit()` and `lt_init()`).
  *
  * @param h                 Handle for communication with TROPIC01
  * @param update_data       Pointer to the data to be written

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -794,7 +794,7 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id,
 
 /**
  * @brief Performs mutable firmware update on ABAB and ACAB silicon revisions.
- * @important After this functions returns successfully, the handle (`lt_handle_t`) has to be
+ * @important After this function returns successfully, the handle (`lt_handle_t`) has to be
  * initialized again (i.e. calling `lt_deinit()` and `lt_init()`).
  *
  * @param h                 Handle for communication with TROPIC01

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -28,8 +28,8 @@ extern "C" {
 
 /**
  * @brief Initialize handle and transport layer.
- * @note If the function fails, `lt_deinit` must not be called. In this case, the function handles the
- * cleanup itself.
+ * @note If the function fails, `lt_deinit()` must not be called. In this case, the function handles
+ * the cleanup itself.
  *
  * @param h           Handle for communication with TROPIC01
  *


### PR DESCRIPTION
## Description

Adds mentions about the need of reinitializing the handle after a successful call of `lt_do_mutable_fw_update`.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---