### PR TITLE
fix: libtropic_examples.h and libtropic_functional_tests.h includes deleted

### DIFF
--- a/hal/rpi-pico/libtropic_port_rpi_pico.c
+++ b/hal/rpi-pico/libtropic_port_rpi_pico.c
@@ -14,8 +14,6 @@
 #include "hardware/gpio.h"
 #include "hardware/spi.h"
 #include "libtropic_common.h"
-#include "libtropic_examples.h"
-#include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
 #include "libtropic_macros.h"
 #include "libtropic_port.h"


### PR DESCRIPTION
## Description

This pull request removes the following includes from the `libtropic_port_rpi_pico.c` file in the rpi_pico HAL.

```
#include  libtropic_examples.h 
#include libtropic_functional_tests.h
```

These includes are unnecessary and cause compilation errors when used in a project.

Reference related issues or tickets: [#458](https://github.com/tropicsquare/libtropic/issues/458) and [#464](https://github.com/tropicsquare/libtropic/pull/464)

---

## Type of Change

Select the type(s) that best describe your change:

- [ x ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [ x ] I opened the Pull Request to the **develop** branch
- [ x ] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [ ] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [ ] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [ x ] The project **builds without errors or warnings**  
- [ x ] I have **verified the functionality against the hardware/model** as applicable  
- [ x ] I have ensured that public APIs remain backward compatible (if applicable)  
- [ x ] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage

---