### PR TITLE
ETR01SDK-603: Enhance/unify read and write functions in USB Devkit HAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- USB DevKit HAL: call `write()` in a loop, allow `EINTR` error code.
+
 ## [3.2.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- USB DevKit HAL: call `write()` in a loop, allow `EINTR` error code.
+- USB DevKit HAL: call `write()` in a loop, allow `EINTR` error code for both `write()` and `read()`.
 
 ## [3.2.0]
 

--- a/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
+++ b/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
@@ -107,7 +107,7 @@ static bool read_port(int fd, uint8_t *buffer, size_t size)
         }
 
         if (read_bytes == 0) {
-            LT_LOG_ERROR("read() timed out.");
+            LT_LOG_ERROR("Failed to read from port (read() returned 0): timeout or EOF.");
             return false;
         }
 

--- a/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
+++ b/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
@@ -17,6 +17,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -45,50 +46,75 @@
 
 /**
  * @brief Writes data to a serial port (specified by fd).
+ * @note Returns after all bytes have been written or if an error occured (EINTR is tolerated).
  *
- * @param  fd        File descriptor of the port to write to.
- * @param  buffer    Pointer to the buffer containing the data to be written.
- * @param  size      Size of the data in bytes to be written from the buffer.
+ * @param[in] fd      File descriptor of the port to write to.
+ * @param[in] buffer  Pointer to the buffer containing the data to be written.
+ * @param[in] size    Size of the data in bytes to be written from the buffer.
  *
- * @return Returns 0 on success, or -1 on error.
+ * @return Returns true on success, false on error.
  */
-static int write_port(int fd, uint8_t *buffer, size_t size)
+static bool write_port(int fd, const uint8_t *buffer, size_t size)
 {
-    ssize_t written_bytes = write(fd, buffer, size);
-    if (written_bytes != (ssize_t)size) {
-        LT_LOG_ERROR("Failed to write to port, written_bytes=%zd.", written_bytes);
-        return -1;
+    size_t written_total = 0;
+
+    while (written_total < size) {
+        ssize_t written_bytes = write(fd, buffer + written_total, size - written_total);
+        if (written_bytes < 0) {
+            if (errno == EINTR) {
+                LT_LOG_INFO("write() interrupted by a signal, will try again.");
+                continue;
+            }
+            LT_LOG_ERROR("write() failed: errno=%d (%s).", errno, strerror(errno));
+            return false;
+        }
+
+        if (written_bytes == 0) {
+            LT_LOG_ERROR("Failed to write to port (write() returned 0).");
+            return false;
+        }
+
+        written_total += (size_t)written_bytes;
     }
-    return 0;
+
+    return true;
 }
 
 /**
  * @brief Reads data from a serial port (specified by fd).
+ * @note Returns after all bytes have been read, after a timeout or if an error occured (EINTR is
+ * tolerated).
  *
- * @note  Returns after all the desired bytes have been read, or if there is a timeout or other error.
+ * @param[in]  fd      The file descriptor to read from.
+ * @param[out] buffer  Pointer to the buffer where the read data will be stored.
+ * @param[in]  size    The maximum number of bytes to read into the buffer.
  *
- * @param fd        The file descriptor to read from.
- * @param buffer    Pointer to the buffer where the read data will be stored.
- * @param size      The maximum number of bytes to read into the buffer.
- *
- * @return Returns the number of bytes actually read on success, or -1 on error.
+ * @return Returns true on success, false on error.
  */
-static ssize_t read_port(int fd, uint8_t *buffer, size_t size)
+static bool read_port(int fd, uint8_t *buffer, size_t size)
 {
     size_t received = 0;
+
     while (received < size) {
         ssize_t read_bytes = read(fd, buffer + received, size - received);
         if (read_bytes < 0) {
-            LT_LOG_ERROR("Failed to read from port, read_bytes=%zd.", read_bytes);
-            return -1;
+            if (errno == EINTR) {
+                LT_LOG_INFO("read() interrupted by a signal, will try again.");
+                continue;
+            }
+            LT_LOG_ERROR("read() failed: errno=%d (%s).", errno, strerror(errno));
+            return false;
         }
+
         if (read_bytes == 0) {
-            // Timeout.
-            break;
+            LT_LOG_ERROR("read() timed out.");
+            return false;
         }
-        received += read_bytes;
+
+        received += (size_t)read_bytes;
     }
-    return received;
+
+    return true;
 }
 
 lt_ret_t lt_port_init(lt_l2_state_t *s2)
@@ -223,17 +249,19 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
     lt_dev_posix_usb_dongle_t *device = (lt_dev_posix_usb_dongle_t *)s2->device;
 
     uint8_t cs_high[] = "CS=0\n";  // Yes, CS=0 really means that CSN is low
-    if (write_port(device->fd, cs_high, 5) != 0) {
+    if (!write_port(device->fd, cs_high, 5)) {
+        LT_LOG_ERROR("Failed to send CS=0 command.");
         return LT_L1_SPI_ERROR;
     }
 
     uint8_t buff[4];
-    int read_bytes = read_port(device->fd, buff, 4);
-    if (read_bytes != 4) {
+    if (!read_port(device->fd, buff, 4)) {
+        LT_LOG_ERROR("Failed to read response for CS=0 command.");
         return LT_L1_SPI_ERROR;
     }
 
     if (memcmp(buff, "OK\r\n", 4) != 0) {
+        LT_LOG_ERROR("USB DevKit did not ACK CS=0 command.");
         return LT_L1_SPI_ERROR;
     }
     return LT_OK;
@@ -250,7 +278,8 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
         return LT_L1_DATA_LEN_ERROR;
     }
 
-    // Bytes from handle which are about to be sent are encoded as chars and stored to buffered_chars.
+    // Bytes from handle which are about to be sent are encoded as chars and stored to
+    // buffered_chars.
     uint8_t buffered_chars[LT_USB_DONGLE_SPI_TRANSFER_BUFF_SIZE_MAX] = {0};
     for (int i = 0; i < tx_data_length; i++) {
         sprintf((char *)(buffered_chars + i * 2), "%02" PRIX8, s2->buff[i + offset]);
@@ -261,15 +290,15 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
     buffered_chars[tx_data_length * 2] = 'x';
     buffered_chars[tx_data_length * 2 + 1] = '\n';
 
-    int ret = write_port(device->fd, buffered_chars, (tx_data_length * 2) + 2);
-    if (ret != 0) {
+    if (!write_port(device->fd, buffered_chars, (tx_data_length * 2) + 2)) {
+        LT_LOG_ERROR("Failed to write SPI payload.");
         return LT_L1_SPI_ERROR;
     }
 
     lt_port_delay(s2, LT_USB_DONGLE_READ_WRITE_DELAY);
 
-    int read_bytes = read_port(device->fd, buffered_chars, (2 * tx_data_length) + 2);
-    if (read_bytes != ((2 * tx_data_length) + 2)) {
+    if (!read_port(device->fd, buffered_chars, (2 * tx_data_length) + 2)) {
+        LT_LOG_ERROR("Failed to read SPI payload.");
         return LT_L1_SPI_ERROR;
     }
 

--- a/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
+++ b/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
@@ -24,7 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <termios.h>
-#include <time.h>
 #include <unistd.h>
 
 #include "libtropic_common.h"
@@ -44,6 +43,9 @@
 #define GETENTROPY_MAX 256
 #endif
 
+// Maximum number of consecutive EINTR retries for read()/write() operations.
+#define LT_PORT_EINTR_RETRY_MAX 10U
+
 /**
  * @brief Writes data to a serial port (specified by fd).
  * @note Returns after all bytes have been written or if an error occurred (EINTR is tolerated).
@@ -57,17 +59,25 @@
 static bool write_port(int fd, const uint8_t *buffer, size_t size)
 {
     size_t written_total = 0;
+    size_t eintr_retries = 0;  // Used for tracking retries upon receiving EINTR.
 
     while (written_total < size) {
         ssize_t written_bytes = write(fd, buffer + written_total, size - written_total);
         if (written_bytes < 0) {
             if (errno == EINTR) {
+                if (++eintr_retries > LT_PORT_EINTR_RETRY_MAX) {
+                    LT_LOG_ERROR("write() returned EINTR too many times (max=%u).",
+                                 LT_PORT_EINTR_RETRY_MAX);
+                    return false;
+                }
                 LT_LOG_INFO("write() interrupted by a signal, will try again.");
                 continue;
             }
             LT_LOG_ERROR("write() failed: errno=%d (%s).", errno, strerror(errno));
             return false;
         }
+
+        eintr_retries = 0;
 
         if (written_bytes == 0) {
             LT_LOG_ERROR("Failed to write to port (write() returned 0).");
@@ -94,17 +104,25 @@ static bool write_port(int fd, const uint8_t *buffer, size_t size)
 static bool read_port(int fd, uint8_t *buffer, size_t size)
 {
     size_t received = 0;
+    size_t eintr_retries = 0;  // Used for tracking retries upon receiving EINTR.
 
     while (received < size) {
         ssize_t read_bytes = read(fd, buffer + received, size - received);
         if (read_bytes < 0) {
             if (errno == EINTR) {
+                if (++eintr_retries > LT_PORT_EINTR_RETRY_MAX) {
+                    LT_LOG_ERROR("read() returned EINTR too many times (max=%u).",
+                                 LT_PORT_EINTR_RETRY_MAX);
+                    return false;
+                }
                 LT_LOG_INFO("read() interrupted by a signal, will try again.");
                 continue;
             }
             LT_LOG_ERROR("read() failed: errno=%d (%s).", errno, strerror(errno));
             return false;
         }
+
+        eintr_retries = 0;
 
         if (read_bytes == 0) {
             LT_LOG_ERROR("Failed to read from port (read() returned 0): timeout or EOF.");

--- a/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
+++ b/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
@@ -46,7 +46,7 @@
 
 /**
  * @brief Writes data to a serial port (specified by fd).
- * @note Returns after all bytes have been written or if an error occured (EINTR is tolerated).
+ * @note Returns after all bytes have been written or if an error occurred (EINTR is tolerated).
  *
  * @param[in] fd      File descriptor of the port to write to.
  * @param[in] buffer  Pointer to the buffer containing the data to be written.
@@ -82,7 +82,7 @@ static bool write_port(int fd, const uint8_t *buffer, size_t size)
 
 /**
  * @brief Reads data from a serial port (specified by fd).
- * @note Returns after all bytes have been read, after a timeout or if an error occured (EINTR is
+ * @note Returns after all bytes have been read, after a timeout or if an error occurred (EINTR is
  * tolerated).
  *
  * @param[in]  fd      The file descriptor to read from.

--- a/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
+++ b/hal/posix/usb_dongle/libtropic_port_posix_usb_dongle.c
@@ -87,7 +87,7 @@ static bool write_port(int fd, const uint8_t *buffer, size_t size)
  *
  * @param[in]  fd      The file descriptor to read from.
  * @param[out] buffer  Pointer to the buffer where the read data will be stored.
- * @param[in]  size    The maximum number of bytes to read into the buffer.
+ * @param[in]  size    Number of bytes to read into the buffer.
  *
  * @return Returns true on success, false on error.
  */


### PR DESCRIPTION
## Description

Changes:
- loop in `write_port()`, as `write()` can do a partial write,
- allow `EINTR` error code of `write()` and `read()` (signal interrupt, it is common to read/write try again),
- unify `write_port()` and `read_port()` API - return bool, as the number of read/written bytes was never used by the caller anyway,
- make `buffer` parameter `const` in `write_port()`.

Tested with the USB DevKit.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---