### PR TITLE
ETR01SDK-600: Rename usb_dongle HAL to usb_devkit

### DIFF
--- a/.github/workflows/linux_build_examples.yml
+++ b/.github/workflows/linux_build_examples.yml
@@ -46,7 +46,7 @@ jobs:
           cmake ./ -B build -G Ninja
           cd build && ninja
 
-      - name: Build USB Devkit examples
+      - name: Build USB DevKit examples
         run: |
           cd examples/linux/usb_devkit/hello_world
           cmake ./ -B build -G Ninja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - USB DevKit HAL: call `write()` in a loop, allow `EINTR` error code for both `write()` and `read()`.
+- Refer to USB Dongle as USB DevKit:
+  - Rename `hal/posix/usb_dongle/` to `hal/posix/usb_devkit/`.
+  - Rename `libtropic_port_posix_usb_dongle.*` to `libtropic_port_posix_usb_devkit.*`
+  - Rename `LT_USB_DONGLE_READ_WRITE_DELAY` to `LT_USB_DEVKIT_READ_WRITE_DELAY`.
+  - Rename `LT_USB_DONGLE_SPI_TRANSFER_BUFF_SIZE_MAX` to `LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX`.
+  - Rename `lt_dev_posix_usb_dongle_t` to `lt_dev_posix_usb_devkit_t`.
 
 ### Added
-- ECC + EdDSA example for USB Devkit.
+- ECC + EdDSA example for USB DevKit.
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/docs/compatibility/host_platforms/posix.md
+++ b/docs/compatibility/host_platforms/posix.md
@@ -2,7 +2,7 @@
 We provide the following ports, which should be compatible with most POSIX compliant operating systems:
 
 - [TCP](#tcp)
-- [TROPIC01 USB Devkit](#tropic01-usb-devkit)
+- [TROPIC01 USB DevKit](#tropic01-usb-devkit)
 
 HALs for these ports are available in the `libtropic/hal/posix/` directory.
 
@@ -18,14 +18,14 @@ We use this port with the [TROPIC01 Python Model](../../tutorials/model/index.md
 !!! failure "Interrupt Pin Support"
     The TCP HAL does not support TROPIC01's interrupt pin.
 
-## TROPIC01 USB Devkit
-Libtropic communicates with our USB Devkits using the USB protocol. See our [TROPIC01 USB Devkit Tutorials](../../tutorials/linux/usb_devkit/index.md) to quickly get started.
+## TROPIC01 USB DevKit
+Libtropic communicates with our USB DevKits using the USB protocol. See our [TROPIC01 USB DevKit Tutorials](../../tutorials/linux/usb_devkit/index.md) to quickly get started.
 
 !!! bug "Raspberry Pi 4 Issues"
     When testing with Raspberry Pi 4, we have encountered [issues with its USB](https://github.com/raspberrypi/linux/issues/3259#), which seems to lose some of the USB packets sent to it.
 
     !!! success "Raspberry Pi 5"
-        Fortunately, Raspberry Pi 5 fixes these issues and the USB Devkit works without any issues.
+        Fortunately, Raspberry Pi 5 fixes these issues and the USB DevKit works without any issues.
 
 !!! failure "Interrupt Pin Support"
-    The USB Devkit port does not support TROPIC01's interrupt pin.
+    The USB DevKit port does not support TROPIC01's interrupt pin.

--- a/docs/reference/tropic01_fw.md
+++ b/docs/reference/tropic01_fw.md
@@ -17,7 +17,7 @@ There are multiple kinds of FW running in TROPIC01:
 Libtropic provides not only implementation of the FW update L2 commands, but also the necessary files for updating both the RISC-V and SPECT FW. Refer to:
 
 1. [Firmware Update Files](#firmware-update-files) section for more information about the `TROPIC01_fw_update_files/` directory.
-2. [Tutorials](../tutorials/index.md), where we demonstrate the firmware update feature. Have a look at, for example, [Firmware Update on TROPIC01 USB Devkit on Linux](../tutorials/linux/usb_devkit/fw_update.md).
+2. [Tutorials](../tutorials/index.md), where we demonstrate the firmware update feature. Have a look at, for example, [Firmware Update on TROPIC01 USB DevKit on Linux](../tutorials/linux/usb_devkit/fw_update.md).
 
 ### Firmware Update Files
 The `TROPIC01_fw_update_files/` directory provides TROPIC01 FW update files in two formats:

--- a/docs/tutorials/linux/index.md
+++ b/docs/tutorials/linux/index.md
@@ -2,4 +2,4 @@
 We offer the following sets of tutorials for Linux:
 
 - [Linux SPI Tutorials](spi/index.md)
-- [TROPIC01 USB Devkit Tutorials](usb_devkit/index.md)
+- [TROPIC01 USB DevKit Tutorials](usb_devkit/index.md)

--- a/docs/tutorials/linux/usb_devkit/index.md
+++ b/docs/tutorials/linux/usb_devkit/index.md
@@ -1,15 +1,15 @@
-# TROPIC01 USB Devkit Tutorials
-These tutorials will help you get started with our TROPIC01 USB Devkit (available [here](https://www.tropicsquare.com/order-devkit)) mainly on Linux-based systems, but it should also be compatible with other POSIX systems. We will go through our examples in the `examples/linux/usb_devkit/` directory.
+# TROPIC01 USB DevKit Tutorials
+These tutorials will help you get started with our TROPIC01 USB DevKit (available [here](https://www.tropicsquare.com/order-devkit)) mainly on Linux-based systems, but it should also be compatible with other POSIX systems. We will go through our examples in the `examples/linux/usb_devkit/` directory.
 
 ## Hardware Setup
-As mentioned above, we will use our TROPIC01 USB Devkit (available [here](https://www.tropicsquare.com/order-devkit)), specifically the TS1303 version, but other versions should also work:
+As mentioned above, we will use our TROPIC01 USB DevKit (available [here](https://www.tropicsquare.com/order-devkit)), specifically the TS1303 version, but other versions should also work:
 <figure style="text-align: center;">
-<img src="../../../img/TS1303_USB_Devkit_prod_photo.png" alt="TROPIC01 USB Devkit (TS1303)" width="250"/>
+<img src="../../../img/TS1303_USB_Devkit_prod_photo.png" alt="TROPIC01 USB DevKit (TS1303)" width="250"/>
 <figcaption style="font-size: 0.9em; color: #555; margin-top: 0.5em;">
-    TROPIC01 USB Devkit (TS1303)
+    TROPIC01 USB DevKit (TS1303)
   </figcaption>
 </figure>
-Go ahead and plug the USB Devkit into your machine.
+Go ahead and plug the USB DevKit into your machine.
 
 ## Software Setup
 First, install the dependencies and prepare the repository:

--- a/docs/tutorials/model/understanding_libtropic.md
+++ b/docs/tutorials/model/understanding_libtropic.md
@@ -182,7 +182,7 @@ Where to learn/do it:
 
 - Read: [TROPIC01 Firmware](../../reference/tropic01_fw.md)
 - If Secure Session / commands start failing unexpectedly, also check: [FAQ](../../faq.md#lt_l3_invalid_cmd-or-lt_l2_unknown_req)
-- Follow the firmware-update tutorials for your platform (for example on Linux USB devkit): [Tutorials](../../tutorials/index.md)
+- Follow the firmware-update tutorials for your platform (for example on Linux USB DevKit): [Tutorials](../../tutorials/index.md)
 
 ---
 

--- a/examples/linux/usb_devkit/ecc_eddsa/CMakeLists.txt
+++ b/examples/linux/usb_devkit/ecc_eddsa/CMakeLists.txt
@@ -7,7 +7,7 @@ include (FetchContent)
 #                                                                         #
 ###########################################################################
 project(libtropic_ecc_eddsa
-        DESCRIPTION "Libtropic ECC + EdDSA signing example on Linux using USB devkit driver."
+        DESCRIPTION "Libtropic ECC + EdDSA signing example on Linux using USB DevKit driver."
         LANGUAGES C)
 
 set(PATH_LIBTROPIC ../../../../)
@@ -17,8 +17,8 @@ set(PATH_LIBTROPIC ../../../../)
 #   Configuration                                                         #
 #                                                                         #
 ###########################################################################
-# Override path to USB devkit device
-set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB devkit serial port.")
+# Override path to USB DevKit device
+set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB DevKit serial port.")
 message(STATUS "Using serial port: ${LT_USB_DEVKIT_PATH}. You can change it by passing -DLT_USB_DEVKIT_PATH=<path> to cmake.")
 
 # Select pairing keys written during manufacturing into your TROPIC01
@@ -85,7 +85,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add USB DevKit POSIX HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_dongle" "posix_usb_dongle")
+add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_devkit" "posix_usb_devkit")
 target_sources(tropic PRIVATE ${LT_HAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_HAL_INC_DIRS})
 

--- a/examples/linux/usb_devkit/ecc_eddsa/main.c
+++ b/examples/linux/usb_devkit/ecc_eddsa/main.c
@@ -1,6 +1,6 @@
 /**
  * @file main.c
- * @brief Example of ECC key generation and EdDSA signing using Libtropic with the USB devkit.
+ * @brief Example of ECC key generation and EdDSA signing using Libtropic with the USB DevKit.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
@@ -13,7 +13,7 @@
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_posix_usb_dongle.h"
+#include "libtropic_port_posix_usb_devkit.h"
 #include "psa/crypto.h"
 
 // Choose pairing keypair for slot 0.
@@ -63,7 +63,7 @@ int main(void)
     //
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
-    lt_dev_posix_usb_dongle_t device = {0};
+    lt_dev_posix_usb_devkit_t device = {0};
 
     // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
     // to cmake if you want to change it.

--- a/examples/linux/usb_devkit/full_chain_verification/CMakeLists.txt
+++ b/examples/linux/usb_devkit/full_chain_verification/CMakeLists.txt
@@ -7,7 +7,7 @@ include (FetchContent)
 #                                                                         #
 ###########################################################################
 project(libtropic_dump_certificates
-        DESCRIPTION "Libtropic utility to dump certificates from TROPIC01 on Linux using USB devkit driver."
+        DESCRIPTION "Libtropic utility to dump certificates from TROPIC01 on Linux using USB DevKit driver."
         LANGUAGES C)
 
 set(PATH_LIBTROPIC ../../../../)
@@ -17,8 +17,8 @@ set(PATH_LIBTROPIC ../../../../)
 #   Configuration                                                         #
 #                                                                         #
 ###########################################################################
-# Override path to USB devkit device
-set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB devkit serial port.")
+# Override path to USB DevKit device
+set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB DevKit serial port.")
 message(STATUS "Using serial port: ${LT_USB_DEVKIT_PATH}. You can change it by passing -DLT_USB_DEVKIT_PATH=<path> to cmake.")
 
 ###########################################################################
@@ -60,7 +60,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add USB DevKit POSIX HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_dongle" "posix_usb_dongle")
+add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_devkit" "posix_usb_devkit")
 target_sources(tropic PRIVATE ${LT_HAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_HAL_INC_DIRS})
 

--- a/examples/linux/usb_devkit/full_chain_verification/main.c
+++ b/examples/linux/usb_devkit/full_chain_verification/main.c
@@ -1,6 +1,6 @@
 /**
  * @file main.c
- * @brief Utility for dumping certificates from TROPIC01 USB Devkit for Linux. Part of the Full chain
+ * @brief Utility for dumping certificates from TROPIC01 USB DevKit for Linux. Part of the Full chain
  * verification example.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
@@ -14,7 +14,7 @@
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_posix_usb_dongle.h"
+#include "libtropic_port_posix_usb_devkit.h"
 #include "psa/crypto.h"
 
 lt_ret_t dump_cert_store(lt_handle_t *lt_handle)
@@ -97,7 +97,7 @@ int main(void)
     //
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
-    lt_dev_posix_usb_dongle_t device = {0};
+    lt_dev_posix_usb_devkit_t device = {0};
 
     // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
     // to cmake if you want to change it.

--- a/examples/linux/usb_devkit/fw_update/CMakeLists.txt
+++ b/examples/linux/usb_devkit/fw_update/CMakeLists.txt
@@ -7,7 +7,7 @@ include (FetchContent)
 #                                                                         #
 ###########################################################################
 project(libtropic_fw_update
-        DESCRIPTION "Libtropic Firmware Update example on Linux using USB devkit driver."
+        DESCRIPTION "Libtropic Firmware Update example on Linux using USB DevKit driver."
         LANGUAGES C)
 
 set(PATH_LIBTROPIC ../../../../)
@@ -18,7 +18,7 @@ set(PATH_LIBTROPIC ../../../../)
 #                                                                         #
 ###########################################################################
 if (NOT DEFINED LT_USB_DEVKIT_PATH)
-    set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB devkit serial port.")
+    set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB DevKit serial port.")
 endif()
 message(STATUS "Using serial port: ${LT_USB_DEVKIT_PATH}. You can change it by passing -DLT_USB_DEVKIT_PATH=<path> to cmake.")
 
@@ -64,7 +64,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add USB DevKit POSIX HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_dongle" "posix_usb_dongle")
+add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_devkit" "posix_usb_devkit")
 target_sources(tropic PRIVATE ${LT_HAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_HAL_INC_DIRS})
 

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -1,7 +1,7 @@
 /**
  * @file main.c
  * @brief Example showing how to perform an update of the TROPIC01 firmware using Libtropic with the
- * USB devkit.
+ * USB DevKit.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
@@ -16,7 +16,7 @@
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_posix_usb_dongle.h"
+#include "libtropic_port_posix_usb_devkit.h"
 #include "psa/crypto.h"
 
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
@@ -78,7 +78,7 @@ int main(void)
     //
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
-    lt_dev_posix_usb_dongle_t device = {0};
+    lt_dev_posix_usb_devkit_t device = {0};
 
     // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
     // to cmake if you want to change it.

--- a/examples/linux/usb_devkit/hello_world/CMakeLists.txt
+++ b/examples/linux/usb_devkit/hello_world/CMakeLists.txt
@@ -7,7 +7,7 @@ include (FetchContent)
 #                                                                         #
 ###########################################################################
 project(libtropic_hello_world
-        DESCRIPTION "Libtropic Hello World example on Linux using USB devkit driver."
+        DESCRIPTION "Libtropic Hello World example on Linux using USB DevKit driver."
         LANGUAGES C)
 
 set(PATH_LIBTROPIC ../../../../)
@@ -17,8 +17,8 @@ set(PATH_LIBTROPIC ../../../../)
 #   Configuration                                                         #
 #                                                                         #
 ###########################################################################
-# Override path to USB devkit device
-set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB devkit serial port.")
+# Override path to USB DevKit device
+set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB DevKit serial port.")
 message(STATUS "Using serial port: ${LT_USB_DEVKIT_PATH}. You can change it by passing -DLT_USB_DEVKIT_PATH=<path> to cmake.")
 
 # Select pairing keys written during manufacturing into your TROPIC01
@@ -85,7 +85,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add USB DevKit POSIX HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_dongle" "posix_usb_dongle")
+add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_devkit" "posix_usb_devkit")
 target_sources(tropic PRIVATE ${LT_HAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_HAL_INC_DIRS})
 

--- a/examples/linux/usb_devkit/hello_world/main.c
+++ b/examples/linux/usb_devkit/hello_world/main.c
@@ -1,6 +1,6 @@
 /**
  * @file main.c
- * @brief Simple "Hello, World!" example of using Libtropic with the USB devkit.
+ * @brief Simple "Hello, World!" example of using Libtropic with the USB DevKit.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
@@ -13,7 +13,7 @@
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_posix_usb_dongle.h"
+#include "libtropic_port_posix_usb_devkit.h"
 #include "psa/crypto.h"
 
 // @brief Message to send with Ping L3 command.
@@ -64,7 +64,7 @@ int main(void)
     //
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
-    lt_dev_posix_usb_dongle_t device = {0};
+    lt_dev_posix_usb_devkit_t device = {0};
 
     // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
     // to cmake if you want to change it.

--- a/examples/linux/usb_devkit/identify_chip/CMakeLists.txt
+++ b/examples/linux/usb_devkit/identify_chip/CMakeLists.txt
@@ -7,7 +7,7 @@ include (FetchContent)
 #                                                                         #
 ###########################################################################
 project(libtropic_identify_chip
-        DESCRIPTION "Libtropic chip identification example on Linux using USB devkit driver."
+        DESCRIPTION "Libtropic chip identification example on Linux using USB DevKit driver."
         LANGUAGES C)
 
 set(PATH_LIBTROPIC ../../../../)
@@ -18,7 +18,7 @@ set(PATH_LIBTROPIC ../../../../)
 #                                                                         #
 ###########################################################################
 if (NOT DEFINED LT_USB_DEVKIT_PATH)
-    set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB devkit serial port.")
+    set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB DevKit serial port.")
 endif()
 message(STATUS "Using serial port: ${LT_USB_DEVKIT_PATH}. You can change it by passing -DLT_USB_DEVKIT_PATH=<path> to cmake.")
 
@@ -64,7 +64,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add USB DevKit POSIX HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_dongle" "posix_usb_dongle")
+add_subdirectory("${PATH_LIBTROPIC}hal/posix/usb_devkit" "posix_usb_devkit")
 target_sources(tropic PRIVATE ${LT_HAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_HAL_INC_DIRS})
 

--- a/examples/linux/usb_devkit/identify_chip/main.c
+++ b/examples/linux/usb_devkit/identify_chip/main.c
@@ -1,7 +1,7 @@
 /**
  * @file main.c
  * @brief Example of reading information about the TROPIC01 chip and its firmware using Libtropic and
- * USB devkit.
+ * USB DevKit.
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
@@ -14,7 +14,7 @@
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_posix_usb_dongle.h"
+#include "libtropic_port_posix_usb_devkit.h"
 #include "psa/crypto.h"
 
 int main(void)
@@ -51,7 +51,7 @@ int main(void)
     //
     // Modify this according to your environment. Default values
     // are compatible with RPi and our RPi shield.
-    lt_dev_posix_usb_dongle_t device = {0};
+    lt_dev_posix_usb_devkit_t device = {0};
 
     // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt. Pass -DLT_USB_DEVKIT_PATH=<path>
     // to cmake if you want to change it.

--- a/hal/posix/usb_devkit/CMakeLists.txt
+++ b/hal/posix/usb_devkit/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21.0)
 
 set(LT_HAL_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/libtropic_port_posix_usb_dongle.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libtropic_port_posix_usb_devkit.c
 )
 
 set(LT_HAL_INC_DIRS

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
@@ -1,16 +1,16 @@
 /**
- * @file libtropic_port_posix_usb_dongle.c
+ * @file libtropic_port_posix_usb_devkit.c
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
- * @brief Port for communication with USB UART Dongle (TS1302).
+ * @brief Port for communication with TROPIC01 USB DevKit.
  *
- * The TS1302 dongle uses a special protocol to translate UART communication to SPI. This port
- * implements the protocol. More info about the dongle in GitHub repo:
- * https://github.com/tropicsquare/ts13-usb-dev-kit-fw
+ * The TROPIC01 USB DevKit uses a special protocol to translate UART communication to SPI. This port
+ * implements the protocol. More info about the USB DevKit here:
+ * https://github.com/tropicsquare/devboards/tree/main/TROPIC01_USB_Devkit
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
-#include "libtropic_port_posix_usb_dongle.h"
+#include "libtropic_port_posix_usb_devkit.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -32,7 +32,7 @@
 #include "libtropic_port.h"
 
 #if LT_USE_INT_PIN
-#error "Interrupt PIN not supported in the USB dongle port!"
+#error "Interrupt PIN not supported in the USB DevKit port!"
 #endif
 
 // getentropy() has a limit of random bytes it can generate in one call. The POSIX.1-2024 standard
@@ -137,7 +137,7 @@ static bool read_port(int fd, uint8_t *buffer, size_t size)
 
 lt_ret_t lt_port_init(lt_l2_state_t *s2)
 {
-    lt_dev_posix_usb_dongle_t *device = (lt_dev_posix_usb_dongle_t *)s2->device;
+    lt_dev_posix_usb_devkit_t *device = (lt_dev_posix_usb_devkit_t *)s2->device;
 
     // Initialize the serial port.
     device->fd = open(device->dev_path, O_RDWR | O_NOCTTY);
@@ -210,7 +210,7 @@ lt_ret_t lt_port_init(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
 {
-    lt_dev_posix_usb_dongle_t *device = (lt_dev_posix_usb_dongle_t *)s2->device;
+    lt_dev_posix_usb_devkit_t *device = (lt_dev_posix_usb_devkit_t *)s2->device;
 
     if (close(device->fd)) {
         return LT_FAIL;
@@ -264,7 +264,7 @@ lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
 {
-    lt_dev_posix_usb_dongle_t *device = (lt_dev_posix_usb_dongle_t *)s2->device;
+    lt_dev_posix_usb_devkit_t *device = (lt_dev_posix_usb_devkit_t *)s2->device;
 
     uint8_t cs_high[] = "CS=0\n";  // Yes, CS=0 really means that CSN is low
     if (!write_port(device->fd, cs_high, 5)) {
@@ -290,7 +290,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
 {
     LT_UNUSED(timeout_ms);
 
-    lt_dev_posix_usb_dongle_t *device = (lt_dev_posix_usb_dongle_t *)s2->device;
+    lt_dev_posix_usb_devkit_t *device = (lt_dev_posix_usb_devkit_t *)s2->device;
 
     if (offset + tx_data_length > TR01_L1_LEN_MAX) {
         return LT_L1_DATA_LEN_ERROR;
@@ -298,13 +298,13 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
 
     // Bytes from handle which are about to be sent are encoded as chars and stored to
     // buffered_chars.
-    uint8_t buffered_chars[LT_USB_DONGLE_SPI_TRANSFER_BUFF_SIZE_MAX] = {0};
+    uint8_t buffered_chars[LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX] = {0};
     for (int i = 0; i < tx_data_length; i++) {
         sprintf((char *)(buffered_chars + i * 2), "%02" PRIX8, s2->buff[i + offset]);
     }
 
-    // Control characters to keep CS LOW (they are expected by USB dongle, see the top of this file
-    // for more information).
+    // Control characters to keep CS LOW (they are expected by USB DevKit, see the top of this file for
+    // more information).
     buffered_chars[tx_data_length * 2] = 'x';
     buffered_chars[tx_data_length * 2 + 1] = '\n';
 
@@ -313,7 +313,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
         return LT_L1_SPI_ERROR;
     }
 
-    lt_port_delay(s2, LT_USB_DONGLE_READ_WRITE_DELAY);
+    lt_port_delay(s2, LT_USB_DEVKIT_READ_WRITE_DELAY);
 
     if (!read_port(device->fd, buffered_chars, (2 * tx_data_length) + 2)) {
         LT_LOG_ERROR("Failed to read SPI payload.");

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.h
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.h
@@ -1,10 +1,10 @@
-#ifndef LIBTROPIC_PORT_POSIX_USB_DONGLE_H
-#define LIBTROPIC_PORT_POSIX_USB_DONGLE_H
+#ifndef LIBTROPIC_PORT_POSIX_USB_DEVKIT_H
+#define LIBTROPIC_PORT_POSIX_USB_DEVKIT_H
 
 /**
- * @file libtropic_port_posix_usb_dongle.h
+ * @file libtropic_port_posix_usb_devkit.h
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
- * @brief Port for communication with USB UART Dongle (TS1302).
+ * @brief Port for communication with TROPIC01 USB DevKit.
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
@@ -15,16 +15,16 @@
 extern "C" {
 #endif
 
-#define LT_USB_DONGLE_READ_WRITE_DELAY 10
-#define LT_USB_DONGLE_SPI_TRANSFER_BUFF_SIZE_MAX ((TR01_L1_LEN_MAX * 2) + 1)
+#define LT_USB_DEVKIT_READ_WRITE_DELAY 10
+#define LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX ((TR01_L1_LEN_MAX * 2) + 1)
 
 /**
- * @brief Device structure for USB Dongle POSIX port.
+ * @brief Device structure for TROPIC01 USB DevKit POSIX port.
  *
  * @note Public members are meant to be configured by the developer before passing the handle to
  *       libtropic.
  */
-typedef struct lt_dev_posix_usb_dongle_t {
+typedef struct lt_dev_posix_usb_devkit_t {
     /** @public @brief Path to USB UART device. */
     char dev_path[LT_DEVICE_PATH_MAX_LEN];
     /** @public @brief UART baudrate. */
@@ -32,10 +32,10 @@ typedef struct lt_dev_posix_usb_dongle_t {
 
     /** @private @brief UART device file descriptor. */
     int fd;
-} lt_dev_posix_usb_dongle_t;
+} lt_dev_posix_usb_devkit_t;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // LIBTROPIC_PORT_POSIX_USB_DONGLE_H
+#endif  // LIBTROPIC_PORT_POSIX_USB_DEVKIT_H

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,7 @@ nav:
           - 2. FW Update: tutorials/linux/spi/fw_update.md
           - 3. Hello, World!: tutorials/linux/spi/hello_world.md
           - 4. Full Chain Verification: tutorials/linux/spi/full_chain_verification.md
-        - USB Devkit:
+        - USB DevKit:
           - tutorials/linux/usb_devkit/index.md
           - 1. Chip Identification: tutorials/linux/usb_devkit/identify_chip.md
           - 2. FW Update: tutorials/linux/usb_devkit/fw_update.md

--- a/tests/functional/linux/usb_devkit/CMakeLists.txt
+++ b/tests/functional/linux/usb_devkit/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 ###########################################################################
 project(libtropic_functional_tests_linux_usb
         VERSION 0.1.0
-        DESCRIPTION "Functional tests in Linux environment using USB dongle driver"
+        DESCRIPTION "Functional tests in Linux environment using TROPIC01 USB DevKit driver"
         LANGUAGES C)
 
 ###########################################################################
@@ -32,8 +32,8 @@ endif()
 #                                                                         #
 ###########################################################################
 
-# Override path to USB devkit device
-set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB devkit serial port.")
+# Override path to USB DevKit device
+set(LT_USB_DEVKIT_PATH "/dev/ttyACM0" CACHE STRING "Path to the USB device representing the USB DevKit serial port.")
 message(STATUS "Using serial port: ${LT_USB_DEVKIT_PATH}. You can change it by passing -DLT_USB_DEVKIT_PATH=<path> to cmake.")
 
 # Optional prefix to tests registered to CTest. Useful when running same test against
@@ -61,8 +61,8 @@ add_subdirectory(${PATH_FN_TESTS} "libtropic_functional_tests")
 #                                                                         #
 ###########################################################################
 
-# Add POSIX USB dongle HAL
-add_subdirectory("${PATH_LIBTROPIC}/hal/posix/usb_dongle" "posix_usb_dongle_hal")
+# Add TROPIC01 USB DevKit POSIX HAL
+add_subdirectory("${PATH_LIBTROPIC}/hal/posix/usb_devkit" "posix_usb_devkit_hal")
 target_sources(tropic PRIVATE ${LT_HAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_HAL_INC_DIRS})
 

--- a/tests/functional/linux/usb_devkit/main.c
+++ b/tests/functional/linux/usb_devkit/main.c
@@ -12,7 +12,7 @@
 #include "libtropic_common.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port_posix_usb_dongle.h"
+#include "libtropic_port_posix_usb_devkit.h"
 
 #if LT_USE_TREZOR_CRYPTO
 #include "libtropic_trezor_crypto.h"
@@ -76,7 +76,7 @@ int main(void)
 #endif
 
     // Device mappings
-    lt_dev_posix_usb_dongle_t device = {0};
+    lt_dev_posix_usb_devkit_t device = {0};
 
     // LT_USB_DEVKIT_PATH is defined in CMakeLists.txt.
     int dev_path_len = snprintf(device.dev_path, sizeof(device.dev_path), "%s", LT_USB_DEVKIT_PATH);


### PR DESCRIPTION
## Description

Changes are listed in the changelog. Additionally, unified capitals in "DevKit" to "Devkit".

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---