### PR TITLE
ETR01SDK-597: Examples: solve DOWNLOAD_EXTRACT_TIMESTAMP CMake warning

### DIFF
--- a/examples/linux/spi/full_chain_verification/CMakeLists.txt
+++ b/examples/linux/spi/full_chain_verification/CMakeLists.txt
@@ -50,6 +50,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/spi/fw_update/CMakeLists.txt
+++ b/examples/linux/spi/fw_update/CMakeLists.txt
@@ -53,6 +53,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/spi/hello_world/CMakeLists.txt
+++ b/examples/linux/spi/hello_world/CMakeLists.txt
@@ -75,6 +75,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/spi/identify_chip/CMakeLists.txt
+++ b/examples/linux/spi/identify_chip/CMakeLists.txt
@@ -53,6 +53,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/ecc_eddsa/CMakeLists.txt
+++ b/examples/linux/usb_devkit/ecc_eddsa/CMakeLists.txt
@@ -69,6 +69,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/full_chain_verification/CMakeLists.txt
+++ b/examples/linux/usb_devkit/full_chain_verification/CMakeLists.txt
@@ -44,6 +44,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/fw_update/CMakeLists.txt
+++ b/examples/linux/usb_devkit/fw_update/CMakeLists.txt
@@ -48,6 +48,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/hello_world/CMakeLists.txt
+++ b/examples/linux/usb_devkit/hello_world/CMakeLists.txt
@@ -69,6 +69,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/identify_chip/CMakeLists.txt
+++ b/examples/linux/usb_devkit/identify_chip/CMakeLists.txt
@@ -48,6 +48,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/model/hello_world/CMakeLists.txt
+++ b/examples/model/hello_world/CMakeLists.txt
@@ -47,6 +47,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
@@ -86,6 +86,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_f439zi/hello_world/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/hello_world/CMakeLists.txt
@@ -86,6 +86,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
@@ -85,6 +85,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
@@ -90,6 +90,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
@@ -90,6 +90,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
@@ -90,6 +90,7 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:


### PR DESCRIPTION
## Description

In `FetchContent_Declare`, if `DOWNLOAD_EXTRACT_TIMESTAMP TRUE` is not present, it raises a long warning that could scare the user.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---