### PR TITLE
ETR01SDK-569: Think about unifying all STM32 HALs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rename `lt_dev_posix_usb_dongle_t` to `lt_dev_posix_usb_devkit_t`.
 - Added `lt_` prefixes to `sh0priv_eng_sample`, `sh0pub_eng_sample`, `sh0priv_prod0`, `sh0pub_prod0` arrays to avoid name collisions.
 - Renamed `TR01_CURVE_GENERATED` to `TR01_KEY_GENERATED` and `TR01_CURVE_STORED` to `TR01_KEY_STORED` in the `lt_ecc_key_origin_t` enum (typo).
+- Rename STM32 Nucleo F439ZI HAL to STM32F4xx HAL, as it is compatible with the entire MCU family:
+  - Renamed `hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.*` to `hal/stm32/stm32f4xx/libtropic_port_stm32f4xx.*`.
+  - Renamed `LT_STM32_F439ZI_GPIO_OUTPUT_CHECK_ATTEMPTS` to `LT_STM32F4XX_GPIO_OUTPUT_CHECK_ATTEMPTS`.
+  - Renamed `lt_dev_stm32_nucleo_f439zi_t` to `lt_dev_stm32f4xx_t`.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed `hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.*` to `hal/stm32/stm32f4xx/libtropic_port_stm32f4xx.*`.
   - Renamed `LT_STM32_F439ZI_GPIO_OUTPUT_CHECK_ATTEMPTS` to `LT_STM32F4XX_GPIO_OUTPUT_CHECK_ATTEMPTS`.
   - Renamed `lt_dev_stm32_nucleo_f439zi_t` to `lt_dev_stm32f4xx_t`.
+- Rename STM32 Nucleo L432KC HAL to STM32L4xx HAL, as it is compatible with the entire MCU family:
+  - Renamed `hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.*` to `hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.*`.
+  - Renamed `LT_STM32_L432KC_GPIO_OUTPUT_CHECK_ATTEMPTS` to `LT_STM32L4XX_GPIO_OUTPUT_CHECK_ATTEMPTS`.
+  - Renamed `lt_dev_stm32_nucleo_l432kc_t` to `lt_dev_stm32l4xx_t`.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rename `lt_dev_posix_usb_dongle_t` to `lt_dev_posix_usb_devkit_t`.
 - Added `lt_` prefixes to `sh0priv_eng_sample`, `sh0pub_eng_sample`, `sh0priv_prod0`, `sh0pub_prod0` arrays to avoid name collisions.
 - Renamed `TR01_CURVE_GENERATED` to `TR01_KEY_GENERATED` and `TR01_CURVE_STORED` to `TR01_KEY_STORED` in the `lt_ecc_key_origin_t` enum (typo).
-- Rename STM32 Nucleo F439ZI HAL to STM32F4xx HAL, as it is compatible with the entire MCU family:
+- Rename STM32 Nucleo F439ZI HAL to STM32F4xx HAL to provide compatibility with the MCU family:
   - Renamed `hal/stm32/nucleo_f439zi/libtropic_port_stm32_nucleo_f439zi.*` to `hal/stm32/stm32f4xx/libtropic_port_stm32f4xx.*`.
   - Renamed `LT_STM32_F439ZI_GPIO_OUTPUT_CHECK_ATTEMPTS` to `LT_STM32F4XX_GPIO_OUTPUT_CHECK_ATTEMPTS`.
   - Renamed `lt_dev_stm32_nucleo_f439zi_t` to `lt_dev_stm32f4xx_t`.
-- Rename STM32 Nucleo L432KC HAL to STM32L4xx HAL, as it is compatible with the entire MCU family:
+- Rename STM32 Nucleo L432KC HAL to STM32L4xx HAL to provide compatibility with the MCU family:
   - Renamed `hal/stm32/nucleo_l432kc/libtropic_port_stm32_nucleo_l432kc.*` to `hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.*`.
   - Renamed `LT_STM32_L432KC_GPIO_OUTPUT_CHECK_ATTEMPTS` to `LT_STM32L4XX_GPIO_OUTPUT_CHECK_ATTEMPTS`.
   - Renamed `lt_dev_stm32_nucleo_l432kc_t` to `lt_dev_stm32l4xx_t`.

--- a/docs/compatibility/host_platforms/stm32.md
+++ b/docs/compatibility/host_platforms/stm32.md
@@ -3,8 +3,8 @@ Currently supported STM32 platforms are:
 
 - STM32F4xx series MCUs, tested with:
     - NUCLEO-F439ZI
-- NUCLEO-L432KC
-    - Using interrupt pin (`LT_USE_INT_PIN`) is not supported for this platform.
+- STM32L4xx series MCUs, tested with:
+    - NUCLEO-L432KC (using interrupt pin (`LT_USE_INT_PIN`) is not supported for this platform)
 - STM32U5xx series MCUs, tested with:
     - NUCLEO-U545RE-Q
 

--- a/docs/compatibility/host_platforms/stm32.md
+++ b/docs/compatibility/host_platforms/stm32.md
@@ -1,7 +1,8 @@
 # STM32
 Currently supported STM32 platforms are:
 
-- NUCLEO-F439ZI
+- STM32F4xx series MCUs, tested with:
+    - NUCLEO-F439ZI
 - NUCLEO-L432KC
     - Using interrupt pin (`LT_USE_INT_PIN`) is not supported for this platform.
 - STM32U5xx series MCUs, tested with:

--- a/docs/tutorials/stm32/index.md
+++ b/docs/tutorials/stm32/index.md
@@ -1,5 +1,5 @@
 # STM32 Tutorials
-These tutorials will help you get started with TROPIC01 on STM32-based platforms using Libtropic. Currently, we officially support [Nucleo F439ZI](https://www.st.com/en/evaluation-tools/nucleo-f439zi.html) and [Nucleo L432KC](https://www.st.com/en/evaluation-tools/nucleo-l432kc.html) development boards.
+These tutorials will help you get started with TROPIC01 on STM32-based platforms using Libtropic. To see the currently supported STM32 platforms, refer to the [STM32 Compatibility](../../compatibility/host_platforms/stm32.md) page.
 
 We will go through our examples in the `examples/stm32/` directory. In this directory, there are multiple subdirectories for each supported Nucleo board. Most of the instructions in this tutorial are common for all of the boards.
 

--- a/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
@@ -121,7 +121,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/stm32/nucleo_f439zi" "nucleo_f439zi_hal")
+add_subdirectory("${PATH_LIBTROPIC}hal/stm32/stm32f4xx" "stm32f4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -20,7 +20,7 @@
 #include "fw_SPECT.h"
 #include "libtropic.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_stm32_nucleo_f439zi.h"
+#include "libtropic_port_stm32f4xx.h"
 #include "psa/crypto.h"
 #include "syscalls.h"
 
@@ -220,7 +220,7 @@ int main(void)
 
         The device structure has to be zero initialized!
         STM32 HAL depends on zero init values. */
-    lt_dev_stm32_nucleo_f439zi_t device = {0};
+    lt_dev_stm32f4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;

--- a/examples/stm32/nucleo_f439zi/hello_world/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/hello_world/CMakeLists.txt
@@ -121,7 +121,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/stm32/nucleo_f439zi" "nucleo_f439zi_hal")
+add_subdirectory("${PATH_LIBTROPIC}hal/stm32/stm32f4xx" "stm32f4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
@@ -17,7 +17,7 @@
 
 #include "libtropic.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_stm32_nucleo_f439zi.h"
+#include "libtropic_port_stm32f4xx.h"
 #include "psa/crypto.h"
 #include "syscalls.h"
 
@@ -191,7 +191,7 @@ int main(void)
 
         The device structure has to be zero initialized!
         STM32 HAL depends on zero init values. */
-    lt_dev_stm32_nucleo_f439zi_t device = {0};
+    lt_dev_stm32f4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;

--- a/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
@@ -120,7 +120,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/stm32/nucleo_f439zi" "nucleo_f439zi_hal")
+add_subdirectory("${PATH_LIBTROPIC}hal/stm32/stm32f4xx" "stm32f4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
@@ -18,7 +18,7 @@
 
 #include "libtropic.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_stm32_nucleo_f439zi.h"
+#include "libtropic_port_stm32f4xx.h"
 #include "psa/crypto.h"
 #include "syscalls.h"
 
@@ -188,7 +188,7 @@ int main(void)
 
         The device structure has to be zero initialized!
         STM32 HAL depends on zero init values. */
-    lt_dev_stm32_nucleo_f439zi_t device = {0};
+    lt_dev_stm32f4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;

--- a/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
@@ -125,7 +125,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/stm32/nucleo_l432kc" "nucleo_l432kc_hal")
+add_subdirectory("${PATH_LIBTROPIC}hal/stm32/stm32l4xx" "stm32l4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -20,7 +20,7 @@
 #include "fw_SPECT.h"
 #include "libtropic.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_stm32_nucleo_l432kc.h"
+#include "libtropic_port_stm32l4xx.h"
 #include "psa/crypto.h"
 
 /** @addtogroup STM32L4xx_HAL_Examples
@@ -255,7 +255,7 @@ int main(void)
 
         The device structure has to be zero initialized!
         STM32 HAL depends on zero init values. */
-    lt_dev_stm32_nucleo_l432kc_t device = {0};
+    lt_dev_stm32l4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;

--- a/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
@@ -125,7 +125,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/stm32/nucleo_l432kc" "nucleo_l432kc_hal")
+add_subdirectory("${PATH_LIBTROPIC}hal/stm32/stm32l4xx" "stm32l4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
@@ -17,7 +17,7 @@
 
 #include "libtropic.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_stm32_nucleo_l432kc.h"
+#include "libtropic_port_stm32l4xx.h"
 #include "psa/crypto.h"
 
 /** @addtogroup STM32L4xx_HAL_Examples
@@ -226,7 +226,7 @@ int main(void)
 
         The device structure has to be zero initialized!
         STM32 HAL depends on zero init values. */
-    lt_dev_stm32_nucleo_l432kc_t device = {0};
+    lt_dev_stm32l4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;

--- a/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
@@ -125,7 +125,7 @@ target_sources(tropic PRIVATE ${LT_CAL_SRCS})
 target_include_directories(tropic PUBLIC ${LT_CAL_INC_DIRS})
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}hal/stm32/nucleo_l432kc" "nucleo_l432kc_hal")
+add_subdirectory("${PATH_LIBTROPIC}hal/stm32/stm32l4xx" "stm32l4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
@@ -18,7 +18,7 @@
 
 #include "libtropic.h"
 #include "libtropic_mbedtls_v4.h"
-#include "libtropic_port_stm32_nucleo_l432kc.h"
+#include "libtropic_port_stm32l4xx.h"
 #include "psa/crypto.h"
 
 /** @addtogroup STM32L4xx_HAL_Examples
@@ -223,7 +223,7 @@ int main(void)
 
         The device structure has to be zero initialized!
         STM32 HAL depends on zero init values. */
-    lt_dev_stm32_nucleo_l432kc_t device = {0};
+    lt_dev_stm32l4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;

--- a/hal/stm32/stm32f4xx/CMakeLists.txt
+++ b/hal/stm32/stm32f4xx/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21.0)
 
 set(LT_HAL_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/libtropic_port_stm32_nucleo_f439zi.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libtropic_port_stm32f4xx.c
 )
 
 set(LT_HAL_INC_DIRS

--- a/hal/stm32/stm32f4xx/libtropic_port_stm32f4xx.c
+++ b/hal/stm32/stm32f4xx/libtropic_port_stm32f4xx.c
@@ -1,7 +1,7 @@
 /**
- * @file libtropic_port_stm32_nucleo_f439zi.c
+ * @file libtropic_port_stm32f4xx.c
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
- * @brief Port for STM32 F439ZI using native SPI HAL (and GPIO HAL for chip select).
+ * @brief Port for STM32F4xx series using native SPI HAL (and GPIO HAL for chip select).
  *
  * Most of this SPI code is inspired by https://github.com/STMicroelectronics/STM32CubeF4:
  * Projects/STM32F429I-Discovery/Examples/SPI/SPI_FullDuplex_ComPolling/Src/main.c
@@ -9,7 +9,7 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
-#include "libtropic_port_stm32_nucleo_f439zi.h"
+#include "libtropic_port_stm32f4xx.h"
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -23,11 +23,11 @@
 #include "libtropic_secure_memzero.h"
 #include "stm32f4xx_hal.h"
 
-#define LT_STM32_F439ZI_GPIO_OUTPUT_CHECK_ATTEMPTS 10
+#define LT_STM32F4XX_GPIO_OUTPUT_CHECK_ATTEMPTS 10
 
 lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
 {
-    lt_dev_stm32_nucleo_f439zi_t *device = (lt_dev_stm32_nucleo_f439zi_t *)(s2->device);
+    lt_dev_stm32f4xx_t *device = (lt_dev_stm32f4xx_t *)(s2->device);
     size_t bytes_left = count;
     uint8_t *buff_ptr = buff;
     int ret;
@@ -53,11 +53,11 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
 
 lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_f439zi_t *device = (lt_dev_stm32_nucleo_f439zi_t *)(s2->device);
+    lt_dev_stm32f4xx_t *device = (lt_dev_stm32f4xx_t *)(s2->device);
 
     HAL_GPIO_WritePin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin, GPIO_PIN_RESET);
 
-    for (uint8_t read_attempts = 0; read_attempts < LT_STM32_F439ZI_GPIO_OUTPUT_CHECK_ATTEMPTS;
+    for (uint8_t read_attempts = 0; read_attempts < LT_STM32F4XX_GPIO_OUTPUT_CHECK_ATTEMPTS;
          read_attempts++) {
         if (!HAL_GPIO_ReadPin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin)) {
             return LT_OK;
@@ -70,11 +70,11 @@ lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_f439zi_t *device = (lt_dev_stm32_nucleo_f439zi_t *)(s2->device);
+    lt_dev_stm32f4xx_t *device = (lt_dev_stm32f4xx_t *)(s2->device);
 
     HAL_GPIO_WritePin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin, GPIO_PIN_SET);
 
-    for (uint8_t read_attempts = 0; read_attempts < LT_STM32_F439ZI_GPIO_OUTPUT_CHECK_ATTEMPTS;
+    for (uint8_t read_attempts = 0; read_attempts < LT_STM32F4XX_GPIO_OUTPUT_CHECK_ATTEMPTS;
          read_attempts++) {
         if (HAL_GPIO_ReadPin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin)) {
             return LT_OK;
@@ -87,7 +87,7 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_init(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_f439zi_t *device = (lt_dev_stm32_nucleo_f439zi_t *)(s2->device);
+    lt_dev_stm32f4xx_t *device = (lt_dev_stm32f4xx_t *)(s2->device);
     int ret;
 
     // Set the SPI parameters.
@@ -139,7 +139,7 @@ lt_ret_t lt_port_init(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_f439zi_t *device = (lt_dev_stm32_nucleo_f439zi_t *)(s2->device);
+    lt_dev_stm32f4xx_t *device = (lt_dev_stm32f4xx_t *)(s2->device);
     int ret;
 
     ret = HAL_SPI_DeInit(&device->spi_handle);
@@ -154,7 +154,7 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
 lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length,
                               uint32_t timeout_ms)
 {
-    lt_dev_stm32_nucleo_f439zi_t *device = (lt_dev_stm32_nucleo_f439zi_t *)(s2->device);
+    lt_dev_stm32f4xx_t *device = (lt_dev_stm32f4xx_t *)(s2->device);
 
     if (offset + tx_data_length > TR01_L1_LEN_MAX) {
         LT_LOG_ERROR("Invalid data length!");
@@ -182,7 +182,7 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
 #if LT_USE_INT_PIN
 lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms)
 {
-    lt_dev_stm32_nucleo_f439zi_t *device = (lt_dev_stm32_nucleo_f439zi_t *)(s2->device);
+    lt_dev_stm32f4xx_t *device = (lt_dev_stm32f4xx_t *)(s2->device);
     uint32_t time_initial = HAL_GetTick();
     uint32_t time_actual;
 

--- a/hal/stm32/stm32f4xx/libtropic_port_stm32f4xx.h
+++ b/hal/stm32/stm32f4xx/libtropic_port_stm32f4xx.h
@@ -1,10 +1,10 @@
-#ifndef LIBTROPIC_PORT_STM32_NUCLEO_F439ZI_H
-#define LIBTROPIC_PORT_STM32_NUCLEO_F439ZI_H
+#ifndef LIBTROPIC_PORT_STM32F4XX_H
+#define LIBTROPIC_PORT_STM32F4XX_H
 
 /**
- * @file libtropic_port_stm32_nucleo_f439zi.h
+ * @file libtropic_port_stm32f4xx.h
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
- * @brief Port for STM32 F439ZI using native SPI HAL (and GPIO HAL for chip select).
+ * @brief Port for STM32F4xx series using native SPI HAL (and GPIO HAL for chip select).
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
@@ -12,12 +12,12 @@
 #include "stm32f4xx_hal.h"
 
 /**
- * @brief Device structure for STM32 F439ZI port.
+ * @brief Device structure for STM32F4xx port.
  *
  * @note Public members are meant to be configured by the developer before passing the handle to
  *       libtropic.
  */
-typedef struct lt_dev_stm32_nucleo_f439zi_t {
+typedef struct lt_dev_stm32f4xx_t {
     /** @brief @public Instance of STM SPI interface. Use STM32 macro (SPIX, e.g. SPI1). */
     SPI_TypeDef *spi_instance;
 
@@ -46,6 +46,6 @@ typedef struct lt_dev_stm32_nucleo_f439zi_t {
 
     /** @brief @private SPI handle. */
     SPI_HandleTypeDef spi_handle;
-} lt_dev_stm32_nucleo_f439zi_t;
+} lt_dev_stm32f4xx_t;
 
-#endif  // LIBTROPIC_PORT_STM32_NUCLEO_F439ZI_H
+#endif  // LIBTROPIC_PORT_STM32F4XX_H

--- a/hal/stm32/stm32l4xx/CMakeLists.txt
+++ b/hal/stm32/stm32l4xx/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21.0)
 
 set(LT_HAL_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/libtropic_port_stm32_nucleo_l432kc.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libtropic_port_stm32l4xx.c
 )
 
 set(LT_HAL_INC_DIRS

--- a/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.c
+++ b/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.c
@@ -1,12 +1,12 @@
 /**
- * @file libtropic_port_stm32_nucleo_l432kc.c
+ * @file libtropic_port_stm32l4xx.c
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
- * @brief Port for STM32 L432KC using native SPI HAL (and GPIO HAL for chip select).
+ * @brief Port for STM32L4xx series using native SPI HAL (and GPIO HAL for chip select).
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
-#include "libtropic_port_stm32_nucleo_l432kc.h"
+#include "libtropic_port_stm32l4xx.h"
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -20,11 +20,11 @@
 #include "libtropic_secure_memzero.h"
 #include "stm32l4xx_hal.h"
 
-#define LT_STM32_L432KC_GPIO_OUTPUT_CHECK_ATTEMPTS 10
+#define LT_STM32L4XX_GPIO_OUTPUT_CHECK_ATTEMPTS 10
 
 lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
 {
-    lt_dev_stm32_nucleo_l432kc_t *device = (lt_dev_stm32_nucleo_l432kc_t *)(s2->device);
+    lt_dev_stm32l4xx_t *device = (lt_dev_stm32l4xx_t *)(s2->device);
     size_t bytes_left = count;
     uint8_t *buff_ptr = buff;
     int ret;
@@ -50,10 +50,10 @@ lt_ret_t lt_port_random_bytes(lt_l2_state_t *s2, void *buff, size_t count)
 
 lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_l432kc_t *device = (lt_dev_stm32_nucleo_l432kc_t *)(s2->device);
+    lt_dev_stm32l4xx_t *device = (lt_dev_stm32l4xx_t *)(s2->device);
 
     HAL_GPIO_WritePin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin, GPIO_PIN_RESET);
-    for (uint8_t read_attempts = 0; read_attempts < LT_STM32_L432KC_GPIO_OUTPUT_CHECK_ATTEMPTS;
+    for (uint8_t read_attempts = 0; read_attempts < LT_STM32L4XX_GPIO_OUTPUT_CHECK_ATTEMPTS;
          read_attempts++) {
         if (!HAL_GPIO_ReadPin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin)) {
             return LT_OK;
@@ -66,10 +66,10 @@ lt_ret_t lt_port_spi_csn_low(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_l432kc_t *device = (lt_dev_stm32_nucleo_l432kc_t *)(s2->device);
+    lt_dev_stm32l4xx_t *device = (lt_dev_stm32l4xx_t *)(s2->device);
 
     HAL_GPIO_WritePin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin, GPIO_PIN_SET);
-    for (uint8_t read_attempts = 0; read_attempts < LT_STM32_L432KC_GPIO_OUTPUT_CHECK_ATTEMPTS;
+    for (uint8_t read_attempts = 0; read_attempts < LT_STM32L4XX_GPIO_OUTPUT_CHECK_ATTEMPTS;
          read_attempts++) {
         if (HAL_GPIO_ReadPin(device->spi_cs_gpio_bank, device->spi_cs_gpio_pin)) {
             return LT_OK;
@@ -82,7 +82,7 @@ lt_ret_t lt_port_spi_csn_high(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_init(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_l432kc_t *device = (lt_dev_stm32_nucleo_l432kc_t *)(s2->device);
+    lt_dev_stm32l4xx_t *device = (lt_dev_stm32l4xx_t *)(s2->device);
     int ret;
 
     // Set the SPI parameters.
@@ -125,7 +125,7 @@ lt_ret_t lt_port_init(lt_l2_state_t *s2)
 
 lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
 {
-    lt_dev_stm32_nucleo_l432kc_t *device = (lt_dev_stm32_nucleo_l432kc_t *)(s2->device);
+    lt_dev_stm32l4xx_t *device = (lt_dev_stm32l4xx_t *)(s2->device);
     int ret;
 
     ret = HAL_SPI_DeInit(&device->spi_handle);
@@ -140,7 +140,7 @@ lt_ret_t lt_port_deinit(lt_l2_state_t *s2)
 lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_data_length,
                               uint32_t timeout_ms)
 {
-    lt_dev_stm32_nucleo_l432kc_t *device = (lt_dev_stm32_nucleo_l432kc_t *)(s2->device);
+    lt_dev_stm32l4xx_t *device = (lt_dev_stm32l4xx_t *)(s2->device);
 
     if (offset + tx_data_length > TR01_L1_LEN_MAX) {
         LT_LOG_ERROR("Invalid data length!");

--- a/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.h
+++ b/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.h
@@ -1,10 +1,10 @@
-#ifndef LIBTROPIC_PORT_STM32_NUCLEO_L432KC_H
-#define LIBTROPIC_PORT_STM32_NUCLEO_L432KC_H
+#ifndef LIBTROPIC_PORT_STM32L4XX_H
+#define LIBTROPIC_PORT_STM32L4XX_H
 
 /**
- * @file libtropic_port_stm32_nucleo_l432kc.h
+ * @file libtropic_port_stm32l4xx.h
  * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
- * @brief Port for STM32 L432KC using native SPI HAL (and GPIO HAL for chip select).
+ * @brief Port for STM32L4xx series using native SPI HAL (and GPIO HAL for chip select).
  *
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
@@ -12,12 +12,12 @@
 #include "stm32l4xx_hal.h"
 
 /**
- * @brief Device structure for STM32 L432KC port.
+ * @brief Device structure for STM32L4xx port.
  *
  * @note Public members are meant to be configured by the developer before passing the handle to
  *       libtropic.
  */
-typedef struct lt_dev_stm32_nucleo_l432kc_t {
+typedef struct lt_dev_stm32l4xx_t {
     /** @brief @public Instance of STM SPI interface. Use STM32 macro (SPIX, e.g. SPI1). */
     SPI_TypeDef *spi_instance;
 
@@ -39,6 +39,6 @@ typedef struct lt_dev_stm32_nucleo_l432kc_t {
 
     /** @brief @private SPI handle. */
     SPI_HandleTypeDef spi_handle;
-} lt_dev_stm32_nucleo_l432kc_t;
+} lt_dev_stm32l4xx_t;
 
-#endif  // LIBTROPIC_PORT_STM32_NUCLEO_L432KC_H
+#endif  // LIBTROPIC_PORT_STM32L4XX_H

--- a/tests/functional/stm32/nucleo_f439zi/CMakeLists.txt
+++ b/tests/functional/stm32/nucleo_f439zi/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 ###########################################################################
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}/hal/stm32/nucleo_f439zi" "nucleo_f439zi_hal")
+add_subdirectory("${PATH_LIBTROPIC}/hal/stm32/stm32f4xx" "stm32f4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/tests/functional/stm32/nucleo_f439zi/Src/main.c
+++ b/tests/functional/stm32/nucleo_f439zi/Src/main.c
@@ -18,7 +18,7 @@
 #include "libtropic.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port_stm32_nucleo_f439zi.h"
+#include "libtropic_port_stm32f4xx.h"
 #include "lt_test_common.h"
 #include "syscalls.h"
 
@@ -181,7 +181,7 @@ int main(void)
     lt_handle_t lt_handle = {0};
 
     /* Device mappings */
-    lt_dev_stm32_nucleo_f439zi_t device = {0};
+    lt_dev_stm32f4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;

--- a/tests/functional/stm32/nucleo_l432kc/CMakeLists.txt
+++ b/tests/functional/stm32/nucleo_l432kc/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 ###########################################################################
 
 # Add Libtropic STM32 HAL
-add_subdirectory("${PATH_LIBTROPIC}/hal/stm32/nucleo_l432kc" "nucleo_l432kc_hal")
+add_subdirectory("${PATH_LIBTROPIC}/hal/stm32/stm32l4xx" "stm32l4xx_hal")
 
 # Specify other source files
 set(SOURCES

--- a/tests/functional/stm32/nucleo_l432kc/Src/main.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/main.c
@@ -18,7 +18,7 @@
 #include "libtropic.h"
 #include "libtropic_functional_tests.h"
 #include "libtropic_logging.h"
-#include "libtropic_port_stm32_nucleo_l432kc.h"
+#include "libtropic_port_stm32l4xx.h"
 #include "lt_test_common.h"
 
 #if LT_USE_TREZOR_CRYPTO
@@ -217,7 +217,7 @@ int main(void)
     lt_handle_t lt_handle = {0};
 
     /* Device mappings */
-    lt_dev_stm32_nucleo_l432kc_t device = {0};
+    lt_dev_stm32l4xx_t device = {0};
 
     device.spi_instance = LT_SPI_INSTANCE;
     device.baudrate_prescaler = SPI_BAUDRATEPRESCALER_16;


### PR DESCRIPTION
## Description

Changes described in the changelog. The reason is to not duplicate future HALs for each board with the same STM32 MCU series, because for one STM32 MCU series (e.g. STM32F4xx), they would be the same, as they include one STM32 HAL (e.g. `stm32f4xx_hal.h`). I already tested this approach with the new STM32U5xx HAL, which I use with both STM32U535xx and STM32U545xx MCU.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---