### PR TITLE
ETR01SDK-506: Use appropriate type for slot parameter in pairing key functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - ECC + EdDSA example for USB Devkit.
 
+### Fixed
+- Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.
+
 ## [3.2.0]
 
 ### Changed

--- a/examples/model/hw_wallet/main.c
+++ b/examples/model/hw_wallet/main.c
@@ -471,7 +471,7 @@ static int session_initial(lt_handle_t *h)
 
     // Write pairing keys into slots 1,2,3
     printf("Will write new pairing keys to slots 1, 2 and 3:\n");
-    for (uint8_t i = TR01_PAIRING_KEY_SLOT_INDEX_1; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
+    for (lt_pkey_index_t i = TR01_PAIRING_KEY_SLOT_INDEX_1; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
         printf("\tWriting to pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, pub_keys[i], i);
         if (LT_OK != ret) {
@@ -581,7 +581,7 @@ static int session1(lt_handle_t *h)
 
     uint8_t dummy_key[TR01_SHIPUB_LEN] = {0};
     printf("Will try to write all pairing key slots (should fail due to unauthorized access):\n");
-    for (uint8_t i = TR01_PAIRING_KEY_SLOT_INDEX_0; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
+    for (lt_pkey_index_t i = TR01_PAIRING_KEY_SLOT_INDEX_0; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
         printf("\tWriting pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
@@ -651,7 +651,7 @@ static int session2(lt_handle_t *h)
     printf("OK (failed)\n");
 
     printf("Will try to write all pairing key slots (should fail due to unauthorized access):\n");
-    for (uint8_t i = TR01_PAIRING_KEY_SLOT_INDEX_0; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
+    for (lt_pkey_index_t i = TR01_PAIRING_KEY_SLOT_INDEX_0; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
         printf("\tWriting pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {
@@ -853,7 +853,7 @@ static int session3(lt_handle_t *h)
     printf("OK (failed)\n");
 
     printf("Will try to write all pairing key slots (should fail due to unauthorized access):\n");
-    for (uint8_t i = TR01_PAIRING_KEY_SLOT_INDEX_0; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
+    for (lt_pkey_index_t i = TR01_PAIRING_KEY_SLOT_INDEX_0; i <= TR01_PAIRING_KEY_SLOT_INDEX_3; i++) {
         printf("\tWriting pairing key slot %" PRIu8 "...", i);
         ret = lt_pairing_key_write(h, dummy_key, i);
         if (LT_L3_UNAUTHORIZED != ret) {

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -313,26 +313,26 @@ lt_ret_t lt_ping(lt_handle_t *h, const uint8_t *msg_out, uint8_t *msg_in, const 
  *
  * @param h           Handle for communication with TROPIC01
  * @param pairing_pub 32B of pubkey
- * @param slot        Pairing key lot SH0PUB - SH3PUB
+ * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
  *
  * @retval            LT_OK Function executed successfully
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get
  * verbose encoding of returned value
  */
-lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const uint8_t slot);
+lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const lt_pkey_index_t slot);
 
 /**
  * @brief Reads pairing public key from TROPIC01's pairing key slot 0-3
  *
  * @param h           Handle for communication with TROPIC01
  * @param pairing_pub 32B of pubkey
- * @param slot        Pairing key lot SH0PUB - SH3PUB
+ * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
  *
  * @retval            LT_OK Function executed successfully
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get
  * verbose encoding of returned value
  */
-lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const uint8_t slot);
+lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const lt_pkey_index_t slot);
 
 /**
  * @brief Invalidates pairing key in slot 0-3
@@ -343,13 +343,13 @@ lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const uint8_t
  * invalidated if operating outside this range. Refer to datasheet for absolute maximum ratings.
  *
  * @param h           Handle for communication with TROPIC01
- * @param slot        Pairing key lot SH0PUB - SH3PUB
+ * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
  *
  * @retval            LT_OK Function executed successfully
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get
  * verbose encoding of returned value
  */
-lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const uint8_t slot);
+lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot);
 
 /**
  * @brief Writes configuration object specified by `addr`. Make sure to read the Configuration Objects

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -313,7 +313,7 @@ lt_ret_t lt_ping(lt_handle_t *h, const uint8_t *msg_out, uint8_t *msg_in, const 
  *
  * @param h           Handle for communication with TROPIC01
  * @param pairing_pub 32B of pubkey
- * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
+ * @param slot        Pairing key slot index
  *
  * @retval            LT_OK Function executed successfully
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get
@@ -326,7 +326,7 @@ lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const 
  *
  * @param h           Handle for communication with TROPIC01
  * @param pairing_pub 32B of pubkey
- * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
+ * @param slot        Pairing key slot index
  *
  * @retval            LT_OK Function executed successfully
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get
@@ -343,7 +343,7 @@ lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const lt_pkey
  * invalidated if operating outside this range. Refer to datasheet for absolute maximum ratings.
  *
  * @param h           Handle for communication with TROPIC01
- * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
+ * @param slot        Pairing key slot index
  *
  * @retval            LT_OK Function executed successfully
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get

--- a/include/libtropic_l3.h
+++ b/include/libtropic_l3.h
@@ -99,10 +99,11 @@ lt_ret_t lt_in__ping(lt_handle_t *h, uint8_t *msg_in, const uint16_t msg_len);
  *
  * @param h           Handle for communication with TROPIC01
  * @param pairing_pub 32B of pubkey
- * @param slot        Pairing key lot SH0PUB - SH3PUB
+ * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_out__pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const uint8_t slot);
+lt_ret_t lt_out__pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub,
+                                   const lt_pkey_index_t slot);
 /**
  * @brief Decodes Pairing_Key_Write result payload.
  * @note Used for separate L3 communication, for more information read info
@@ -119,10 +120,10 @@ lt_ret_t lt_in__pairing_key_write(lt_handle_t *h);
  * at the top of this file.
  *
  * @param h           Handle for communication with TROPIC01
- * @param slot        Slot to read pairing key from
+ * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_out__pairing_key_read(lt_handle_t *h, const uint8_t slot);
+lt_ret_t lt_out__pairing_key_read(lt_handle_t *h, const lt_pkey_index_t slot);
 
 /**
  * @brief Decodes Pairing_Key_Read result payload.
@@ -141,10 +142,10 @@ lt_ret_t lt_in__pairing_key_read(lt_handle_t *h, uint8_t *pubkey);
  * read info at the top of this file.
  *
  * @param h           Handle for communication with TROPIC01
- * @param slot        Slot to invalidate pairing key in
+ * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
  * @return            LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_out__pairing_key_invalidate(lt_handle_t *h, const uint8_t slot);
+lt_ret_t lt_out__pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot);
 
 /**
  * @brief Decodes Pairing_Key_Invalidate result payload.

--- a/include/libtropic_l3.h
+++ b/include/libtropic_l3.h
@@ -99,7 +99,7 @@ lt_ret_t lt_in__ping(lt_handle_t *h, uint8_t *msg_in, const uint16_t msg_len);
  *
  * @param h           Handle for communication with TROPIC01
  * @param pairing_pub 32B of pubkey
- * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
+ * @param slot        Pairing key slot index
  * @return            LT_OK if success, otherwise returns other error code.
  */
 lt_ret_t lt_out__pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub,
@@ -120,7 +120,7 @@ lt_ret_t lt_in__pairing_key_write(lt_handle_t *h);
  * at the top of this file.
  *
  * @param h           Handle for communication with TROPIC01
- * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
+ * @param slot        Pairing key slot index
  * @return            LT_OK if success, otherwise returns other error code.
  */
 lt_ret_t lt_out__pairing_key_read(lt_handle_t *h, const lt_pkey_index_t slot);
@@ -142,7 +142,7 @@ lt_ret_t lt_in__pairing_key_read(lt_handle_t *h, uint8_t *pubkey);
  * read info at the top of this file.
  *
  * @param h           Handle for communication with TROPIC01
- * @param slot        Pairing key slot index (SH0PUB-SH3PUB)
+ * @param slot        Pairing key slot index
  * @return            LT_OK if success, otherwise returns other error code.
  */
 lt_ret_t lt_out__pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot);

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -876,9 +876,9 @@ lt_ret_t lt_ping(lt_handle_t *h, const uint8_t *msg_out, uint8_t *msg_in, const 
     return lt_in__ping(h, msg_in, msg_len);
 }
 
-lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const uint8_t slot)
+lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot > 3)) {
+    if (!h || !pairing_pub || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -904,9 +904,9 @@ lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const 
     return lt_in__pairing_key_write(h);
 }
 
-lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const uint8_t slot)
+lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot > 3)) {
+    if (!h || !pairing_pub || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -932,9 +932,9 @@ lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const uint8_t
     return lt_in__pairing_key_read(h, pairing_pub);
 }
 
-lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const uint8_t slot)
+lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot > 3)) {
+    if (!h || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -878,7 +878,8 @@ lt_ret_t lt_ping(lt_handle_t *h, const uint8_t *msg_out, uint8_t *msg_in, const 
 
 lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || !pairing_pub || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) ||
+        (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -906,7 +907,8 @@ lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const 
 
 lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || !pairing_pub || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) ||
+        (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -934,7 +936,7 @@ lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const lt_pkey
 
 lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {

--- a/src/libtropic_l3.c
+++ b/src/libtropic_l3.c
@@ -344,9 +344,10 @@ lt_ret_t lt_in__ping(lt_handle_t *h, uint8_t *msg_in, const uint16_t msg_len)
     return LT_OK;
 }
 
-lt_ret_t lt_out__pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const uint8_t slot)
+lt_ret_t lt_out__pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub,
+                                   const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot > 3)) {
+    if (!h || !pairing_pub || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -393,9 +394,9 @@ lt_ret_t lt_in__pairing_key_write(lt_handle_t *h)
     return LT_OK;
 }
 
-lt_ret_t lt_out__pairing_key_read(lt_handle_t *h, const uint8_t slot)
+lt_ret_t lt_out__pairing_key_read(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot > 3)) {
+    if (!h || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -441,9 +442,9 @@ lt_ret_t lt_in__pairing_key_read(lt_handle_t *h, uint8_t *pubkey)
     return LT_OK;
 }
 
-lt_ret_t lt_out__pairing_key_invalidate(lt_handle_t *h, const uint8_t slot)
+lt_ret_t lt_out__pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot > 3)) {
+    if (!h || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {

--- a/src/libtropic_l3.c
+++ b/src/libtropic_l3.c
@@ -347,7 +347,8 @@ lt_ret_t lt_in__ping(lt_handle_t *h, uint8_t *msg_in, const uint16_t msg_len)
 lt_ret_t lt_out__pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub,
                                    const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || !pairing_pub || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) ||
+        (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -396,7 +397,7 @@ lt_ret_t lt_in__pairing_key_write(lt_handle_t *h)
 
 lt_ret_t lt_out__pairing_key_read(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -444,7 +445,7 @@ lt_ret_t lt_in__pairing_key_read(lt_handle_t *h, uint8_t *pubkey)
 
 lt_ret_t lt_out__pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {


### PR DESCRIPTION
## Description

- Use `lt_pkey_index_t` instead of `uint8_t` for `slot` parameter in pairing key functions.
- Use `TR01_PAIRING_KEY_SLOT_INDEX_3` in the parameter check `if`.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---