### PR TITLE
ETR01SDK-479: fix names of lt_ecc_key_origin_t values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rename `LT_USB_DONGLE_SPI_TRANSFER_BUFF_SIZE_MAX` to `LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX`.
   - Rename `lt_dev_posix_usb_dongle_t` to `lt_dev_posix_usb_devkit_t`.
 - Added `lt_` prefixes to `sh0priv_eng_sample`, `sh0pub_eng_sample`, `sh0priv_prod0`, `sh0pub_prod0` arrays to avoid name collisions.
+- Renamed `TR01_CURVE_GENERATED` to `TR01_KEY_GENERATED` and `TR01_CURVE_STORED` to `TR01_KEY_STORED` in the `lt_ecc_key_origin_t` enum (typo).
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -893,8 +893,14 @@ typedef enum lt_ecc_slot_t {
     TR01_ECC_SLOT_31,
 } lt_ecc_slot_t;
 
-/** @brief ECC key type */
-typedef enum lt_ecc_curve_type_t { TR01_CURVE_P256 = 1, TR01_CURVE_ED25519 } lt_ecc_curve_type_t;
+/** @brief The type of Elliptic Curve public key. Relevant to ECC_Key_Generate, ECC_Key_Store,
+ * ECC_Key_Read L3 commands. */
+typedef enum lt_ecc_curve_type_t {
+    /** @brief P256 Curve - 64-byte long public key. */
+    TR01_CURVE_P256 = 1,
+    /** @brief Ed25519 Curve - 32-byte long public key. */
+    TR01_CURVE_ED25519 = 2
+} lt_ecc_curve_type_t;
 
 /** @brief Length of public keys for P256 curve. */
 #define TR01_CURVE_P256_PUBKEY_LEN 64
@@ -903,8 +909,13 @@ typedef enum lt_ecc_curve_type_t { TR01_CURVE_P256 = 1, TR01_CURVE_ED25519 } lt_
 /** @brief Common length of private keys for both P256 and ED25519 curves. */
 #define TR01_CURVE_PRIVKEY_LEN 32
 
-/** @brief ECC key origin */
-typedef enum lt_ecc_key_origin_t { TR01_CURVE_GENERATED = 1, TR01_CURVE_STORED } lt_ecc_key_origin_t;
+/** @brief The origin of the Elliptic Curve public key. Relevant to ECC_Key_Read L3 command. */
+typedef enum lt_ecc_key_origin_t {
+    /** @brief The key is from key generation on the device. */
+    TR01_KEY_GENERATED = 1,
+    /** @brief The key is from key storage in the device. */
+    TR01_KEY_STORED = 2
+} lt_ecc_key_origin_t;
 
 /** @brief Length of the EC signature (RS) for both ECDSA and EDDSA. */
 #define TR01_ECDSA_EDDSA_SIGNATURE_LENGTH 64

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -893,12 +893,12 @@ typedef enum lt_ecc_slot_t {
     TR01_ECC_SLOT_31,
 } lt_ecc_slot_t;
 
-/** @brief The type of Elliptic Curve public key. Relevant to ECC_Key_Generate, ECC_Key_Store,
- * ECC_Key_Read L3 commands. */
+/** @brief Type of the Elliptic Curve used for the key pair. Used by the ECC_Key_Generate,
+ * ECC_Key_Store and ECC_Key_Read L3 commands. */
 typedef enum lt_ecc_curve_type_t {
-    /** @brief P256 Curve - 64-byte long public key. */
+    /** @brief Curve P-256. */
     TR01_CURVE_P256 = 1,
-    /** @brief Ed25519 Curve - 32-byte long public key. */
+    /** @brief Curve Ed25519. */
     TR01_CURVE_ED25519 = 2
 } lt_ecc_curve_type_t;
 
@@ -909,11 +909,12 @@ typedef enum lt_ecc_curve_type_t {
 /** @brief Common length of private keys for both P256 and ED25519 curves. */
 #define TR01_CURVE_PRIVKEY_LEN 32
 
-/** @brief The origin of the Elliptic Curve public key. Relevant to ECC_Key_Read L3 command. */
+/** @brief Origin of the Elliptic Curve private key used to derive the public key. Used by the
+ * ECC_Key_Read L3 command. */
 typedef enum lt_ecc_key_origin_t {
-    /** @brief The key is from key generation on the device. */
+    /** @brief Private key was generated via the ECC_Key_Generate L3 command. */
     TR01_KEY_GENERATED = 1,
-    /** @brief The key is from key storage in the device. */
+    /** @brief Private key was stored via the ECC_Key_Store L3 command. */
     TR01_KEY_STORED = 2
 } lt_ecc_key_origin_t;
 

--- a/tests/functional/src/lt_test_rev_ecc_key_generate.c
+++ b/tests/functional/src/lt_test_rev_ecc_key_generate.c
@@ -140,7 +140,7 @@ void lt_test_rev_ecc_key_generate(lt_handle_t *h)
         LT_TEST_ASSERT(1, (curve == TR01_CURVE_P256));
 
         LT_LOG_INFO("Checking origin of the read key...");
-        LT_TEST_ASSERT(1, (origin == TR01_CURVE_GENERATED));
+        LT_TEST_ASSERT(1, (origin == TR01_KEY_GENERATED));
 
         LT_LOG_INFO("Erasing the slot...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_erase(h, i));
@@ -173,7 +173,7 @@ void lt_test_rev_ecc_key_generate(lt_handle_t *h)
         LT_TEST_ASSERT(1, (curve == TR01_CURVE_ED25519));
 
         LT_LOG_INFO("Checking origin of the read key...");
-        LT_TEST_ASSERT(1, (origin == TR01_CURVE_GENERATED));
+        LT_TEST_ASSERT(1, (origin == TR01_KEY_GENERATED));
 
         LT_LOG_INFO("Erasing the slot...");
         LT_TEST_ASSERT(LT_OK, lt_ecc_key_erase(h, i));

--- a/tests/functional/src/lt_test_rev_ecc_key_store.c
+++ b/tests/functional/src/lt_test_rev_ecc_key_store.c
@@ -165,7 +165,7 @@ void lt_test_rev_ecc_key_store(lt_handle_t *h)
         LT_TEST_ASSERT(1, (curve == TR01_CURVE_P256));
 
         LT_LOG_INFO("Checking origin of the read key...");
-        LT_TEST_ASSERT(1, (origin == TR01_CURVE_STORED));
+        LT_TEST_ASSERT(1, (origin == TR01_KEY_STORED));
 
         LT_LOG_INFO("Comparing the public key to the pre-generated one...");
         LT_TEST_ASSERT(0, memcmp(p256_pub_test_key, read_pub_key, sizeof(p256_pub_test_key)));
@@ -201,7 +201,7 @@ void lt_test_rev_ecc_key_store(lt_handle_t *h)
         LT_TEST_ASSERT(1, (curve == TR01_CURVE_ED25519));
 
         LT_LOG_INFO("Checking origin of the read key...");
-        LT_TEST_ASSERT(1, (origin == TR01_CURVE_STORED));
+        LT_TEST_ASSERT(1, (origin == TR01_KEY_STORED));
 
         LT_LOG_INFO("Comparing the public key to the pre-generated one...");
         LT_TEST_ASSERT(0, memcmp(ed25519_pub_test_key, read_pub_key, sizeof(ed25519_pub_test_key)));


### PR DESCRIPTION
## Description

Changes are in the changelog + enhanced documentation of `lt_ecc_curve_type_t` and `lt_ecc_key_origin_t`.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---