### PR TITLE
ETR01SDK-282: Refactor reversible tests

### DIFF
--- a/docs/for_contributors/tests/functional_tests.md
+++ b/docs/for_contributors/tests/functional_tests.md
@@ -6,6 +6,9 @@ The functional tests are organized into two categories, as some of them may caus
 - **Reversible** (`lt_test_rev_*.c`): only reversible operations are executed on the TROPIC01.
 - **Irreversible** (`lt_test_ire_*.c`): irreversible operations are executed: the state or contents of the TROPIC01 **cannot** be reverted.
 
+!!! warning "Functional tests reversibility"
+    *Reversible* means that the state of the TROPIC01 can be reverted back to the factory state. However, **it does not** mean that any data or changes stored or done by the user will be retained. For example, ECC keys or contents of R-Memory can be deleted by reversible tests.
+
 ## Compilation and Running
 !!! danger "DANGER!"
     Functional tests are for internal use only and are provided only for reference. Some tests can **destroy** your chip. **Do not run the tests** unless you use model only or you are absolutely sure what you are doing. If you damage your chip with the tests, we are unable to provide any support.

--- a/tests/functional/src/lt_test_rev_ecc_key_generate.c
+++ b/tests/functional/src/lt_test_rev_ecc_key_generate.c
@@ -18,7 +18,7 @@
 // Shared with cleanup function
 lt_handle_t *g_h;
 
-static lt_ret_t lt_test_rev_ecc_key_generate_cleanup(void)
+static lt_ret_t erase_ecc_slots_and_verify(void)
 {
     lt_ret_t ret;
     uint8_t read_pub_key[TR01_CURVE_P256_PUBKEY_LEN];  // The read key can have 32B or 64B, depending
@@ -27,14 +27,6 @@ static lt_ret_t lt_test_rev_ecc_key_generate_cleanup(void)
                                                        // assume the size of pubkey on the P256 curve.
     lt_ecc_curve_type_t curve;
     lt_ecc_key_origin_t origin;
-
-    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
-    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
-                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
-    if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to establish secure session.");
-        return ret;
-    }
 
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = TR01_ECC_SLOT_0; i <= TR01_ECC_SLOT_31; i++) {
@@ -52,6 +44,26 @@ static lt_ret_t lt_test_rev_ecc_key_generate_cleanup(void)
             LT_LOG_ERROR("Return value is not LT_L3_INVALID_KEY.");
             return ret;
         }
+    }
+
+    return LT_OK;
+}
+
+static lt_ret_t lt_test_rev_ecc_key_generate_cleanup(void)
+{
+    lt_ret_t ret;
+
+    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to establish secure session.");
+        return ret;
+    }
+
+    ret = erase_ecc_slots_and_verify();
+    if (LT_OK != ret) {
+        return ret;
     }
 
     LT_LOG_INFO("Aborting secure session");
@@ -94,6 +106,10 @@ void lt_test_rev_ecc_key_generate(lt_handle_t *h)
     LT_LOG_INFO("Starting Secure Session with key %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                   TR01_PAIRING_KEY_SLOT_INDEX_0));
+
+    // We need to start with the slots erased.
+    LT_LOG_INFO("Erasing all ECC slots before starting the test...");
+    LT_TEST_ASSERT(LT_OK, erase_ecc_slots_and_verify());
     LT_LOG_LINE();
 
     lt_test_cleanup_function = &lt_test_rev_ecc_key_generate_cleanup;

--- a/tests/functional/src/lt_test_rev_ecc_key_store.c
+++ b/tests/functional/src/lt_test_rev_ecc_key_store.c
@@ -39,7 +39,7 @@ uint8_t p256_invalid_priv_test_key[] = {
 // Shared with cleanup function
 lt_handle_t *g_h;
 
-static lt_ret_t lt_test_rev_ecc_key_store_cleanup(void)
+static lt_ret_t erase_ecc_slots_and_verify(void)
 {
     lt_ret_t ret;
     uint8_t read_pub_key[TR01_CURVE_P256_PUBKEY_LEN];  // The read key can have 32B or 64B, depending
@@ -48,14 +48,6 @@ static lt_ret_t lt_test_rev_ecc_key_store_cleanup(void)
                                                        // assume the size of pubkey on the P256 curve.
     lt_ecc_curve_type_t curve;
     lt_ecc_key_origin_t origin;
-
-    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
-    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
-                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
-    if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to establish secure session.");
-        return ret;
-    }
 
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = TR01_ECC_SLOT_0; i <= TR01_ECC_SLOT_31; i++) {
@@ -73,6 +65,26 @@ static lt_ret_t lt_test_rev_ecc_key_store_cleanup(void)
             LT_LOG_ERROR("Return value is not LT_L3_INVALID_KEY.");
             return ret;
         }
+    }
+
+    return LT_OK;
+}
+
+static lt_ret_t lt_test_rev_ecc_key_store_cleanup(void)
+{
+    lt_ret_t ret;
+
+    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to establish secure session.");
+        return ret;
+    }
+
+    ret = erase_ecc_slots_and_verify();
+    if (LT_OK != ret) {
+        return ret;
     }
 
     LT_LOG_INFO("Aborting secure session");
@@ -115,6 +127,10 @@ void lt_test_rev_ecc_key_store(lt_handle_t *h)
     LT_LOG_INFO("Starting Secure Session with key %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                   TR01_PAIRING_KEY_SLOT_INDEX_0));
+
+    // We need to start with the slots erased.
+    LT_LOG_INFO("Erasing all ECC slots before starting the test...");
+    LT_TEST_ASSERT(LT_OK, erase_ecc_slots_and_verify());
     LT_LOG_LINE();
 
     lt_test_cleanup_function = &lt_test_rev_ecc_key_store_cleanup;

--- a/tests/functional/src/lt_test_rev_ecdsa_sign.c
+++ b/tests/functional/src/lt_test_rev_ecdsa_sign.c
@@ -29,7 +29,7 @@ uint8_t priv_test_key[] = {0x5e, 0xc6, 0xf1, 0xef, 0x96, 0x1f, 0x69, 0xb5, 0xd4,
 // Shared with cleanup function
 lt_handle_t *g_h;
 
-static lt_ret_t lt_test_rev_ecdsa_sign_cleanup(void)
+static lt_ret_t erase_ecc_slots_and_verify(void)
 {
     lt_ret_t ret;
     uint8_t read_pub_key[TR01_CURVE_P256_PUBKEY_LEN];  // The read key can have 32B or 64B, depending
@@ -39,14 +39,6 @@ static lt_ret_t lt_test_rev_ecdsa_sign_cleanup(void)
                                                        // pubkey on the P256 curve to be safe.
     lt_ecc_curve_type_t curve;
     lt_ecc_key_origin_t origin;
-
-    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
-    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
-                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
-    if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to establish secure session.");
-        return ret;
-    }
 
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = TR01_ECC_SLOT_0; i <= TR01_ECC_SLOT_31; i++) {
@@ -64,6 +56,26 @@ static lt_ret_t lt_test_rev_ecdsa_sign_cleanup(void)
             LT_LOG_ERROR("Return value is not LT_L3_INVALID_KEY.");
             return ret;
         }
+    }
+
+    return LT_OK;
+}
+
+static lt_ret_t lt_test_rev_ecdsa_sign_cleanup(void)
+{
+    lt_ret_t ret;
+
+    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to establish secure session.");
+        return ret;
+    }
+
+    ret = erase_ecc_slots_and_verify();
+    if (LT_OK != ret) {
+        return ret;
     }
 
     LT_LOG_INFO("Aborting secure session");
@@ -105,6 +117,10 @@ void lt_test_rev_ecdsa_sign(lt_handle_t *h)
     LT_LOG_INFO("Starting Secure Session with key %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                   TR01_PAIRING_KEY_SLOT_INDEX_0));
+
+    // We need to start with the slots erased.
+    LT_LOG_INFO("Erasing all ECC slots before starting the test...");
+    LT_TEST_ASSERT(LT_OK, erase_ecc_slots_and_verify());
     LT_LOG_LINE();
 
     lt_test_cleanup_function = &lt_test_rev_ecdsa_sign_cleanup;

--- a/tests/functional/src/lt_test_rev_eddsa_sign.c
+++ b/tests/functional/src/lt_test_rev_eddsa_sign.c
@@ -26,7 +26,7 @@ uint8_t priv_test_key[] = {0x42, 0xb2, 0xee, 0x0e, 0x9b, 0xb5, 0x72, 0x50, 0x6e,
 // Shared with cleanup function
 lt_handle_t *g_h;
 
-static lt_ret_t lt_test_rev_eddsa_sign_cleanup(void)
+static lt_ret_t erase_ecc_slots_and_verify(void)
 {
     lt_ret_t ret;
     uint8_t read_pub_key[TR01_CURVE_P256_PUBKEY_LEN];  // The read key can have 32B or 64B, depending
@@ -36,14 +36,6 @@ static lt_ret_t lt_test_rev_eddsa_sign_cleanup(void)
                                                        // pubkey on the P256 curve to be safe.
     lt_ecc_curve_type_t curve;
     lt_ecc_key_origin_t origin;
-
-    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
-    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
-                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
-    if (LT_OK != ret) {
-        LT_LOG_ERROR("Failed to establish secure session.");
-        return ret;
-    }
 
     LT_LOG_INFO("Erasing all ECC key slots");
     for (uint8_t i = TR01_ECC_SLOT_0; i <= TR01_ECC_SLOT_31; i++) {
@@ -61,6 +53,26 @@ static lt_ret_t lt_test_rev_eddsa_sign_cleanup(void)
             LT_LOG_ERROR("Return value is not LT_L3_INVALID_KEY.");
             return ret;
         }
+    }
+
+    return LT_OK;
+}
+
+static lt_ret_t lt_test_rev_eddsa_sign_cleanup(void)
+{
+    lt_ret_t ret;
+
+    LT_LOG_INFO("Starting secure session with slot %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    ret = lt_verify_chip_and_start_secure_session(g_h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        LT_LOG_ERROR("Failed to establish secure session.");
+        return ret;
+    }
+
+    ret = erase_ecc_slots_and_verify();
+    if (LT_OK != ret) {
+        return ret;
     }
 
     LT_LOG_INFO("Aborting secure session");
@@ -101,6 +113,10 @@ void lt_test_rev_eddsa_sign(lt_handle_t *h)
     LT_LOG_INFO("Starting Secure Session with key %d", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
     LT_TEST_ASSERT(LT_OK, lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                   TR01_PAIRING_KEY_SLOT_INDEX_0));
+
+    // We need to start with the slots erased.
+    LT_LOG_INFO("Erasing all ECC slots before starting the test...");
+    LT_TEST_ASSERT(LT_OK, erase_ecc_slots_and_verify());
     LT_LOG_LINE();
 
     lt_test_cleanup_function = &lt_test_rev_eddsa_sign_cleanup;


### PR DESCRIPTION
## Description

ECC tests were assuming that the slots are already empty, which is not the case if in the previous run, one of the tests cleanup was not successfull. So I added a new function which erases the ECC slots and verifies it was successful. This function is called before the test starts and also in the cleanup, as it is also needed here.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---