### PR TITLE
docs(esp32): fix the official ESP-IDF setup guide link to a specific …

### DIFF
--- a/docs/tutorials/esp32/index.md
+++ b/docs/tutorials/esp32/index.md
@@ -78,7 +78,7 @@ See below for instructions based on your OS:
 !!! example "Installation Instructions"
     === ":fontawesome-brands-linux: Linux"
         1. Setup ESP-IDF and its dependencies:
-            - Complete the first 4 steps in the [official ESP-IDF setup guide](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/linux-macos-setup.html).
+            - Complete the first 4 steps in the [official ESP-IDF setup guide](https://docs.espressif.com/projects/esp-idf/en/v5.5.3/esp32/get-started/linux-macos-setup.html).
             - We recommend getting the 5.5.1 version, but any 5.x.x version should work.
         2. Get the Libtropic repository:
             - Using git: `git clone https://github.com/tropicsquare/libtropic.git`


### PR DESCRIPTION
## Description

Unfortunately, the link used the latest documentation version, but Espressif changed the page structure and added installation via GUI only. Based on internal feedback, it is better to fix the link to a specific version that was assumed when writing this docs page.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---