### PR TITLE
ETR01SDK-610: Missing dependencies for STM32 compilation on Fedora

### DIFF
--- a/docs/tutorials/stm32/index.md
+++ b/docs/tutorials/stm32/index.md
@@ -57,7 +57,7 @@ First, install the dependencies and prepare the repository:
             - Fedora: `sudo dnf install make`
         3. Install GCC cross-compiler for ARM:
             - Ubuntu/Debian: `sudo apt update && sudo apt install gcc-arm-none-eabi`
-            - Fedora: `sudo dnf install arm-none-eabi-gcc`
+            - Fedora: `sudo dnf install arm-none-eabi-gcc arm-none-eabi-binutils-cs arm-none-eabi-newlib`
         4. Install [OpenOCD](https://openocd.org/pages/getting-openocd.html):
             - Ubuntu/Debian: `sudo apt update && sudo apt install openocd`
             - Fedora: `sudo dnf install openocd`


### PR DESCRIPTION
## Description

I noticed that there are some missing dependencies for Fedora. If those aren't installed, compilation will fail with vague error, something like " The C compiler is not able to compile a simple test program.".

I tested this on F43. @medexs if you still have F42 by a chance, can you please test if those dependencies suffice for successful compilation? Thanks!

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage