### PR TITLE
fix(pairing key functions): slot parameter check

### DIFF
--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -878,8 +878,7 @@ lt_ret_t lt_ping(lt_handle_t *h, const uint8_t *msg_out, uint8_t *msg_in, const 
 
 lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) ||
-        (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || !pairing_pub || ((unsigned)slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -907,8 +906,7 @@ lt_ret_t lt_pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub, const 
 
 lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) ||
-        (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || !pairing_pub || ((unsigned)slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -936,7 +934,7 @@ lt_ret_t lt_pairing_key_read(lt_handle_t *h, uint8_t *pairing_pub, const lt_pkey
 
 lt_ret_t lt_pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || ((unsigned)slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {

--- a/src/libtropic_l3.c
+++ b/src/libtropic_l3.c
@@ -347,8 +347,7 @@ lt_ret_t lt_in__ping(lt_handle_t *h, uint8_t *msg_in, const uint16_t msg_len)
 lt_ret_t lt_out__pairing_key_write(lt_handle_t *h, const uint8_t *pairing_pub,
                                    const lt_pkey_index_t slot)
 {
-    if (!h || !pairing_pub || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) ||
-        (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || !pairing_pub || ((unsigned)slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -397,7 +396,7 @@ lt_ret_t lt_in__pairing_key_write(lt_handle_t *h)
 
 lt_ret_t lt_out__pairing_key_read(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || ((unsigned)slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -445,7 +444,7 @@ lt_ret_t lt_in__pairing_key_read(lt_handle_t *h, uint8_t *pubkey)
 
 lt_ret_t lt_out__pairing_key_invalidate(lt_handle_t *h, const lt_pkey_index_t slot)
 {
-    if (!h || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) || (slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
+    if (!h || ((unsigned)slot > TR01_PAIRING_KEY_SLOT_INDEX_3)) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {


### PR DESCRIPTION
## Description

WIth our strict compilation flags, the current state gives this compilation error (observed when compiling for STM32):
```
libtropic/src/libtropic.c:881:37: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  881 |     if (!h || !pairing_pub || (slot < TR01_PAIRING_KEY_SLOT_INDEX_0) ||
      |                                     ^
```
But without it, the user can pass a negative value and it will pass the check. So a solution is to cast the value to unsigned, which makes negative values big enough and fails the check.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---