### PR TITLE
fix,docs(examples index.md): reorder pins table to match Arduino shield image

### DIFF
--- a/docs/tutorials/esp32/index.md
+++ b/docs/tutorials/esp32/index.md
@@ -27,11 +27,11 @@ Unfortunately, ESP32 boards and our Arduino shield are not plug-and-play, so ple
         | IOREF                       | 3V3                  |
         | +3V3                        | 3V3                  |
         | GND                         | GND                  |
-        | GPO                         | GPIO32               |
-        | MOSI                        | GPIO23               |
-        | MISO                        | GPIO19               |
         | SCK                         | GPIO18               |
+        | MISO                        | GPIO19               |
+        | MOSI                        | GPIO23               |
         | CS                          | GPIO5                |
+        | GPO                         | GPIO32               |
         
         </div>
     
@@ -44,11 +44,11 @@ Unfortunately, ESP32 boards and our Arduino shield are not plug-and-play, so ple
         | IOREF                       | 3V3                    |
         | +3V3                        | 3V3                    |
         | GND                         | GND                    |
-        | GPO                         | GPIO1                  |
-        | MOSI                        | GPIO11                 |
-        | MISO                        | GPIO13                 |
         | SCK                         | GPIO12                 |
+        | MISO                        | GPIO13                 |
+        | MOSI                        | GPIO11                 |
         | CS                          | GPIO10                 |
+        | GPO                         | GPIO1                  |
         
         </div>
 
@@ -61,11 +61,11 @@ Unfortunately, ESP32 boards and our Arduino shield are not plug-and-play, so ple
         | IOREF                       | 3V3                        |
         | +3V3                        | 3V3                        |
         | GND                         | GND                        |
-        | GPO                         | GPIO10                     |
-        | MOSI                        | GPIO1                      |
-        | MISO                        | GPIO0                      |
         | SCK                         | GPIO3                      |
+        | MISO                        | GPIO0                      |
+        | MOSI                        | GPIO1                      |
         | CS                          | GPIO8                      |
+        | GPO                         | GPIO10                     |
         
         </div>
 
@@ -78,7 +78,7 @@ See below for instructions based on your OS:
 !!! example "Installation Instructions"
     === ":fontawesome-brands-linux: Linux"
         1. Setup ESP-IDF and its dependencies:
-            - Complete the first 4 steps in the [official ESP-IDF setup guide](https://docs.espressif.com/projects/esp-idf/en/v5.5.3/esp32/get-started/linux-macos-setup.html).
+            - Complete the first 4 steps in the [official ESP-IDF setup guide](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/linux-macos-setup.html).
             - We recommend getting the 5.5.1 version, but any 5.x.x version should work.
         2. Get the Libtropic repository:
             - Using git: `git clone https://github.com/tropicsquare/libtropic.git`

--- a/docs/tutorials/stm32/index.md
+++ b/docs/tutorials/stm32/index.md
@@ -1,5 +1,5 @@
 # STM32 Tutorials
-These tutorials will help you get started with TROPIC01 on STM32-based platforms using Libtropic. To see the currently supported STM32 platforms, refer to the [STM32 Compatibility](../../compatibility/host_platforms/stm32.md) page.
+These tutorials will help you get started with TROPIC01 on STM32-based platforms using Libtropic. Currently, we officially support [Nucleo F439ZI](https://www.st.com/en/evaluation-tools/nucleo-f439zi.html) and [Nucleo L432KC](https://www.st.com/en/evaluation-tools/nucleo-l432kc.html) development boards.
 
 We will go through our examples in the `examples/stm32/` directory. In this directory, there are multiple subdirectories for each supported Nucleo board. Most of the instructions in this tutorial are common for all of the boards.
 
@@ -20,11 +20,11 @@ We will go through our examples in the `examples/stm32/` directory. In this dire
         
         |  TROPIC01     |   NUCLEO F439ZI  |
         |---------------|------------------|
-        |  GND          |  GND             |
         |  3V3          |  3V3             |
+        |  GND          |  GND             |
+        |  SCK          |  GPIOA_5         |
         |  MISO (SDO)   |  GPIOA_6         |
         |  MOSI (SDI)   |  GPIOA_7         |
-        |  SCK          |  GPIOA_5         |
         |  CS (CSN)     |  GPIOD_14        |
         |  GPO          |  GPIOF_15        |
 
@@ -34,11 +34,11 @@ We will go through our examples in the `examples/stm32/` directory. In this dire
 
         |  TROPIC01     |  NUCLEO L432KC  |
         |---------------|-----------------|
-        |  GND          |  GND            |
         |  3V3          |  3V3            |
-        |  MISO (SDO)   |  A5             |
-        |  MOSI (SDI)   |  A6             |
+        |  GND          |  GND            |
         |  SCK          |  A4             |
+        |  MISO (SDO)   |  A6             |
+        |  MOSI (SDI)   |  A5             |
         |  CS (CSN)     |  A3             |
     
     ??? question "Advanced: How to Use Different Nucleo Pins?"


### PR DESCRIPTION
## Description

As trying to use tutorials, I have been mistaken by the start of the pin connection table and thought the order there matches the image. This changes goals to really make so.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [] The project **builds without errors or warnings**  
- [] I have **verified the functionality against the hardware/model** as applicable  
- [ ] I have ensured that public APIs remain backward compatible (if applicable)  
- [ ] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage

---

## Notes for Reviewers

(Optional) Add any additional context, known limitations, or areas you'd like reviewers to focus on. If not applicable, you can delete this section.