### PR TITLE
ETR01SDK-599: STM32 L432: setup GPO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - ECC + EdDSA example for USB DevKit.
+- STM32L4xx HAL: support for TROPIC01 GPO pin.
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/docs/compatibility/host_platforms/stm32.md
+++ b/docs/compatibility/host_platforms/stm32.md
@@ -4,7 +4,7 @@ Currently supported STM32 platforms are:
 - STM32F4xx series MCUs, tested with:
     - NUCLEO-F439ZI
 - STM32L4xx series MCUs, tested with:
-    - NUCLEO-L432KC (using interrupt pin (`LT_USE_INT_PIN`) is not supported for this platform)
+    - NUCLEO-L432KC
 - STM32U5xx series MCUs, tested with:
     - NUCLEO-U545RE-Q
 

--- a/docs/tutorials/stm32/index.md
+++ b/docs/tutorials/stm32/index.md
@@ -40,6 +40,7 @@ We will go through our examples in the `examples/stm32/` directory. In this dire
         |  MISO (SDO)   |  A5             |
         |  MOSI (SDI)   |  A6             |
         |  CS (CSN)     |  A3             |
+        |  GPO          |  D10            |
     
     ??? question "Advanced: How to Use Different Nucleo Pins?"
         The pin assignments above are used in our examples by default. The pins can be changed in the source code of each example. However, apart from changing assignment, you also have to initialize different peripherals, which is not documented here.

--- a/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.c
+++ b/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.c
@@ -120,6 +120,15 @@ lt_ret_t lt_port_init(lt_l2_state_t *s2)
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_MEDIUM;
     HAL_GPIO_Init(device->spi_cs_gpio_bank, &GPIO_InitStruct);
 
+#if LT_USE_INT_PIN
+    // GPIO for INT pin.
+    GPIO_InitStruct.Pin = device->int_gpio_pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(device->int_gpio_bank, &GPIO_InitStruct);
+#endif
+
     return LT_OK;
 }
 
@@ -164,6 +173,25 @@ lt_ret_t lt_port_delay(lt_l2_state_t *s2, uint32_t ms)
 
     return LT_OK;
 }
+
+#if LT_USE_INT_PIN
+lt_ret_t lt_port_delay_on_int(lt_l2_state_t *s2, uint32_t ms)
+{
+    lt_dev_stm32l4xx_t *device = (lt_dev_stm32l4xx_t *)(s2->device);
+    uint32_t time_initial = HAL_GetTick();
+    uint32_t time_actual;
+
+    while ((HAL_GPIO_ReadPin(device->int_gpio_bank, device->int_gpio_pin) == 0)) {
+        time_actual = HAL_GetTick();
+        if ((time_actual - time_initial) > ms) {
+            return LT_L1_INT_TIMEOUT;
+        }
+        // HAL_Delay(ms);
+    }
+
+    return LT_OK;
+}
+#endif
 
 int lt_port_log(const char *format, ...)
 {

--- a/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.h
+++ b/hal/stm32/stm32l4xx/libtropic_port_stm32l4xx.h
@@ -34,6 +34,13 @@ typedef struct lt_dev_stm32l4xx_t {
     /** @brief @public GPIO bank of the pin used for chip select. Use STM32 macro (GPIOX). */
     GPIO_TypeDef *spi_cs_gpio_bank;
 
+#if LT_USE_INT_PIN
+    /** @brief @public GPIO pin used for interrupts. Use STM32 macro (GPIO_PIN_XX). */
+    uint16_t int_gpio_pin;
+    /** @brief @public GPIO bank of the pin used for interrupts. Use STM32 macro (GPIOX). */
+    GPIO_TypeDef *int_gpio_bank;
+#endif
+
     /** @brief @public Random number generator handle. */
     RNG_HandleTypeDef *rng_handle;
 

--- a/tests/functional/stm32/nucleo_l432kc/CMakeLists.txt
+++ b/tests/functional/stm32/nucleo_l432kc/CMakeLists.txt
@@ -45,10 +45,6 @@ project(
 #                                                                         #
 ###########################################################################
 
-if(LT_USE_INT_PIN)
-    message(FATAL_ERROR "Using interrupt pin is currently not supported on Nucleo L432KC board")
-endif()
-
 if (LT_CAL STREQUAL "openssl")
     message(FATAL_ERROR "OpenSSL is not supported on STM32!")
 endif()

--- a/tests/functional/stm32/nucleo_l432kc/Inc/main.h
+++ b/tests/functional/stm32/nucleo_l432kc/Inc/main.h
@@ -75,10 +75,10 @@
 /* Definition for GPIO interrupt pin clock resources
  * Following GPIO is used to check on INT pin for READY signal during communication.
  */
-#define LT_INT_BANK GPIOC
-#define LT_INT_PIN GPIO_PIN_15
+#define LT_INT_BANK GPIOA
+#define LT_INT_PIN GPIO_PIN_11
 /* Definition for GPIO interrupt pin clock resources */
-#define LT_INT_CLK_ENABLE() __HAL_RCC_GPIOC_CLK_ENABLE()
+#define LT_INT_CLK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
 #endif
 
 /* Exported variables ------------------------------------------------------- */

--- a/tests/functional/stm32/nucleo_l432kc/Inc/main.h
+++ b/tests/functional/stm32/nucleo_l432kc/Inc/main.h
@@ -71,6 +71,16 @@
 #define SPIx_MOSI_GPIO_PORT GPIOA
 #define SPIx_MOSI_AF GPIO_AF5_SPI1
 
+#if LT_USE_INT_PIN
+/* Definition for GPIO interrupt pin clock resources
+ * Following GPIO is used to check on INT pin for READY signal during communication.
+ */
+#define LT_INT_BANK GPIOC
+#define LT_INT_PIN GPIO_PIN_15
+/* Definition for GPIO interrupt pin clock resources */
+#define LT_INT_CLK_ENABLE() __HAL_RCC_GPIOC_CLK_ENABLE()
+#endif
+
 /* Exported variables ------------------------------------------------------- */
 extern RNG_HandleTypeDef RNGHandle;
 

--- a/tests/functional/stm32/nucleo_l432kc/Src/main.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/main.c
@@ -225,6 +225,14 @@ int main(void)
     device.spi_cs_gpio_bank = LT_SPI_CS_BANK;
     device.spi_cs_gpio_pin = LT_SPI_CS_PIN;
     device.rng_handle = &RNGHandle;
+
+#ifdef LT_USE_INT_PIN
+    /* Enable clock of the GPIO bank where interrupt input is present. */
+    LT_INT_CLK_ENABLE(); /* Defined in main.h. */
+    device.int_gpio_bank = LT_INT_BANK;
+    device.int_gpio_pin = LT_INT_PIN;
+#endif
+
     lt_handle.l2.device = &device;
 
     /* Crypto abstraction layer (CAL) context (selectable). */


### PR DESCRIPTION
## Description

Adds support for GPO pin on STM32 L432KC and the L4xx HAL.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---