### PR TITLE
ETR01SDK-591: change type of rnd_bytes_cnt parameter to uint8_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed `LT_STM32_L432KC_GPIO_OUTPUT_CHECK_ATTEMPTS` to `LT_STM32L4XX_GPIO_OUTPUT_CHECK_ATTEMPTS`.
   - Renamed `lt_dev_stm32_nucleo_l432kc_t` to `lt_dev_stm32l4xx_t`.
 - `lt_ecc_ecdsa_sign` now expects a 32-byte hash instead of an arbitrary message - provided data are not hashed anymore. Select a hash function that outputs 32 bytes (for example, SHA-256). If using a longer digest, apply standard truncation as appropriate; do not pad shorter digests.
-- `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()`: changed type of `rnd_bytes_cnt` parameter to `uint8_t` to be accurate with the TROPIC01 User API.
+- `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()`: changed type of `rnd_bytes_cnt` parameter to `uint8_t` to align with the TROPIC01 User API.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed `LT_STM32_L432KC_GPIO_OUTPUT_CHECK_ATTEMPTS` to `LT_STM32L4XX_GPIO_OUTPUT_CHECK_ATTEMPTS`.
   - Renamed `lt_dev_stm32_nucleo_l432kc_t` to `lt_dev_stm32l4xx_t`.
 - `lt_ecc_ecdsa_sign` now expects a 32-byte hash instead of an arbitrary message - provided data are not hashed anymore. Select a hash function that outputs 32 bytes (for example, SHA-256). If using a longer digest, apply standard truncation as appropriate; do not pad shorter digests.
+- `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()`: changed type of `rnd_bytes_cnt` parameter to `uint8_t` to be accurate with the TROPIC01 User API.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -482,7 +482,7 @@ lt_ret_t lt_r_mem_data_erase(lt_handle_t *h, const uint16_t udata_slot);
  * @retval                  other Function did not execute successully, you might use lt_ret_verbose()
  * to get verbose encoding of returned value
  */
-lt_ret_t lt_random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint16_t rnd_bytes_cnt);
+lt_ret_t lt_random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint8_t rnd_bytes_cnt);
 
 /**
  * @brief Generates ECC key in the specified ECC key slot

--- a/include/libtropic_l3.h
+++ b/include/libtropic_l3.h
@@ -347,7 +347,7 @@ lt_ret_t lt_in__r_mem_data_erase(lt_handle_t *h);
  * @param rnd_bytes_cnt   Number of random bytes to get (255 bytes is the maximum)
  * @return                LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_out__random_value_get(lt_handle_t *h, const uint16_t rnd_bytes_cnt);
+lt_ret_t lt_out__random_value_get(lt_handle_t *h, const uint8_t rnd_bytes_cnt);
 
 /**
  * @brief Decodes Random_Value_Get result payload.
@@ -359,7 +359,7 @@ lt_ret_t lt_out__random_value_get(lt_handle_t *h, const uint16_t rnd_bytes_cnt);
  * @param rnd_bytes_cnt     Number of random bytes to get (255 bytes is the maximum)
  * @return                  LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_in__random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint16_t rnd_bytes_cnt);
+lt_ret_t lt_in__random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint8_t rnd_bytes_cnt);
 
 /**
  * @brief Encodes ECC_Key_Generate command payload.

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1193,9 +1193,9 @@ lt_ret_t lt_r_mem_data_erase(lt_handle_t *h, const uint16_t udata_slot)
     return lt_in__r_mem_data_erase(h);
 }
 
-lt_ret_t lt_random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint16_t rnd_bytes_cnt)
+lt_ret_t lt_random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint8_t rnd_bytes_cnt)
 {
-    if (!h || !rnd_bytes || (rnd_bytes_cnt > TR01_RANDOM_VALUE_GET_LEN_MAX)) {
+    if (!h || !rnd_bytes) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {

--- a/src/libtropic_l3.c
+++ b/src/libtropic_l3.c
@@ -924,9 +924,9 @@ lt_ret_t lt_in__r_mem_data_erase(lt_handle_t *h)
     return LT_OK;
 }
 
-lt_ret_t lt_out__random_value_get(lt_handle_t *h, const uint16_t rnd_bytes_cnt)
+lt_ret_t lt_out__random_value_get(lt_handle_t *h, const uint8_t rnd_bytes_cnt)
 {
-    if ((rnd_bytes_cnt > TR01_RANDOM_VALUE_GET_LEN_MAX) || !h) {
+    if (!h) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {
@@ -944,9 +944,9 @@ lt_ret_t lt_out__random_value_get(lt_handle_t *h, const uint16_t rnd_bytes_cnt)
     return lt_l3_encrypt_request(&h->l3);
 }
 
-lt_ret_t lt_in__random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint16_t rnd_bytes_cnt)
+lt_ret_t lt_in__random_value_get(lt_handle_t *h, uint8_t *rnd_bytes, const uint8_t rnd_bytes_cnt)
 {
-    if (!h || !rnd_bytes || (rnd_bytes_cnt > TR01_RANDOM_VALUE_GET_LEN_MAX)) {
+    if (!h || !rnd_bytes) {
         return LT_PARAM_ERR;
     }
     if (h->l3.session_status != LT_SECURE_SESSION_ON) {

--- a/tests/functional/src/lt_test_rev_param_check.c
+++ b/tests/functional/src/lt_test_rev_param_check.c
@@ -180,8 +180,6 @@ void lt_test_rev_param_check(lt_handle_t *h)
         uint8_t buf[1];
         LT_TEST_ASSERT(LT_PARAM_ERR, lt_random_value_get(NULL, buf, sizeof(buf)));
         LT_TEST_ASSERT(LT_PARAM_ERR, lt_random_value_get(h, NULL, sizeof(buf)));
-        LT_TEST_ASSERT(LT_PARAM_ERR,
-                       lt_random_value_get(h, buf, (uint16_t)(TR01_RANDOM_VALUE_GET_LEN_MAX + 1)));
     }
 
     LT_TEST_ASSERT(LT_PARAM_ERR, lt_ecc_key_generate(NULL, TR01_ECC_SLOT_0, TR01_CURVE_ED25519));


### PR DESCRIPTION
## Description

Relevant to `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()` - the type of `rnd_bytes_cnt` parameter was `uint16_t`, so we can check if the user passes a value bigger than 255, but we agreed to change it to `uint8_t` so it's aligned with the TROPIC01 User API.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---