### PR TITLE
ETR01SDK-613: Fix logging of number of wrong attempts and destroyed slot indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.
+- `examples/model/mac_and_destroy/`: Log the correct number of wrong attempts and indexes of destroyed slots.
 
 ## [3.2.0]
 

--- a/examples/model/mac_and_destroy/main.c
+++ b/examples/model/mac_and_destroy/main.c
@@ -682,9 +682,9 @@ int main(void)
     printf("Initialized final_key: %s\n", print_buff);
 
     uint8_t final_key_exported[TR01_MAC_AND_DESTROY_DATA_SIZE] = {0};
-    printf("\nWill do %d PIN check attempts with wrong PIN:\n", MACANDD_ROUNDS);
-    for (int i = 1; i < MACANDD_ROUNDS; i++) {
-        printf("\tInputting wrong PIN -> slot #%d will be destroyed...\n", i);
+    printf("\nWill do %d PIN check attempts with wrong PIN:\n", MACANDD_ROUNDS - 1);
+    for (int i = 0; i < MACANDD_ROUNDS - 1; i++) {
+        printf("\tInputting wrong PIN -> slot #%d will be destroyed...\n", MACANDD_ROUNDS - 1 - i);
         ret = PIN_entry_check(&lt_handle, pin_wrong, sizeof(pin_wrong), additional_data,
                               sizeof(additional_data), final_key_exported);
         if (ret != LT_FAIL) {


### PR DESCRIPTION
## Description

The M&D example logs that it does 12 wrong attempts, but it actually does 11 wrong attempts and a last correct attempt. Also fixed slot indexes, as they are indexed from `MACANDD_ROUND-1` to `0` (which is the opposite order compared to the [M&D paper](https://github.com/tropicsquare/tropic01-rtl/blob/public/doc/theory/MAC-and-destroy-v2.pdf)).

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---