### PR TITLE
ETR01SDK-612: ESP32 tutorials: add instructions for exiting the serial monitor

### DIFF
--- a/docs/tutorials/esp32/fw_update.md
+++ b/docs/tutorials/esp32/fw_update.md
@@ -14,13 +14,15 @@
         ```bash { .copy }
         idf.py build flash monitor
         ```
+        After this, you should see a colored output in your terminal.
+
+        !!! tip "Closing the ESP-IDF serial monitor"
+            To close the ESP-IDF serial monitor, press <kbd>Ctrl</kbd> + <kbd>]</kbd>. Refer to the [ESP-IDF monitor documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-monitor.html) for a full list of available keyboard shortcuts.
 
     === ":fontawesome-brands-apple: macOS"
         TBA
 
     === ":fontawesome-brands-windows: Windows"
         TBA
-
-    After this, you should see a colored output in your terminal.
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/esp32/hello_world.md
+++ b/docs/tutorials/esp32/hello_world.md
@@ -14,14 +14,16 @@
         ```bash { .copy }
         idf.py build flash monitor
         ```
+        After this, you should see a colored output in your terminal.
+
+        !!! tip "Closing the ESP-IDF serial monitor"
+            To close the ESP-IDF serial monitor, press <kbd>Ctrl</kbd> + <kbd>]</kbd>. Refer to the [ESP-IDF monitor documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-monitor.html) for a full list of available keyboard shortcuts.
 
     === ":fontawesome-brands-apple: macOS"
         TBA
 
     === ":fontawesome-brands-windows: Windows"
         TBA
-
-    After this, you should see a colored output in your terminal.
 
 If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
 !!! example "Switching to engineering sample pairing keys"

--- a/docs/tutorials/esp32/identify_chip.md
+++ b/docs/tutorials/esp32/identify_chip.md
@@ -14,13 +14,15 @@
         ```bash { .copy }
         idf.py build flash monitor
         ```
+        After this, you should see a colored output in your terminal.
+
+        !!! tip "Closing the ESP-IDF serial monitor"
+            To close the ESP-IDF serial monitor, press <kbd>Ctrl</kbd> + <kbd>]</kbd>. Refer to the [ESP-IDF monitor documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-monitor.html) for a full list of available keyboard shortcuts.
 
     === ":fontawesome-brands-apple: macOS"
         TBA
 
     === ":fontawesome-brands-windows: Windows"
         TBA
-
-    After this, you should see a colored output in your terminal.
 
 [Next example :material-arrow-right:](fw_update.md){ .md-button }


### PR DESCRIPTION
## Description

Added a tip box to all ESP32 tutorials with instructions how to close the ESP-IDF serial monitor. Based on @jerabst1ts feedback.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---