### PR TITLE
ETR01SDK-312: behavior based on silicon revision and bootloader version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed `lt_dev_stm32_nucleo_l432kc_t` to `lt_dev_stm32l4xx_t`.
 - `lt_ecc_ecdsa_sign` now expects a 32-byte hash instead of an arbitrary message - provided data are not hashed anymore. Select a hash function that outputs 32 bytes (for example, SHA-256). If using a longer digest, apply standard truncation as appropriate; do not pad shorter digests.
 - `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()`: changed type of `rnd_bytes_cnt` parameter to `uint8_t` to align with the TROPIC01 User API.
-- Added `LT_SILICON_REV_` prefix to `ABAB` and `ACAB` internal macros to avoid naming collisions (affects users that don't build Libtropic with CMake).
+- Added the `LT_SILICON_REV_` prefix to the `ABAB` and `ACAB` build-time configuration macros to avoid naming collisions; these macros are user-facing when building Libtropic from sources, especially outside CMake.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed `lt_dev_stm32_nucleo_l432kc_t` to `lt_dev_stm32l4xx_t`.
 - `lt_ecc_ecdsa_sign` now expects a 32-byte hash instead of an arbitrary message - provided data are not hashed anymore. Select a hash function that outputs 32 bytes (for example, SHA-256). If using a longer digest, apply standard truncation as appropriate; do not pad shorter digests.
 - `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()`: changed type of `rnd_bytes_cnt` parameter to `uint8_t` to align with the TROPIC01 User API.
+- Added `LT_SILICON_REV_` prefix to `ABAB` and `ACAB` internal macros to avoid naming collisions (affects users that don't build Libtropic with CMake).
 
 ### Added
 - ECC + EdDSA example for USB DevKit.
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.
 - `examples/model/mac_and_destroy/`: Log the correct number of wrong attempts and indexes of destroyed slots.
 - Target version reporting in Firmware Update examples for Linux.
+- Compatibility table in main README.md: mention support of Bootloader FW 1.0.1-2.0.1 for all existing Libtropic releases.
 
 ## [3.2.1]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,9 +258,9 @@ endforeach()
 ###########################################################################
 
 if (LT_SILICON_REV STREQUAL "ABAB")
-    target_compile_definitions(tropic PUBLIC ABAB)
+    target_compile_definitions(tropic PUBLIC LT_SILICON_REV_ABAB)
 elseif (LT_SILICON_REV STREQUAL "ACAB")
-    target_compile_definitions(tropic PUBLIC ACAB)
+    target_compile_definitions(tropic PUBLIC LT_SILICON_REV_ACAB)
 endif()
 
 if(LT_PRINT_SPI_DATA)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ For details, see particular part number in [TROPIC01](https://github.com/tropics
 | Libtropic | Application FW | SPECT FW | Bootloader FW | Tests              |
 |:---------:|:--------------:|:--------:|:-------------:|:------------------:|
 | 1.0.0     | 1.0.0          | 1.0.0    | 1.0.1-2.0.1   | :white_check_mark: |
-| 2.0.0     | 1.0.0–1.0.1    | 1.0.0    | 2.0.1         | :white_check_mark: |
-| 2.0.1     | 1.0.0–1.0.1    | 1.0.0    | 2.0.1         | :white_check_mark: |
-| 3.0.0     | 1.0.0–2.0.0    | 1.0.0    | 2.0.1         | :white_check_mark: |
-| 3.1.0     | 1.0.0–2.0.0    | 1.0.0    | 2.0.1         | :white_check_mark: |
-| 3.2.0     | 1.0.0–2.0.0    | 1.0.0    | 2.0.1         | :white_check_mark: |
-| 3.2.1     | 1.0.0–2.0.0    | 1.0.0    | 2.0.1         | :white_check_mark: |
+| 2.0.0     | 1.0.0–1.0.1    | 1.0.0    | 1.0.1-2.0.1   | :white_check_mark: |
+| 2.0.1     | 1.0.0–1.0.1    | 1.0.0    | 1.0.1-2.0.1   | :white_check_mark: |
+| 3.0.0     | 1.0.0–2.0.0    | 1.0.0    | 1.0.1-2.0.1   | :white_check_mark: |
+| 3.1.0     | 1.0.0–2.0.0    | 1.0.0    | 1.0.1-2.0.1   | :white_check_mark: |
+| 3.2.0     | 1.0.0–2.0.0    | 1.0.0    | 1.0.1-2.0.1   | :white_check_mark: |
+| 3.2.1     | 1.0.0–2.0.0    | 1.0.0    | 1.0.1-2.0.1   | :white_check_mark: |
 
 > [!WARNING]
 > Mismatched component versions may cause errors or unpredictable behavior. Use the latest compatible versions whenever possible.

--- a/docs/tutorials/esp32/fw_update.md
+++ b/docs/tutorials/esp32/fw_update.md
@@ -25,4 +25,7 @@
     === ":fontawesome-brands-windows: Windows"
         TBA
 
+!!! failure "FW update failed"
+    Checkout the dedicated section in [FAQ](../../faq.md#fw-update-failed).
+
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/esp32/fw_update.md
+++ b/docs/tutorials/esp32/fw_update.md
@@ -26,6 +26,6 @@
         TBA
 
 !!! failure "FW update failed"
-    Checkout the dedicated section in [FAQ](../../faq.md#fw-update-failed).
+    Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/linux/spi/fw_update.md
+++ b/docs/tutorials/linux/spi/fw_update.md
@@ -33,4 +33,7 @@
     
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
+!!! failure "FW update failed"
+    Checkout the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
+
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/linux/spi/fw_update.md
+++ b/docs/tutorials/linux/spi/fw_update.md
@@ -34,6 +34,6 @@
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
 !!! failure "FW update failed"
-    Checkout the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
+    Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/linux/usb_devkit/fw_update.md
+++ b/docs/tutorials/linux/usb_devkit/fw_update.md
@@ -33,4 +33,7 @@
     
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
+!!! failure "FW update failed"
+    Checkout the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
+
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/linux/usb_devkit/fw_update.md
+++ b/docs/tutorials/linux/usb_devkit/fw_update.md
@@ -34,6 +34,6 @@
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
 !!! failure "FW update failed"
-    Checkout the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
+    Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/stm32/fw_update.md
+++ b/docs/tutorials/stm32/fw_update.md
@@ -39,4 +39,7 @@
 
     After this, you should see a colored output in your serial monitor.
 
+!!! failure "FW update failed"
+    Checkout the dedicated section in [FAQ](../../faq.md#fw-update-failed).
+
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/stm32/fw_update.md
+++ b/docs/tutorials/stm32/fw_update.md
@@ -40,6 +40,6 @@
     After this, you should see a colored output in your serial monitor.
 
 !!! failure "FW update failed"
-    Checkout the dedicated section in [FAQ](../../faq.md#fw-update-failed).
+    Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -215,7 +215,7 @@ lt_ret_t lt_sleep(lt_handle_t *h, const uint8_t sleep_kind);
  */
 lt_ret_t lt_reboot(lt_handle_t *h, const lt_startup_id_t startup_id);
 
-#ifdef ABAB
+#ifdef LT_SILICON_REV_ABAB
 /** @brief Maximal size of update data */
 #define TR01_MUTABLE_FW_UPDATE_SIZE_MAX 25600
 /**
@@ -244,7 +244,7 @@ lt_ret_t lt_mutable_fw_erase(lt_handle_t *h, const lt_bank_id_t bank_id);
 lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint16_t fw_data_size,
                               lt_bank_id_t bank_id);
 
-#elif ACAB
+#elif LT_SILICON_REV_ACAB
 /** @brief Maximal size of update data */
 #define TR01_MUTABLE_FW_UPDATE_SIZE_MAX 30720
 

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -215,7 +215,7 @@ lt_ret_t lt_sleep(lt_handle_t *h, const uint8_t sleep_kind);
  */
 lt_ret_t lt_reboot(lt_handle_t *h, const lt_startup_id_t startup_id);
 
-#ifdef LT_SILICON_REV_ABAB
+#if defined(LT_SILICON_REV_ABAB)
 /** @brief Maximal size of update data */
 #define TR01_MUTABLE_FW_UPDATE_SIZE_MAX 25600
 /**
@@ -244,7 +244,7 @@ lt_ret_t lt_mutable_fw_erase(lt_handle_t *h, const lt_bank_id_t bank_id);
 lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint16_t fw_data_size,
                               lt_bank_id_t bank_id);
 
-#elif LT_SILICON_REV_ACAB
+#elif defined(LT_SILICON_REV_ACAB)
 /** @brief Maximal size of update data */
 #define TR01_MUTABLE_FW_UPDATE_SIZE_MAX 30720
 

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -602,7 +602,7 @@ lt_ret_t lt_reboot(lt_handle_t *h, const lt_startup_id_t startup_id)
     return LT_OK;
 }
 
-#ifdef ABAB
+#ifdef LT_SILICON_REV_ABAB
 lt_ret_t lt_mutable_fw_erase(lt_handle_t *h, const lt_bank_id_t bank_id)
 {
     if (!h || ((bank_id != TR01_FW_BANK_FW1) && (bank_id != TR01_FW_BANK_FW2) &&
@@ -698,7 +698,7 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint
 
     return LT_OK;
 }
-#elif ACAB
+#elif LT_SILICON_REV_ACAB
 lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *update_request)
 {
     if (!h || !update_request) {
@@ -809,7 +809,7 @@ lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *update_data,
     return LT_OK;
 }
 #else
-#error "Undefined silicon revision. Please define either ABAB or ACAB."
+#error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
 #endif
 
 lt_ret_t lt_get_log_req(lt_handle_t *h, uint8_t *log_msg, const uint16_t log_msg_max_size,
@@ -1943,7 +1943,7 @@ lt_ret_t lt_print_chip_id(const struct lt_chip_id_t *chip_id,
 lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
                                  const uint16_t update_data_size, const lt_bank_id_t bank_id)
 {
-#ifdef ABAB
+#ifdef LT_SILICON_REV_ABAB
     if (!h || !update_data || update_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX ||
         ((bank_id != TR01_FW_BANK_FW1) && (bank_id != TR01_FW_BANK_FW2) &&
          (bank_id != TR01_FW_BANK_SPECT1) && (bank_id != TR01_FW_BANK_SPECT2))) {
@@ -1959,7 +1959,7 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
         return ret;
     }
 
-#elif ACAB
+#elif LT_SILICON_REV_ACAB
     LT_UNUSED(bank_id);  // bank_id is not used with ACAB, chip handles banks on its own
     if (!h || !update_data || update_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
         return LT_PARAM_ERR;
@@ -1978,7 +1978,7 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
     }
 
 #else
-#error "Undefined silicon revision. Please define either ABAB or ACAB."
+#error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
 #endif
 
     return LT_OK;

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -602,7 +602,7 @@ lt_ret_t lt_reboot(lt_handle_t *h, const lt_startup_id_t startup_id)
     return LT_OK;
 }
 
-#ifdef LT_SILICON_REV_ABAB
+#if defined(LT_SILICON_REV_ABAB)
 lt_ret_t lt_mutable_fw_erase(lt_handle_t *h, const lt_bank_id_t bank_id)
 {
     if (!h || ((bank_id != TR01_FW_BANK_FW1) && (bank_id != TR01_FW_BANK_FW2) &&
@@ -698,7 +698,7 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint
 
     return LT_OK;
 }
-#elif LT_SILICON_REV_ACAB
+#elif defined(LT_SILICON_REV_ACAB)
 lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *update_request)
 {
     if (!h || !update_request) {
@@ -1943,7 +1943,7 @@ lt_ret_t lt_print_chip_id(const struct lt_chip_id_t *chip_id,
 lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
                                  const uint16_t update_data_size, const lt_bank_id_t bank_id)
 {
-#ifdef LT_SILICON_REV_ABAB
+#if defined(LT_SILICON_REV_ABAB)
     if (!h || !update_data || update_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX ||
         ((bank_id != TR01_FW_BANK_FW1) && (bank_id != TR01_FW_BANK_FW2) &&
          (bank_id != TR01_FW_BANK_SPECT1) && (bank_id != TR01_FW_BANK_SPECT2))) {
@@ -1959,7 +1959,7 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
         return ret;
     }
 
-#elif LT_SILICON_REV_ACAB
+#elif defined(LT_SILICON_REV_ACAB)
     LT_UNUSED(bank_id);  // bank_id is not used with ACAB, chip handles banks on its own
     if (!h || !update_data || update_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
         return LT_PARAM_ERR;

--- a/src/lt_l2_api_structs.h
+++ b/src/lt_l2_api_structs.h
@@ -595,10 +595,9 @@ LT_STATIC_ASSERT(
 )
 /** \endcond */
 // clang-format on
-#endif
 
 // Firmware update API structs for ACAB silicon revision
-#if defined(LT_SILICON_REV_ACAB)
+#elif defined(LT_SILICON_REV_ACAB)
 /** @brief Request ID */
 #define TR01_L2_MUTABLE_FW_UPDATE_REQ_ID 0xb0
 /** @brief Request min length */
@@ -728,6 +727,8 @@ LT_STATIC_ASSERT(
 )
 /** \endcond */
 // clang-format on
+#else
+#error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
 #endif
 
 /** @brief Request ID */

--- a/src/lt_l2_api_structs.h
+++ b/src/lt_l2_api_structs.h
@@ -515,7 +515,7 @@ LT_STATIC_ASSERT(
 // clang-format on
 
 // Firmware update API structs for ABAB silicon revision
-#ifdef ABAB
+#ifdef LT_SILICON_REV_ABAB
 /** @brief Request ID */
 #define TR01_L2_MUTABLE_FW_UPDATE_REQ_ID 0xb1
 /** @brief Request min length */
@@ -598,7 +598,7 @@ LT_STATIC_ASSERT(
 #endif
 
 // Firmware update API structs for ACAB silicon revision
-#ifdef ACAB
+#ifdef LT_SILICON_REV_ACAB
 /** @brief Request ID */
 #define TR01_L2_MUTABLE_FW_UPDATE_REQ_ID 0xb0
 /** @brief Request min length */

--- a/src/lt_l2_api_structs.h
+++ b/src/lt_l2_api_structs.h
@@ -515,7 +515,7 @@ LT_STATIC_ASSERT(
 // clang-format on
 
 // Firmware update API structs for ABAB silicon revision
-#ifdef LT_SILICON_REV_ABAB
+#if defined(LT_SILICON_REV_ABAB)
 /** @brief Request ID */
 #define TR01_L2_MUTABLE_FW_UPDATE_REQ_ID 0xb1
 /** @brief Request min length */
@@ -598,7 +598,7 @@ LT_STATIC_ASSERT(
 #endif
 
 // Firmware update API structs for ACAB silicon revision
-#ifdef LT_SILICON_REV_ACAB
+#if defined(LT_SILICON_REV_ACAB)
 /** @brief Request ID */
 #define TR01_L2_MUTABLE_FW_UPDATE_REQ_ID 0xb0
 /** @brief Request min length */

--- a/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
+++ b/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
@@ -154,7 +154,7 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
     LT_LOG_INFO("----------------------------------------------");
 
     g_h = h;
-#ifdef LT_SILICON_REV_ACAB
+#if defined(LT_SILICON_REV_ACAB)
     uint8_t cert1[CERTS_BUF_LEN] = {0}, cert2[CERTS_BUF_LEN] = {0}, cert3[CERTS_BUF_LEN] = {0},
             cert4[CERTS_BUF_LEN] = {0};
     struct lt_cert_store_t store = {
@@ -172,7 +172,7 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
 
     lt_test_cleanup_function = &lt_test_rev_get_info_req_bootloader_cleanup;
 
-#ifdef LT_SILICON_REV_ACAB
+#if defined(LT_SILICON_REV_ACAB)
     LT_LOG_INFO("Reading X509 Certificate Store...");
     LT_TEST_ASSERT(LT_OK, lt_get_info_cert_store(h, &store));
     LT_LOG_INFO();
@@ -196,7 +196,7 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
         LT_LOG_INFO();
     }
     LT_LOG_LINE();
-#elif LT_SILICON_REV_ABAB
+#elif defined(LT_SILICON_REV_ABAB)
     LT_LOG_INFO("Bootloader v1.0.1 provided just 512B for device certificate only");
 #else
 #error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."

--- a/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
+++ b/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
@@ -154,7 +154,7 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
     LT_LOG_INFO("----------------------------------------------");
 
     g_h = h;
-#ifdef ACAB
+#ifdef LT_SILICON_REV_ACAB
     uint8_t cert1[CERTS_BUF_LEN] = {0}, cert2[CERTS_BUF_LEN] = {0}, cert3[CERTS_BUF_LEN] = {0},
             cert4[CERTS_BUF_LEN] = {0};
     struct lt_cert_store_t store = {
@@ -172,7 +172,7 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
 
     lt_test_cleanup_function = &lt_test_rev_get_info_req_bootloader_cleanup;
 
-#ifdef ACAB
+#ifdef LT_SILICON_REV_ACAB
     LT_LOG_INFO("Reading X509 Certificate Store...");
     LT_TEST_ASSERT(LT_OK, lt_get_info_cert_store(h, &store));
     LT_LOG_INFO();
@@ -196,10 +196,10 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
         LT_LOG_INFO();
     }
     LT_LOG_LINE();
-#elif ABAB
+#elif LT_SILICON_REV_ABAB
     LT_LOG_INFO("Bootloader v1.0.1 provided just 512B for device certificate only");
 #else
-#error "Undefined silicon revision. Please define either ABAB or ACAB."
+#error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
 #endif
     LT_LOG_INFO("Reading Chip ID...");
     LT_TEST_ASSERT(LT_OK, lt_get_info_chip_id(h, &chip_id));

--- a/tests/functional/src/lt_test_rev_param_check.c
+++ b/tests/functional/src/lt_test_rev_param_check.c
@@ -303,7 +303,7 @@ void lt_test_rev_param_check(lt_handle_t *h)
                        lt_mutable_fw_update_data(h, dummy_data, TR01_MUTABLE_FW_UPDATE_SIZE_MAX + 1));
     }
 #else
-#warning "Unknown silicon revision, no revision specific parameter checks implemented!"
+#error "Unknown silicon revision, no revision specific parameter checks implemented!"
 #endif
 
     // --------------------------------------------------------

--- a/tests/functional/src/lt_test_rev_param_check.c
+++ b/tests/functional/src/lt_test_rev_param_check.c
@@ -273,7 +273,7 @@ void lt_test_rev_param_check(lt_handle_t *h)
     // --------------------------------------------------------
     // Silicon revision specific functions
     // --------------------------------------------------------
-#ifdef ABAB
+#ifdef LT_SILICON_REV_ABAB
     LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_erase(NULL, TR01_FW_BANK_FW1));
     LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_erase(h, 0xFFFFFFFF));
 
@@ -289,7 +289,7 @@ void lt_test_rev_param_check(lt_handle_t *h)
         LT_TEST_ASSERT(LT_PARAM_ERR,
                        lt_mutable_fw_update(h, dummy_data, sizeof(dummy_data), 0xFFFFFFFF));
     }
-#elif ACAB
+#elif LT_SILICON_REV_ACAB
     {
         uint8_t dummy_data[1];
         LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_update(NULL, dummy_data));

--- a/tests/functional/src/lt_test_rev_param_check.c
+++ b/tests/functional/src/lt_test_rev_param_check.c
@@ -273,7 +273,7 @@ void lt_test_rev_param_check(lt_handle_t *h)
     // --------------------------------------------------------
     // Silicon revision specific functions
     // --------------------------------------------------------
-#ifdef LT_SILICON_REV_ABAB
+#if defined(LT_SILICON_REV_ABAB)
     LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_erase(NULL, TR01_FW_BANK_FW1));
     LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_erase(h, 0xFFFFFFFF));
 
@@ -289,7 +289,7 @@ void lt_test_rev_param_check(lt_handle_t *h)
         LT_TEST_ASSERT(LT_PARAM_ERR,
                        lt_mutable_fw_update(h, dummy_data, sizeof(dummy_data), 0xFFFFFFFF));
     }
-#elif LT_SILICON_REV_ACAB
+#elif defined(LT_SILICON_REV_ACAB)
     {
         uint8_t dummy_data[1];
         LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_update(NULL, dummy_data));

--- a/tests/functional/src/lt_test_rev_startup_req.c
+++ b/tests/functional/src/lt_test_rev_startup_req.c
@@ -114,12 +114,12 @@ void lt_test_rev_startup_req(lt_handle_t *h)
         LT_LOG_INFO("Checking the chip is in the maintenance mode...");
         LT_TEST_ASSERT(MAINTENANCE_MODE, check_current_state());
         LT_LOG_INFO("Checking that the handshake does not work...");
-#ifdef LT_SILICON_REV_ABAB
+#if defined(LT_SILICON_REV_ABAB)
         LT_TEST_ASSERT(LT_L2_GEN_ERR,
                        lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                TR01_PAIRING_KEY_SLOT_INDEX_0));
 
-#elif LT_SILICON_REV_ACAB
+#elif defined(LT_SILICON_REV_ACAB)
         LT_TEST_ASSERT(LT_L2_UNKNOWN_REQ,
                        lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                TR01_PAIRING_KEY_SLOT_INDEX_0));

--- a/tests/functional/src/lt_test_rev_startup_req.c
+++ b/tests/functional/src/lt_test_rev_startup_req.c
@@ -114,17 +114,17 @@ void lt_test_rev_startup_req(lt_handle_t *h)
         LT_LOG_INFO("Checking the chip is in the maintenance mode...");
         LT_TEST_ASSERT(MAINTENANCE_MODE, check_current_state());
         LT_LOG_INFO("Checking that the handshake does not work...");
-#ifdef ABAB
+#ifdef LT_SILICON_REV_ABAB
         LT_TEST_ASSERT(LT_L2_GEN_ERR,
                        lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                TR01_PAIRING_KEY_SLOT_INDEX_0));
 
-#elif ACAB
+#elif LT_SILICON_REV_ACAB
         LT_TEST_ASSERT(LT_L2_UNKNOWN_REQ,
                        lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
                                                                TR01_PAIRING_KEY_SLOT_INDEX_0));
 #else
-#error "Undefined silicon revision. Please define either ABAB or ACAB."
+#error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
 #endif
     }
 


### PR DESCRIPTION
## Description

The original goal in this task was to check silicon revision at runtime, deduce bootloader FW from it and adjust libtropic behavior according to them similarly as we do it with application FW. However, as we agreed to keep support for ABAB, it makes more sense to stay with the current approach - behavior of libtropic based on silicon revision is decided at compile time via the macros.

So, this PR only implement minor documentation and the silicon revision macros improvements:
- added `LT_SILICON_REV_` prefix to `ABAB` and `ACAB` macros to avoid naming collisions and comply with other used macros names, started using `#if defined()` and `#elif defined()` to align with how the macros are defined in CMakeLists.txt (the `#elif` before was wrong, `#if` was updated to be consistent),
- updated the compatibility table in the main readme - Libtropic supports bootloader FW 1.0.1 (only in ABAB revision) in all of its releases,
- added an FAQ mention to FW update tutorials if the FW update fails (part of this PR because it can be due to the wrong silicon revision macro usage during compilation).

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---