### PR TITLE
ETR01SDK-617: Fix CHIP_ID parsing in its older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `examples/model/mac_and_destroy/`: Log the correct number of wrong attempts and indexes of destroyed slots.
 - Target version reporting in Firmware Update examples for Linux.
 - Compatibility table in main README.md: mention support of Bootloader FW 1.0.1-2.0.1 for all existing Libtropic releases.
+- `lt_print_chip_id()`: Silicon revision field in CHIP_ID v0.0.0.1 is not interpreted as ASCII chars, as this version does not include silicon revision.
 
 ## [3.2.1]
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,6 +71,8 @@ You have two options:
 
 1. Read the product number (P/N) from the packaging you received your TROPIC01 product in. After that, refer to the [Available Parts](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#available-parts) section (in the [TROPIC01 GitHub repository](https://github.com/tropicsquare/tropic01)) and read the linked Catalog list, which will help you decode the silicon revision based on your P/N.
 2. Run our example Identify Chip (see [Tutorials](tutorials/index.md)), which **does not** require the Secure Channel Session.
+    - You might see "N/A" instead of the actual silicon revision. This means that the silicon revision of your TROPIC01 is **ABAB**.
+    - The reason is that ABAB chips use CHIP_ID version 0.0.0.1, which does not include silicon revision information.
 
 ## What FW versions is my TROPIC01 running?
 Run our example Identify Chip (see [Tutorials](tutorials/index.md)), which **does not** require the Secure Channel Session.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,8 +71,7 @@ You have two options:
 
 1. Read the product number (P/N) from the packaging you received your TROPIC01 product in. After that, refer to the [Available Parts](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#available-parts) section (in the [TROPIC01 GitHub repository](https://github.com/tropicsquare/tropic01)) and read the linked Catalog list, which will help you decode the silicon revision based on your P/N.
 2. Run our example Identify Chip (see [Tutorials](tutorials/index.md)), which **does not** require the Secure Channel Session.
-    - You might see "N/A" instead of the actual silicon revision. This means that the silicon revision of your TROPIC01 is **ABAB**.
-    - The reason is that ABAB chips use CHIP_ID version 0.0.0.1, which does not include silicon revision information.
+    - If the silicon revision field says "N/A", silicon revision of the TROPIC01 is **ABAB**. This is because CHIP_ID v0.0.0.1, used in ABAB chips, does not include the silicon revision field.
 
 ## What FW versions is my TROPIC01 running?
 Run our example Identify Chip (see [Tutorials](tutorials/index.md)), which **does not** require the Secure Channel Session.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -58,7 +58,7 @@ Log SPI communication using `printf`. Handy to debug low level communication.
 - string
 - default value: latest silicon revision available in the current Libtropic release
 
-Silicon version (e.g. `"ACAB"`) of the currently used TROPIC01 has to be set in this option. It is needed for TROPIC01's firmware update and functional tests, as some behavior differs between the TROPIC01 revisions.
+Silicon revision (e.g. `"ACAB"`) of the currently used TROPIC01 has to be set in this option. It is needed for TROPIC01's firmware update and functional tests, as some behavior differs between the TROPIC01 revisions.
 
 !!! question "What Is the Silicon Revision of My TROPIC01?"
     Refer to the dedicated section in the [FAQ](../../../faq.md#what-is-the-silicon-revision-of-my-tropic01).

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -101,6 +101,8 @@ lt_ret_t lt_get_st_pub(const struct lt_cert_store_t *store, uint8_t *stpub);
 
 /**
  * @brief Read TROPIC01's CHIP ID
+ * @note The read silicon revision field may not contain a valid ASCII-encoded string. This may
+ * indicate CHIP_ID version 0.0.0.1, which did not include silicon revision information.
  *
  * @param h           Handle for communication with TROPIC01
  * @param chip_id     Structure which holds all fields of CHIP ID
@@ -768,6 +770,8 @@ lt_ret_t lt_print_bytes(const uint8_t *bytes, const size_t bytes_cnt, char *out_
 
 /**
  * @brief Interprets fields of CHIP_ID and prints them using the passed printf-like function.
+ * @note If the silicon revision field says "N/A", silicon revision of the TROPIC01 is ABAB. This is
+ * because CHIP_ID v0.0.0.1, used in ABAB chips, does not include the silicon revision field.
  *
  * @param  chip_id     CHIP_ID structure
  * @param  print_func  printf-like function to use for printing

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -101,8 +101,8 @@ lt_ret_t lt_get_st_pub(const struct lt_cert_store_t *store, uint8_t *stpub);
 
 /**
  * @brief Read TROPIC01's CHIP ID
- * @note The read silicon revision field may not contain a valid ASCII-encoded string. This may
- * indicate CHIP_ID version 0.0.0.1, which did not include silicon revision information.
+ * @note The silicon revision field may be unavailable in CHIP_ID version 0.0.0.1. This CHIP_ID version
+ * was used only in ABAB silicon revisions.
  *
  * @param h           Handle for communication with TROPIC01
  * @param chip_id     Structure which holds all fields of CHIP ID

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1858,7 +1858,8 @@ lt_ret_t lt_print_chip_id(const struct lt_chip_id_t *chip_id,
             break;
 
         default:
-            if (0 > print_func("Fab ID         = 0x%03" PRIX16 " (%s)\n", parsed_fab_id, "N/A")) {
+            if (0 >
+                print_func("Fab ID                 = 0x%03" PRIX16 " (%s)\n", parsed_fab_id, "N/A")) {
                 return LT_FAIL;
             }
             break;

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1802,11 +1802,24 @@ lt_ret_t lt_print_chip_id(const struct lt_chip_id_t *chip_id,
         return LT_FAIL;
     }
 
+    // If CHIP_ID v0.0.0.1 is detected, we won't interpret silicon revision data, as this version does
+    // not include silicon revision.
+    bool chip_id_ver_is_0001 = (chip_id->chip_id_ver[0] == 0 && chip_id->chip_id_ver[1] == 0 &&
+                                chip_id->chip_id_ver[2] == 0 && chip_id->chip_id_ver[3] == 1);
+
     if (LT_OK != lt_print_bytes(chip_id->silicon_rev, sizeof(chip_id->silicon_rev), print_bytes_buff,
-                                sizeof(print_bytes_buff)) ||
-        0 > print_func("Silicon rev            = 0x%s (%c%c%c%c)\n", print_bytes_buff,
-                       chip_id->silicon_rev[0], chip_id->silicon_rev[1], chip_id->silicon_rev[2],
-                       chip_id->silicon_rev[3])) {
+                                sizeof(print_bytes_buff))) {
+        return LT_FAIL;
+    }
+
+    if (chip_id_ver_is_0001) {
+        if (0 > print_func("Silicon rev            = 0x%s (N/A)\n", print_bytes_buff)) {
+            return LT_FAIL;
+        }
+    }
+    else if (0 > print_func("Silicon rev            = 0x%s (%c%c%c%c)\n", print_bytes_buff,
+                            chip_id->silicon_rev[0], chip_id->silicon_rev[1], chip_id->silicon_rev[2],
+                            chip_id->silicon_rev[3])) {
         return LT_FAIL;
     }
 


### PR DESCRIPTION
## Description

- fixes indentation of Fab ID field if the value is N/A,
- in `lt_print_chip_id`, "N/A" is printed instead of silicon revision ASCII-encoded string, if CHIP_ID v0.0.0.1 is detected,
- mention CHIP_ID v0.0.0.1 limitations in the documentation.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---