### PR TITLE
ETR01SDK-564: New helper for FW update

### DIFF
--- a/.github/workflows/esp32_build_examples.yml
+++ b/.github/workflows/esp32_build_examples.yml
@@ -24,6 +24,7 @@ jobs:
             idf.py -C examples/esp32/ESP32-DevKitC-V4/hello_world/ build
             idf.py -C examples/esp32/ESP32-DevKitC-V4/identify_chip/ build
             idf.py -C examples/esp32/ESP32-DevKitC-V4/fw_update/ build
+            idf.py -D LT_SILICON_REV=ABAB -C examples/esp32/ESP32-DevKitC-V4/fw_update/ -B build_abab_devkitc_v4 build
 
       - name: Build ESP32-S3-DevKitC-1 examples
         run: |
@@ -31,6 +32,7 @@ jobs:
             idf.py -C examples/esp32/ESP32-S3-DevKitC-1/hello_world/ build
             idf.py -C examples/esp32/ESP32-S3-DevKitC-1/identify_chip/ build
             idf.py -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ build
+            idf.py -D LT_SILICON_REV=ABAB -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ -B build_abab_s3_devkitc_1 build
 
       - name: Build ESP32-C3-DevKit-RUST-1 examples
         run: |
@@ -38,3 +40,4 @@ jobs:
             idf.py -C examples/esp32/ESP32-C3-DevKit-RUST-1/hello_world/ build
             idf.py -C examples/esp32/ESP32-C3-DevKit-RUST-1/identify_chip/ build
             idf.py -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ build
+            idf.py -D LT_SILICON_REV=ABAB -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ -B build_abab_c3_devkit_rust_1 build

--- a/.github/workflows/linux_build_examples.yml
+++ b/.github/workflows/linux_build_examples.yml
@@ -42,6 +42,10 @@ jobs:
           cmake ./ -B build -G Ninja
           cd build && ninja
 
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cd build_abab && ninja
+
           cd ../../full_chain_verification
           cmake ./ -B build -G Ninja
           cd build && ninja
@@ -59,6 +63,10 @@ jobs:
           cd ../../fw_update
           cmake ./ -B build -G Ninja
           cd build && ninja
+
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cd build_abab && ninja
 
           cd ../../full_chain_verification
           cmake ./ -B build -G Ninja

--- a/.github/workflows/stm32_build_examples.yml
+++ b/.github/workflows/stm32_build_examples.yml
@@ -42,6 +42,10 @@ jobs:
           cmake ./ -B build -G Ninja
           cd build && ninja
 
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cd build_abab && ninja
+
       - name: Compile L432KC examples
         run: |
           cd examples/stm32/nucleo_l432kc/hello_world
@@ -55,3 +59,7 @@ jobs:
           cd ../../fw_update
           cmake ./ -B build -G Ninja
           cd build && ninja
+
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cd build_abab && ninja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ECC + EdDSA example for USB DevKit.
 - STM32L4xx HAL: support for TROPIC01 GPO pin.
 - Arrays to firmware update files which contain firmware version of the update: `fw_CPU_ver`, `fw_SPECT_ver`.
+- `fw_data_size` parameter to `lt_mutable_fw_update()` (ACAB version).
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - FW update: added necessary reboot into Maintenance Mode before updating the second FW bank pair. Without the reboot, only one FW bank pair was updated.
-- Compatibility table in main README.md: mention support of Bootloader FW 1.0.1-2.0.1 for all existing Libtropic releases.
 
 ## [3.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lt_ecc_ecdsa_sign` now expects a 32-byte hash instead of an arbitrary message - provided data are not hashed anymore. Select a hash function that outputs 32 bytes (for example, SHA-256). If using a longer digest, apply standard truncation as appropriate; do not pad shorter digests.
 - `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()`: changed type of `rnd_bytes_cnt` parameter to `uint8_t` to align with the TROPIC01 User API.
 - Added the `LT_SILICON_REV_` prefix to the `ABAB` and `ACAB` build-time configuration macros to avoid naming collisions; these macros are user-facing when building Libtropic from sources, especially outside CMake.
+- `lt_do_mutable_fw_update()`: changed parameters, reworked to do the recommended FW update procedure.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lt_random_value_get()`, `lt_out__random_value_get()`, `lt_in__random_value_get()`: changed type of `rnd_bytes_cnt` parameter to `uint8_t` to align with the TROPIC01 User API.
 - Added the `LT_SILICON_REV_` prefix to the `ABAB` and `ACAB` build-time configuration macros to avoid naming collisions; these macros are user-facing when building Libtropic from sources, especially outside CMake.
 - `lt_do_mutable_fw_update()`: changed parameters, reworked to do the recommended FW update procedure.
+- Updated all FW update examples to use the reworked `lt_do_mutable_fw_update()` helper function.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - FW update: added necessary reboot into Maintenance Mode before updating the second FW bank pair. Without the reboot, only one FW bank pair was updated.
+- Compatibility table in main README.md: mention support of Bootloader FW 1.0.1-2.0.1 for all existing Libtropic releases.
 
 ## [3.2.0]
 

--- a/docs/common/examples_descriptions/fw_update.md
+++ b/docs/common/examples_descriptions/fw_update.md
@@ -1,10 +1,7 @@
 This example explains the firmware update process for both ABAB and ACAB silicon revisions. Use this example as a reference for integrating TROPIC01 firmware updates into your application. You will learn:
 
 - How to read the current firmware versions.
-- How to update the firmware using `lt_do_mutable_fw_update()`.
-
-    !!! info "Updating FW with `lt_do_mutable_fw_update()` in Your Application"
-        If you are using `lt_do_mutable_fw_update()` in your application to update TROPIC01's FW, make sure to reinitialize the handle (`lt_handle_t`) after the function returns successfully, i.e. call `lt_deinit()` and `lt_init()`.
+- How to update the firmware using `lt_do_mutable_fw_update()`, which performs the recommended FW update procedure.
 
 !!! info "TROPIC01 Firmware"
     For more information about the firmware itself, refer to the [TROPIC01 Firmware](/reference/tropic01_fw.md) section.

--- a/docs/reference/tropic01_fw.md
+++ b/docs/reference/tropic01_fw.md
@@ -14,9 +14,8 @@ There are multiple kinds of FW running in TROPIC01:
     For more detailed information about each FW, refer to the latest **FW Update Application Note**:
 
     1. Get the part number of your TROPIC01 (you can refer to [FAQ](../faq.md#what-is-the-part-number-pn-of-my-tropic01)).
-    1. Look for your TROPIC01 part number in our [TROPIC01 repository](https://github.com/tropicsquare/tropic01/blob/main/doc/pages/part-numbers.md#part-numbers) and click on it.
-    2. Scroll down to the **Application Notes** table and look for the row with **FW Update Application Note**.
-
+    2. Look for your TROPIC01 part number in our [TROPIC01 repository](https://github.com/tropicsquare/tropic01/blob/main/doc/pages/part-numbers.md#part-numbers) and click on it.
+    3. Scroll down to the **Application Notes** table and look for the row with **FW Update Application Note**.
 ## TROPIC01 Firmware in Libtropic
 Libtropic provides not only implementation of the FW update L2 commands, but also the necessary files for updating both the RISC-V and SPECT FW. Refer to:
 

--- a/docs/reference/tropic01_fw.md
+++ b/docs/reference/tropic01_fw.md
@@ -15,7 +15,7 @@ There are multiple kinds of FW running in TROPIC01:
 
     1. Get the part number of your TROPIC01 (you can refer to [FAQ](../faq.md#what-is-the-part-number-pn-of-my-tropic01)).
     1. Look for your TROPIC01 part number in our [TROPIC01 repository](https://github.com/tropicsquare/tropic01/blob/main/doc/pages/part-numbers.md#part-numbers) and click on it.
-    2. scroll down to the **Application Notes** table and look for the row with **FW Update Application Note**.
+    2. Scroll down to the **Application Notes** table and look for the row with **FW Update Application Note**.
 
 ## TROPIC01 Firmware in Libtropic
 Libtropic provides not only implementation of the FW update L2 commands, but also the necessary files for updating both the RISC-V and SPECT FW. Refer to:

--- a/docs/reference/tropic01_fw.md
+++ b/docs/reference/tropic01_fw.md
@@ -11,7 +11,11 @@ There are multiple kinds of FW running in TROPIC01:
 3. *ECC engine mutable FW (ECC engine FW or SPECT FW)*. Updatable, located in R-memory, runs on ECC engine from RAM, helps the RISC-V CPU FW with processing ECC commands (ECC_Key_*, ECDSA/EDDSA_Sign).
 
 !!! info "More Information About TROPIC01 Firmware"
-    For more detailed information about each FW, refer to the [FW Update Application Note](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#application-notes).
+    For more detailed information about each FW, refer to the latest **FW Update Application Note**:
+
+    1. Get the part number of your TROPIC01 (you can refer to [FAQ](../faq.md#what-is-the-part-number-pn-of-my-tropic01)).
+    1. Look for your TROPIC01 part number in our [TROPIC01 repository](https://github.com/tropicsquare/tropic01/blob/main/doc/pages/part-numbers.md#part-numbers) and click on it.
+    2. scroll down to the **Application Notes** table and look for the row with **FW Update Application Note**.
 
 ## TROPIC01 Firmware in Libtropic
 Libtropic provides not only implementation of the FW update L2 commands, but also the necessary files for updating both the RISC-V and SPECT FW. Refer to:

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
@@ -131,90 +131,24 @@ void app_main(void)
         mbedtls_psa_crypto_free();
         return;
     }
-    ESP_LOGI(TAG, "OK");
+
+    ESP_LOGI(TAG, "Versions to update to:");
+    ESP_LOGI(TAG, "  - RISC-V FW version: %d.%d.%d", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
+    ESP_LOGI(TAG, "  - SPECT FW version: %d.%d.%d", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
+
     ESP_LOGI(TAG, "");
-
-    ESP_LOGI(TAG, "Starting firmware update...");
-
-    // The chip must be in Start-up Mode to be able to perform a firmware update.
-    ESP_LOGI(TAG, "- Sending maintenance reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
+    ESP_LOGI(TAG, "Updating TROPIC01 firmware...");
+    // This helper function implements the recommended FW update process.
+    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        ESP_LOGE(TAG, "Maintenance reboot failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
+        ESP_LOGE(TAG,
+                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;
     }
     ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "- Updating TR01_FW_BANK_FW1 and TR01_FW_BANK_SPECT1");
-    ESP_LOGI(TAG, "  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW1);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "RISC-V FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT1);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "SPECT FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    // Reboot into Maintenance Mode. This step is crucial if we want to update both FW bank pairs.
-    // If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
-    // will not be updated, which increases the possibility of a downgrade attack.
-    ESP_LOGI(TAG, "- Rebooting TROPIC01 into Maintenance Mode...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "- Updating TR01_FW_BANK_FW2 and TR01_FW_BANK_SPECT2");
-    ESP_LOGI(TAG, "  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW2);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "RISC-V FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT2);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "SPECT FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-    ESP_LOGI(TAG, "Successfully updated all 4 FW banks.");
-    ESP_LOGI(TAG, "");
-
-    ESP_LOGI(TAG, "Sending reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_REBOOT);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-    ESP_LOGI(TAG, "TROPIC01 is executing Application FW now");
-    ESP_LOGI(TAG, "");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
@@ -141,9 +141,8 @@ void app_main(void)
     // This helper function implements the recommended FW update process.
     ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
-        ESP_LOGE(TAG,
-                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
+        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
@@ -131,90 +131,24 @@ void app_main(void)
         mbedtls_psa_crypto_free();
         return;
     }
-    ESP_LOGI(TAG, "OK");
+
+    ESP_LOGI(TAG, "Versions to update to:");
+    ESP_LOGI(TAG, "  - RISC-V FW version: %d.%d.%d", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
+    ESP_LOGI(TAG, "  - SPECT FW version: %d.%d.%d", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
+
     ESP_LOGI(TAG, "");
-
-    ESP_LOGI(TAG, "Starting firmware update...");
-
-    // The chip must be in Start-up Mode to be able to perform a firmware update.
-    ESP_LOGI(TAG, "- Sending maintenance reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
+    ESP_LOGI(TAG, "Updating TROPIC01 firmware...");
+    // This helper function implements the recommended FW update process.
+    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        ESP_LOGE(TAG, "Maintenance reboot failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
+        ESP_LOGE(TAG,
+                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;
     }
     ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "- Updating TR01_FW_BANK_FW1 and TR01_FW_BANK_SPECT1");
-    ESP_LOGI(TAG, "  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW1);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "RISC-V FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT1);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "SPECT FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    // Reboot into Maintenance Mode. This step is crucial if we want to update both FW bank pairs.
-    // If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
-    // will not be updated, which increases the possibility of a downgrade attack.
-    ESP_LOGI(TAG, "- Rebooting TROPIC01 into Maintenance Mode...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "- Updating TR01_FW_BANK_FW2 and TR01_FW_BANK_SPECT2");
-    ESP_LOGI(TAG, "  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW2);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "RISC-V FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT2);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "SPECT FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-    ESP_LOGI(TAG, "Successfully updated all 4 FW banks.");
-    ESP_LOGI(TAG, "");
-
-    ESP_LOGI(TAG, "Sending reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_REBOOT);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-    ESP_LOGI(TAG, "TROPIC01 is executing Application FW now");
-    ESP_LOGI(TAG, "");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
@@ -141,9 +141,8 @@ void app_main(void)
     // This helper function implements the recommended FW update process.
     ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
-        ESP_LOGE(TAG,
-                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
+        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
@@ -131,90 +131,24 @@ void app_main(void)
         mbedtls_psa_crypto_free();
         return;
     }
-    ESP_LOGI(TAG, "OK");
+
+    ESP_LOGI(TAG, "Versions to update to:");
+    ESP_LOGI(TAG, "  - RISC-V FW version: %d.%d.%d", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
+    ESP_LOGI(TAG, "  - SPECT FW version: %d.%d.%d", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
+
     ESP_LOGI(TAG, "");
-
-    ESP_LOGI(TAG, "Starting firmware update...");
-
-    // The chip must be in Start-up Mode to be able to perform a firmware update.
-    ESP_LOGI(TAG, "- Sending maintenance reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
+    ESP_LOGI(TAG, "Updating TROPIC01 firmware...");
+    // This helper function implements the recommended FW update process.
+    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        ESP_LOGE(TAG, "Maintenance reboot failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
+        ESP_LOGE(TAG,
+                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;
     }
     ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "- Updating TR01_FW_BANK_FW1 and TR01_FW_BANK_SPECT1");
-    ESP_LOGI(TAG, "  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW1);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "RISC-V FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT1);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "SPECT FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    // Reboot into Maintenance Mode. This step is crucial if we want to update both FW bank pairs.
-    // If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
-    // will not be updated, which increases the possibility of a downgrade attack.
-    ESP_LOGI(TAG, "- Rebooting TROPIC01 into Maintenance Mode...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "- Updating TR01_FW_BANK_FW2 and TR01_FW_BANK_SPECT2");
-    ESP_LOGI(TAG, "  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW2);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "RISC-V FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-
-    ESP_LOGI(TAG, "  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT2);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "SPECT FW update failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-    ESP_LOGI(TAG, "Successfully updated all 4 FW banks.");
-    ESP_LOGI(TAG, "");
-
-    ESP_LOGI(TAG, "Sending reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_REBOOT);
-    if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return;
-    }
-    ESP_LOGI(TAG, "OK");
-    ESP_LOGI(TAG, "TROPIC01 is executing Application FW now");
-    ESP_LOGI(TAG, "");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
@@ -141,9 +141,8 @@ void app_main(void)
     // This helper function implements the recommended FW update process.
     ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
-        ESP_LOGE(TAG,
-                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
+        ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;

--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -154,84 +154,19 @@ int main(void)
         mbedtls_psa_crypto_free();
         return 0;
     }
-    printf("\nStarting firmware update...\n");
 
-    // The chip must be in Start-up Mode to be able to perform a firmware update.
-    printf("- Sending maintenance reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
+    printf("\nUpdating TROPIC01 firmware...");
+    // This helper function implements the recommended FW update process.
+    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }
     printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW1 and TR01_FW_BANK_SPECT1\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    // Reboot into Maintenance Mode. This step is crucial if we want to update both FW bank pairs.
-    // If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
-    // will not be updated, which increases the possibility of a downgrade attack.
-    printf("- Rebooting TROPIC01 into Maintenance Mode...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW2 and TR01_FW_BANK_SPECT2\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-    printf("Successfully updated all 4 FW banks.\n\n");
-
-    printf("Sending reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK!\nTROPIC01 is executing Application FW now\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);

--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -27,12 +27,12 @@ lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
     printf("Reading firmware versions from TROPIC01...");
     lt_ret_t ret = lt_get_info_riscv_fw_ver(lt_handle, cpu_fw_ver);
     if (ret != LT_OK) {
-        fprintf(stderr, "\nFailed to get RISC-V FW version, ret=%s", lt_ret_verbose(ret));
+        fprintf(stderr, "\nFailed to get RISC-V FW version, ret=%s\n", lt_ret_verbose(ret));
         return ret;
     }
     ret = lt_get_info_spect_fw_ver(lt_handle, spect_fw_ver);
     if (ret != LT_OK) {
-        fprintf(stderr, "\nFailed to get SPECT FW version, ret=%s", lt_ret_verbose(ret));
+        fprintf(stderr, "\nFailed to get SPECT FW version, ret=%s\n", lt_ret_verbose(ret));
         return ret;
     }
     printf("OK\n");

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -139,84 +139,19 @@ int main(void)
         mbedtls_psa_crypto_free();
         return 0;
     }
-    printf("\nStarting firmware update...\n");
 
-    // The chip must be in Start-up Mode to be able to perform a firmware update.
-    printf("- Sending maintenance reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
+    printf("\nUpdating TROPIC01 firmware...");
+    // This helper function implements the recommended FW update process.
+    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }
     printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW1 and TR01_FW_BANK_SPECT1\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    // Reboot into Maintenance Mode. This step is crucial if we want to update both FW bank pairs.
-    // If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
-    // will not be updated, which increases the possibility of a downgrade attack.
-    printf("- Rebooting TROPIC01 into Maintenance Mode...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW2 and TR01_FW_BANK_SPECT2\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-    printf("Successfully updated all 4 FW banks.\n\n");
-
-    printf("Sending reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK!\nTROPIC01 is executing Application FW now\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -295,90 +295,22 @@ int main(void)
         return -1;
     }
 
-    printf("Starting firmware update...\n");
+    printf("Versions to update to:\n");
+    printf("  - RISC-V FW version: %d.%d.%d\n", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
+    printf("  - SPECT FW version: %d.%d.%d\n", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
 
-    /* The chip must be in Start-up Mode to be able to perform a firmware update. */
-    printf("- Sending maintenance reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
+    printf("\nUpdating TROPIC01 firmware...");
+    // This helper function implements the recommended FW update process.
+    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }
     printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW1 and TR01_FW_BANK_SPECT1\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    /* Reboot into Maintenance Mode. This step is crucial if we want to update both FW bank pairs.
-       If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
-       will not be updated, which increases the possibility of a downgrade attack. */
-    printf("Rebooting TROPIC01 into Maintenance Mode...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW2 and TR01_FW_BANK_SPECT2\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-    printf("Successfully updated all 4 FW banks.\n\n");
-
-    printf("Sending reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK!\nTROPIC01 is executing Application FW now\n");
-
-    if (get_fw_versions(&lt_handle) != LT_OK) {
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
 
     printf("Deinitializing handle...");
     ret = lt_deinit(&lt_handle);

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -312,6 +312,12 @@ int main(void)
     }
     printf("OK\n");
 
+    if (get_fw_versions(&lt_handle) != LT_OK) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+
     printf("Deinitializing handle...");
     ret = lt_deinit(&lt_handle);
     if (LT_OK != ret) {

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -325,84 +325,22 @@ int main(void)
         return -1;
     }
 
-    printf("Starting firmware update...\n");
+    printf("Versions to update to:\n");
+    printf("  - RISC-V FW version: %d.%d.%d\n", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
+    printf("  - SPECT FW version: %d.%d.%d\n", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
 
-    /* The chip must be in Start-up Mode to be able to perform a firmware update. */
-    printf("- Sending maintenance reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
+    printf("\nUpdating TROPIC01 firmware...");
+    // This helper function implements the recommended FW update process.
+    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
     if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
     }
     printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW1 and TR01_FW_BANK_SPECT1\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT1);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    /* Reboot into Maintenance Mode. This step is crucial if we want to update both FW bank pairs.
-       If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
-       will not be updated, which increases the possibility of a downgrade attack. */
-    printf("Rebooting TROPIC01 into Maintenance Mode...");
-    ret = lt_reboot(&lt_handle, TR01_MAINTENANCE_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("- Updating TR01_FW_BANK_FW2 and TR01_FW_BANK_SPECT2\n");
-    printf("  - Updating RISC-V FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), TR01_FW_BANK_FW2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nRISC-V FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("  - Updating SPECT FW...");
-    ret = lt_do_mutable_fw_update(&lt_handle, fw_SPECT, sizeof(fw_SPECT), TR01_FW_BANK_SPECT2);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nSPECT FW update failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-    printf("Successfully updated all 4 FW banks.\n\n");
-
-    printf("Sending reboot request...");
-    ret = lt_reboot(&lt_handle, TR01_REBOOT);
-    if (ret != LT_OK) {
-        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK!\nTROPIC01 is executing Application FW now\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -260,16 +260,17 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint
 lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size);
 
 /**
- * @brief Sends mutable firmware update data to TROPIC01 with silicon revision ACAB. Function
- * `lt_mutable_fw_update()` must be called first to start authenticated mutable fw update.
+ * @brief Performs the rest of the FW update by sending multiple Mutable_FW_Update_Data_Req L2
+ * requests.
+ * @attention `lt_mutable_fw_update()` must be called before this function.
+ * @note This function is used with silicon revision ACAB and newer.
  *
- * @param h                 Handle for communication with TROPIC01
- * @param update_data       Array with firmware update data bytes
- * @param update_data_size  Size of update data
- * @return                  LT_OK if success, otherwise returns other error code.
+ * @param h             Handle for communication with TROPIC01
+ * @param fw_data       Firmware update data
+ * @param fw_data_size  Size of firmware update data
+ * @return              LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *update_data,
-                                   const uint16_t update_data_size);
+lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size);
 
 #endif
 /**

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -802,7 +802,7 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id,
  * @brief Helper function to perform mutable firmware update on both firmware banks.
  * @note This helper function follows the recommended FW update process.
  * @note This helper function is compatible with all silicon revisions.
- * @important Even if this function fails, the Application FW might still be bootable (atleast one
+ * @important Even if this function fails, the Application FW might still be bootable (at least one
  * of the banks was updated successfully). However, ignoring this is strongly discouraged:
  *  - There is a non-negligible security risk.
  *  - Libtropic was not reinitialized to be compatible with the updated Application FW - some

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -232,18 +232,19 @@ lt_ret_t lt_reboot(lt_handle_t *h, const lt_startup_id_t startup_id);
 lt_ret_t lt_mutable_fw_erase(lt_handle_t *h, const lt_bank_id_t bank_id);
 
 /**
- * @brief Update mutable firmware in one of banks
+ * @brief Performs FW update by sending multiple Mutable_FW_Update_Req L2 requests.
+ * @note This function is used with silicon revision ABAB.
  *
  * @param h             Handle for communication with TROPIC01
- * @param fw_data       Array with firmware bytes
- * @param fw_data_size  Number of firmware's bytes in passed array
- * @param bank_id       enum lt_bank_id_t
- * lt_ret_t             LT_OK            - SUCCESS
- *                      other parameters - ERROR, for verbose output pass return value to function
- * lt_ret_verbose()
+ * @param fw_data       Firmware update data
+ * @param fw_data_size  Size of firmware update data
+ * @param bank_id       Mutable firmware bank ID
+ * @retval              LT_OK Function executed successfully
+ * @retval              other Function did not execute successully, you might use lt_ret_verbose() to
+ * get verbose encoding of returned value
  */
-lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint16_t fw_data_size,
-                              lt_bank_id_t bank_id);
+lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size,
+                              const lt_bank_id_t bank_id);
 
 #elif defined(LT_SILICON_REV_ACAB)
 /** @brief Maximal size of update data */

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -249,13 +249,15 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint
 #define TR01_MUTABLE_FW_UPDATE_SIZE_MAX 30720
 
 /**
- * @brief Sends mutable firmware update L2 request to TROPIC01 with silicon revision ACAB
+ * @brief Sends Mutable_FW_Update_Req L2 request.
+ * @note This function is used with silicon revision ACAB and newer.
  *
- * @param h               Handle for communication with TROPIC01
- * @param update_request  Array with firmware update request bytes
- * @return                LT_OK if success, otherwise returns other error code.
+ * @param h             Handle for communication with TROPIC01
+ * @param fw_data       Firmware update data
+ * @param fw_data_size  Size of firmware update data
+ * @return              LT_OK if success, otherwise returns other error code.
  */
-lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *update_request);
+lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size);
 
 /**
  * @brief Sends mutable firmware update data to TROPIC01 with silicon revision ACAB. Function

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -219,10 +219,11 @@ lt_ret_t lt_reboot(lt_handle_t *h, const lt_startup_id_t startup_id);
 /** @brief Maximal size of update data */
 #define TR01_MUTABLE_FW_UPDATE_SIZE_MAX 25600
 /**
- * @brief Erase mutable firmware in one of banks
+ * @brief Erases the given mutable firmware bank using Mutable_FW_Erase_Req L2 request.
+ * @note This function is used with silicon revision ABAB.
  *
  * @param h           Handle for communication with TROPIC01
- * @param bank_id     enum lt_bank_id_t
+ * @param bank_id     Mutable firmware bank ID
  *
  * @retval            LT_OK Function executed successfully
  * @retval            other Function did not execute successully, you might use lt_ret_verbose() to get

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -807,7 +807,7 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id,
  *  - There is a non-negligible security risk.
  *  - Libtropic was not reinitialized to be compatible with the updated Application FW - some
  *    functionalities may not be available or may produce undefined behavior.
- *  - **Solution**: call this function again and make sure it suceeds. If it continues to fail, refer
+ *  - **Solution**: call this function again and make sure it succeeds. If it continues to fail, refer
  *    to our [FAQ](https://tropicsquare.github.io/libtropic/latest/faq/) or contact us via our [support
  *    portal](https://support.desk.tropicsquare.com/servicedesk/customer/user/login?destination=portals).
  *

--- a/include/libtropic.h
+++ b/include/libtropic.h
@@ -799,20 +799,30 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id,
                             int (*print_func)(const char *format, ...));
 
 /**
- * @brief Performs mutable firmware update on ABAB and ACAB silicon revisions.
- * @important After this function returns successfully, the handle (`lt_handle_t`) has to be
- * initialized again (i.e. calling `lt_deinit()` and `lt_init()`).
+ * @brief Helper function to perform mutable firmware update on both firmware banks.
+ * @note This helper function follows the recommended FW update process.
+ * @note This helper function is compatible with all silicon revisions.
+ * @important Even if this function fails, the Application FW might still be bootable (atleast one
+ * of the banks was updated successfully). However, ignoring this is strongly discouraged:
+ *  - There is a non-negligible security risk.
+ *  - Libtropic was not reinitialized to be compatible with the updated Application FW - some
+ *    functionalities may not be available or may produce undefined behavior.
+ *  - **Solution**: call this function again and make sure it suceeds. If it continues to fail, refer
+ *    to our [FAQ](https://tropicsquare.github.io/libtropic/latest/faq/) or contact us via our [support
+ *    portal](https://support.desk.tropicsquare.com/servicedesk/customer/user/login?destination=portals).
  *
- * @param h                 Handle for communication with TROPIC01
- * @param update_data       Pointer to the data to be written
- * @param update_data_size  Size of the data to be written
- * @param bank_id           Bank ID where the update should be applied, valid values are
- *                             For ABAB: TR01_FW_BANK_FW1, TR01_FW_BANK_FW2, TR01_FW_BANK_SPECT1,
- * TR01_FW_BANK_SPECT2 For ACAB: Parameter is ignored, chip is handling firmware banks on its own
- * @return                  LT_OK if success, otherwise returns other error code.
+ * @param h                   Handle for communication with TROPIC01
+ * @param cpu_fw_data         Firmware update data for RISC-V main CPU
+ * @param cpu_fw_data_size    Size of firmware update data for RISC-V main CPU
+ * @param spect_fw_data       Firmware update data for SPECT coprocessor
+ * @param spect_fw_data_size  Size of firmware update data for SPECT coprocessor
+ * @retval                    LT_OK Function executed successfully
+ * @retval                    other Function did not execute successully, you might use
+ * lt_ret_verbose() to get verbose encoding of returned value
  */
-lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
-                                 const uint16_t update_data_size, const lt_bank_id_t bank_id);
+lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
+                                 const size_t cpu_fw_data_size, const uint8_t *spect_fw_data,
+                                 const size_t spect_fw_data_size);
 
 /** @} */  // end of libtropic_API_helpers group
 #endif

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -297,7 +297,8 @@ typedef enum lt_ret_t {
        Application FW - it will stay in Start-up Mode no matter the `startup_id`), or
 
        - `startup_id`==`TR01_MAINTENANCE_REBOOT` and TROPIC01's mode after successful reboot is **not**
-       `LT_TR01_MAINTENANCE`.
+       `LT_TR01_MAINTENANCE` (this can e.g. happen when Maintenance Mode is disabled in R-Config or
+       I-Config).
     */
     LT_REBOOT_UNSUCCESSFUL = 6,
 

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -642,6 +642,39 @@ typedef enum lt_bank_id_t {
 } lt_bank_id_t;
 
 /**
+ * @brief Format of the first chunk in the mutable FW update data.
+ * @note This format applies to silicon revision ACAB and newer.
+ */
+typedef struct lt_mutable_fw_update_chunk_0_t {
+    uint8_t req_len;       /**< Length byte. */
+    uint8_t signature[64]; /**< Signature of SHA256 hash calculated from the rest of the data in
+                              Mutable_FW_Update_Req.REQ_DATA field. */
+    uint8_t hash[32]; /**< SHA256 hash of the first FW chunk sent in Mutable_FW_Update_Data_Req. */
+    uint16_t type;    /**< FW type which is going to be updated. */
+    uint8_t padding;  /**< Padding, zero value. */
+    uint8_t header_version; /**< Version of used header. */
+    uint32_t version;       /**< Version of the mutable FW. */
+} __attribute__((__packed__)) lt_mutable_fw_update_chunk_0_t;
+
+// clang-format off
+/** \cond */
+LT_STATIC_ASSERT(
+    ( sizeof(struct lt_mutable_fw_update_chunk_0_t) )
+    ==
+    (
+        LT_MEMBER_SIZE(struct lt_mutable_fw_update_chunk_0_t, req_len) + 
+        LT_MEMBER_SIZE(struct lt_mutable_fw_update_chunk_0_t, signature) + 
+        LT_MEMBER_SIZE(struct lt_mutable_fw_update_chunk_0_t, hash) + 
+        LT_MEMBER_SIZE(struct lt_mutable_fw_update_chunk_0_t, type) + 
+        LT_MEMBER_SIZE(struct lt_mutable_fw_update_chunk_0_t, padding) + 
+        LT_MEMBER_SIZE(struct lt_mutable_fw_update_chunk_0_t, header_version) +
+        LT_MEMBER_SIZE(struct lt_mutable_fw_update_chunk_0_t, version)
+    )
+)
+/** \endcond */
+// clang-format on
+
+/**
  * @brief When in MAINTENANCE mode, it is possible to read firmware header from a firmware bank.
  * Returned data differs based on bootloader version. This header layout is returned by bootloader
  * version v1.0.1

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -654,7 +654,7 @@ typedef struct lt_mutable_fw_update_chunk_0_t {
     uint8_t padding;  /**< Padding, zero value. */
     uint8_t header_version; /**< Version of used header. */
     uint32_t version;       /**< Version of the mutable FW. */
-} __attribute__((__packed__)) lt_mutable_fw_update_chunk_0_t;
+} __attribute__((packed)) lt_mutable_fw_update_chunk_0_t;
 
 // clang-format off
 /** \cond */

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -699,9 +699,9 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint
     return LT_OK;
 }
 #elif defined(LT_SILICON_REV_ACAB)
-lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *update_request)
+lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size)
 {
-    if (!h || !update_request) {
+    if (!h || !fw_data || fw_data_size < sizeof(lt_mutable_fw_update_chunk_0_t)) {
         return LT_PARAM_ERR;
     }
 
@@ -714,7 +714,7 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *update_request)
 
     // Setup a pointer to incomming data
     struct lt_mutable_fw_update_chunk_0_t *fw_chunk_0 =
-        (struct lt_mutable_fw_update_chunk_0_t *)(update_request);
+        (struct lt_mutable_fw_update_chunk_0_t *)(fw_data);
 
     p_l2_req->req_id = TR01_L2_MUTABLE_FW_UPDATE_REQ_ID;
     p_l2_req->req_len = TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN;
@@ -1955,7 +1955,7 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
     }
 
     // send the update 'request'
-    lt_ret_t ret = lt_mutable_fw_update(h, update_data);
+    lt_ret_t ret = lt_mutable_fw_update(h, update_data, update_data_size);
     if (ret != LT_OK) {
         return ret;
     }

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -2034,7 +2034,7 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
 
 // 5. Check both FW bank pairs contain the new FW versions. We do this only for ACAB revision and
 // newer, because FW update data for ABAB did not contain information about the FW version.
-#ifndef LT_SILICON_REV_ABAB
+#if !defined(LT_SILICON_REV_ABAB)
 // The two following macros are used for pretty logging of FW versions.
 #define _LT_FW_VER_FMT                              \
     "'"                                             \
@@ -2113,7 +2113,7 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
         return ret;
     }
 
-#ifndef LT_SILICON_REV_ABAB
+#if !defined(LT_SILICON_REV_ABAB)
     // 7. Check the updated FW version was booted.
     uint8_t riscv_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE];
     ret = lt_get_info_riscv_fw_ver(h, riscv_ver);

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -635,8 +635,8 @@ lt_ret_t lt_mutable_fw_erase(lt_handle_t *h, const lt_bank_id_t bank_id)
     return LT_OK;
 }
 
-lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const uint16_t fw_data_size,
-                              lt_bank_id_t bank_id)
+lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size,
+                              const lt_bank_id_t bank_id)
 {
     if (!h || !fw_data || fw_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX ||
         ((bank_id != TR01_FW_BANK_FW1) && (bank_id != TR01_FW_BANK_FW2) &&

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -2045,9 +2045,10 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
 
     lt_header_boot_v2_t fw_header;
     uint16_t read_header_size;
-    lt_mutable_fw_update_chunk_0_t *cpu_fw_chunk_0 = (lt_mutable_fw_update_chunk_0_t *)(cpu_fw_data);
-    lt_mutable_fw_update_chunk_0_t *spect_fw_chunk_0 =
-        (lt_mutable_fw_update_chunk_0_t *)(spect_fw_data);
+    const lt_mutable_fw_update_chunk_0_t *cpu_fw_chunk_0 =
+        (const lt_mutable_fw_update_chunk_0_t *)(cpu_fw_data);
+    const lt_mutable_fw_update_chunk_0_t *spect_fw_chunk_0 =
+        (const lt_mutable_fw_update_chunk_0_t *)(spect_fw_data);
 
     ret = lt_get_info_fw_bank(h, TR01_FW_BANK_FW1, (uint8_t *)&fw_header, sizeof(fw_header),
                               &read_header_size);

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -743,11 +743,10 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size
     return LT_OK;
 }
 
-lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *update_data,
-                                   const uint16_t update_data_size)
+lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size)
 {
-    if (!h || !update_data || update_data_size <= (TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN + 1U) ||
-        update_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
+    if (!h || !fw_data || fw_data_size <= (TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN + 1U) ||
+        fw_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
         return LT_PARAM_ERR;
     }
 
@@ -757,9 +756,6 @@ lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *update_data,
     // Setup a request pointer to l2 buffer with response data
     struct lt_l2_mutable_fw_update_rsp_t *p_l2_resp = (struct lt_l2_mutable_fw_update_rsp_t *)
                                                           h->l2.buff;
-
-    // Normalized sizes for arithmetic.
-    size_t upd_size = (size_t)update_data_size;
     size_t copy_len;
 
     // Compute how many bytes are available in the `lt_l2_mutable_fw_update_data_req_t` struct starting
@@ -770,16 +766,16 @@ lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *update_data,
 
     // Data consist of "request" and "data" parts,
     // 'data' byte chunks are taken starting from 'chunk_index'
-    for (size_t chunk_index = (size_t)TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN + 1U; chunk_index < upd_size;
-         chunk_index += copy_len) {
-        copy_len = (size_t)update_data[chunk_index] + 1U;
+    for (size_t chunk_index = (size_t)TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN + 1U;
+         chunk_index < fw_data_size; chunk_index += copy_len) {
+        copy_len = (size_t)fw_data[chunk_index] + 1U;
 
-        if (copy_len > upd_size - chunk_index || copy_len > dest_capacity) {
+        if (copy_len > fw_data_size - chunk_index || copy_len > dest_capacity) {
             return LT_PARAM_ERR;
         }
 
         p2_l2_req->req_id = TR01_L2_MUTABLE_FW_UPDATE_DATA_REQ;
-        memcpy((uint8_t *)&p2_l2_req->req_len, update_data + chunk_index, copy_len);
+        memcpy((uint8_t *)&p2_l2_req->req_len, fw_data + chunk_index, copy_len);
 
         lt_ret_t ret = lt_l2_send(&h->l2);
         if (ret != LT_OK) {

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -713,8 +713,8 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size
                                                           h->l2.buff;
 
     // Setup a pointer to incomming data
-    struct lt_mutable_fw_update_chunk_0_t *fw_chunk_0 =
-        (struct lt_mutable_fw_update_chunk_0_t *)(fw_data);
+    const struct lt_mutable_fw_update_chunk_0_t *fw_chunk_0 =
+        (const struct lt_mutable_fw_update_chunk_0_t *)(fw_data);
 
     p_l2_req->req_id = TR01_L2_MUTABLE_FW_UPDATE_REQ_ID;
     p_l2_req->req_len = TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN;

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1981,6 +1981,62 @@ static lt_ret_t update_mutable_fw_bank(lt_handle_t *h, const uint8_t *fw_data,
     return LT_OK;
 }
 
+// The two following macros are used for pretty logging of FW versions in lt_do_mutable_fw_update() and
+// validate_fw_ver_in_bank().
+#define _LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT         \
+    "'"                                             \
+    "%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(.%" PRIu32 \
+    ")"                                             \
+    "'"
+#define _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(v) \
+    (((v) >> 24) & 0xFF), (((v) >> 16) & 0xFF), (((v) >> 8) & 0xFF), ((v) & 0xFF)
+
+/**
+ * @brief Reads out firmware header from the given firmware bank and validates the firmware version
+ * against the expected one.
+ * @note This function is compatible with silicon revision ACAB and newer.
+ *
+ * @param h                Handle for communication with TROPIC01
+ * @param expected_fw_ver  Firmware version that is expected to be read from the bank
+ * @param bank_id          Mutable firmware bank ID
+ * @return                 LT_OK if success, otherwise returns other error code.
+ */
+static lt_ret_t validate_fw_ver_in_bank(lt_handle_t *h, const uint32_t expected_fw_ver,
+                                        const lt_bank_id_t bank_id)
+{
+    if (!h) {
+        // bank_id will be checked by lt_get_info_fw_bank().
+        return LT_PARAM_ERR;
+    }
+    lt_header_boot_v2_t fw_header;
+    uint16_t read_header_size;
+    lt_ret_t ret;
+
+    // Read FW header and validate read size.
+    ret = lt_get_info_fw_bank(h, bank_id, (uint8_t *)&fw_header, sizeof(fw_header), &read_header_size);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to read FW header from the bank.");
+        return ret;
+    }
+    if (read_header_size != sizeof(fw_header)) {
+        LT_LOG_ERROR("Read unexpected FW header size: expected=%zu, read=%" PRIu16, sizeof(fw_header),
+                     read_header_size);
+        return LT_FAIL;
+    }
+
+    // Validate the FW version.
+    if (expected_fw_ver != fw_header.ver) {
+        LT_LOG_ERROR(
+            "FW version read from the bank mismatch: expected "_LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT
+            ", read "_LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT,
+            _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(expected_fw_ver),
+            _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(fw_header.ver));
+        return LT_FAIL;
+    }
+
+    return LT_OK;
+}
+
 lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
                                  const size_t cpu_fw_data_size, const uint8_t *spect_fw_data,
                                  const size_t spect_fw_data_size)
@@ -2035,75 +2091,33 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
 // 5. Check both FW bank pairs contain the new FW versions. We do this only for ACAB revision and
 // newer, because FW update data for ABAB did not contain information about the FW version.
 #if !defined(LT_SILICON_REV_ABAB)
-// The two following macros are used for pretty logging of FW versions.
-#define _LT_FW_VER_FMT                              \
-    "'"                                             \
-    "%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(.%" PRIu32 \
-    ")"                                             \
-    "'"
-#define _LT_FW_VER_ARG(v) (((v) >> 24) & 0xFF), (((v) >> 16) & 0xFF), (((v) >> 8) & 0xFF), ((v) & 0xFF)
+    const struct lt_mutable_fw_update_chunk_0_t *cpu_fw_chunk_0 =
+        (const struct lt_mutable_fw_update_chunk_0_t *)cpu_fw_data;
+    const struct lt_mutable_fw_update_chunk_0_t *spect_fw_chunk_0 =
+        (const struct lt_mutable_fw_update_chunk_0_t *)spect_fw_data;
 
-    lt_header_boot_v2_t fw_header;
-    uint16_t read_header_size;
-    const lt_mutable_fw_update_chunk_0_t *cpu_fw_chunk_0 =
-        (const lt_mutable_fw_update_chunk_0_t *)(cpu_fw_data);
-    const lt_mutable_fw_update_chunk_0_t *spect_fw_chunk_0 =
-        (const lt_mutable_fw_update_chunk_0_t *)(spect_fw_data);
-
-    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_FW1, (uint8_t *)&fw_header, sizeof(fw_header),
-                              &read_header_size);
+    LT_LOG_INFO("Validating FW version in RISC-V FW bank 1.");
+    ret = validate_fw_ver_in_bank(h, cpu_fw_chunk_0->version, TR01_FW_BANK_FW1);
     if (ret != LT_OK) {
-        LT_LOG_ERROR("Failed to read FW header from RISC-V FW bank 1.");
         return ret;
     }
-    if (cpu_fw_chunk_0->version != fw_header.ver) {
-        LT_LOG_ERROR(
-            "RISC-V FW version from bank 1 mismatch: expected "_LT_FW_VER_FMT
-            ", read "_LT_FW_VER_FMT,
-            _LT_FW_VER_ARG(cpu_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
-        return LT_FAIL;
-    }
 
-    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_SPECT1, (uint8_t *)&fw_header, sizeof(fw_header),
-                              &read_header_size);
+    LT_LOG_INFO("Validating FW version in SPECT FW bank 1.");
+    ret = validate_fw_ver_in_bank(h, spect_fw_chunk_0->version, TR01_FW_BANK_SPECT1);
     if (ret != LT_OK) {
-        LT_LOG_ERROR("Failed to read FW header from SPECT FW bank 1.");
         return ret;
     }
-    if (spect_fw_chunk_0->version != fw_header.ver) {
-        LT_LOG_ERROR(
-            "SPECT FW version from bank 1 mismatch: expected "_LT_FW_VER_FMT
-            ", read "_LT_FW_VER_FMT,
-            _LT_FW_VER_ARG(spect_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
-        return LT_FAIL;
-    }
 
-    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_FW2, (uint8_t *)&fw_header, sizeof(fw_header),
-                              &read_header_size);
+    LT_LOG_INFO("Validating FW version in RISC-V FW bank 2.");
+    ret = validate_fw_ver_in_bank(h, cpu_fw_chunk_0->version, TR01_FW_BANK_FW2);
     if (ret != LT_OK) {
-        LT_LOG_ERROR("Failed to read FW header from RISC-V FW bank 2.");
         return ret;
     }
-    if (cpu_fw_chunk_0->version != fw_header.ver) {
-        LT_LOG_ERROR(
-            "RISC-V FW version from bank 2 mismatch: expected "_LT_FW_VER_FMT
-            ", read "_LT_FW_VER_FMT,
-            _LT_FW_VER_ARG(cpu_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
-        return LT_FAIL;
-    }
 
-    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_SPECT2, (uint8_t *)&fw_header, sizeof(fw_header),
-                              &read_header_size);
+    LT_LOG_INFO("Validating FW version in SPECT FW bank 2.");
+    ret = validate_fw_ver_in_bank(h, spect_fw_chunk_0->version, TR01_FW_BANK_SPECT2);
     if (ret != LT_OK) {
-        LT_LOG_ERROR("Failed to read FW header from SPECT FW bank 2.");
         return ret;
-    }
-    if (spect_fw_chunk_0->version != fw_header.ver) {
-        LT_LOG_ERROR(
-            "SPECT FW version from bank 2 mismatch: expected "_LT_FW_VER_FMT
-            ", read "_LT_FW_VER_FMT,
-            _LT_FW_VER_ARG(spect_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
-        return LT_FAIL;
     }
 #endif
 
@@ -2117,17 +2131,21 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
 #if !defined(LT_SILICON_REV_ABAB)
     // 7. Check the updated FW version was booted.
     uint8_t riscv_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+
     ret = lt_get_info_riscv_fw_ver(h, riscv_ver);
     if (ret != LT_OK) {
         LT_LOG_ERROR("Failed to read RISC-V FW version.");
         return ret;
     }
-    if (0 != memcmp(riscv_ver, (uint8_t *)&cpu_fw_chunk_0->version, sizeof(riscv_ver))) {
+    const uint32_t riscv_ver_read = ((uint32_t)riscv_ver[3] << 24) | ((uint32_t)riscv_ver[2] << 16) |
+                                    ((uint32_t)riscv_ver[1] << 8) | (uint32_t)riscv_ver[0];
+
+    if (riscv_ver_read != cpu_fw_chunk_0->version) {
         LT_LOG_ERROR(
-            "Unexpected RISC-V FW version was booted: expected "_LT_FW_VER_FMT
-            ", read "_LT_FW_VER_FMT,
-            _LT_FW_VER_ARG(cpu_fw_chunk_0->version), riscv_ver[3], riscv_ver[2], riscv_ver[1],
-            riscv_ver[0]);
+            "Unexpected RISC-V FW version was booted: expected "_LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT
+            ", read "_LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT,
+            _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(cpu_fw_chunk_0->version),
+            _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(riscv_ver_read));
         return LT_FAIL;
     }
 #endif

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1925,11 +1925,23 @@ lt_ret_t lt_print_chip_id(const struct lt_chip_id_t *chip_id,
     return LT_OK;
 }
 
-lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
-                                 const uint16_t update_data_size, const lt_bank_id_t bank_id)
+/**
+ * @brief Performs mutable firmware update on a specific firmware bank.
+ * @note This function is compatible with all silicon revisions.
+ *
+ * @param h             Handle for communication with TROPIC01
+ * @param fw_data       Firmware update data
+ * @param fw_data_size  Size of firmware update data
+ * @param bank_id       ID of the firmware bank to update. This parameter is used only for ABAB
+ * silicon revision and unused for others (newer silicon revisions handle bank selection
+ * automatically).
+ * @return              LT_OK if success, otherwise returns other error code.
+ */
+static lt_ret_t update_mutable_fw_bank(lt_handle_t *h, const uint8_t *fw_data,
+                                       const size_t fw_data_size, const lt_bank_id_t bank_id)
 {
 #if defined(LT_SILICON_REV_ABAB)
-    if (!h || !update_data || update_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX ||
+    if (!h || !fw_data || fw_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX ||
         ((bank_id != TR01_FW_BANK_FW1) && (bank_id != TR01_FW_BANK_FW2) &&
          (bank_id != TR01_FW_BANK_SPECT1) && (bank_id != TR01_FW_BANK_SPECT2))) {
         return LT_PARAM_ERR;
@@ -1939,25 +1951,25 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
         return ret;
     }
 
-    ret = lt_mutable_fw_update(h, update_data, update_data_size, bank_id);
+    ret = lt_mutable_fw_update(h, fw_data, fw_data_size, bank_id);
     if (ret != LT_OK) {
         return ret;
     }
 
 #elif defined(LT_SILICON_REV_ACAB)
     LT_UNUSED(bank_id);  // bank_id is not used with ACAB, chip handles banks on its own
-    if (!h || !update_data || update_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
+    if (!h || !fw_data || fw_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
         return LT_PARAM_ERR;
     }
 
     // send the update 'request'
-    lt_ret_t ret = lt_mutable_fw_update(h, update_data, update_data_size);
+    lt_ret_t ret = lt_mutable_fw_update(h, fw_data, fw_data_size);
     if (ret != LT_OK) {
         return ret;
     }
 
     // send the rest - update 'data'
-    ret = lt_mutable_fw_update_data(h, update_data, update_data_size);
+    ret = lt_mutable_fw_update_data(h, fw_data, fw_data_size);
     if (ret != LT_OK) {
         return ret;
     }
@@ -1965,6 +1977,166 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *update_data,
 #else
 #error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
 #endif
+
+    return LT_OK;
+}
+
+lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
+                                 const size_t cpu_fw_data_size, const uint8_t *spect_fw_data,
+                                 const size_t spect_fw_data_size)
+{
+    if (!h || !cpu_fw_data || cpu_fw_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX || !spect_fw_data ||
+        spect_fw_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
+        return LT_PARAM_ERR;
+    }
+    lt_ret_t ret;
+
+    // 1. To do FW update, we need to be in Maintenance Mode.
+    ret = lt_reboot(h, TR01_MAINTENANCE_REBOOT);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to reboot into Maintenance Mode before updating the first FW bank pair.");
+        return ret;
+    }
+
+    // 2. Update the first pair of FW banks with RISC-V and SPECT FW.
+    ret = update_mutable_fw_bank(h, cpu_fw_data, cpu_fw_data_size, TR01_FW_BANK_FW1);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to update RISC-V FW bank 1.");
+        return ret;
+    }
+    ret = update_mutable_fw_bank(h, spect_fw_data, spect_fw_data_size, TR01_FW_BANK_SPECT1);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to update SPECT FW bank 1.");
+        return ret;
+    }
+
+    // 3. Reboot into Maintenance Mode. This step is crucial if we want to update both FW banks pairs.
+    // If the reboot is not done, then in the case of ACAB silicon revision, the second FW bank pair
+    // will not be updated, which increases the possibility of a downgrade attack.
+    ret = lt_reboot(h, TR01_MAINTENANCE_REBOOT);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR(
+            "Failed to reboot into Maintenance Mode before updating the second FW bank pair.");
+        return ret;
+    }
+
+    // 4. Update the second pair of FW banks with RISC-V and SPECT FW.
+    ret = update_mutable_fw_bank(h, cpu_fw_data, cpu_fw_data_size, TR01_FW_BANK_FW2);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to update RISC-V FW bank 2.");
+        return ret;
+    }
+    ret = update_mutable_fw_bank(h, spect_fw_data, spect_fw_data_size, TR01_FW_BANK_SPECT2);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to update SPECT FW bank 2.");
+        return ret;
+    }
+
+// 5. Check both FW bank pairs contain the new FW versions. We do this only for ACAB revision and
+// newer, because FW update data for ABAB did not contain information about the FW version.
+#ifndef LT_SILICON_REV_ABAB
+// The two following macros are used for pretty logging of FW versions.
+#define _LT_FW_VER_FMT                              \
+    "'"                                             \
+    "%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(.%" PRIu32 \
+    ")"                                             \
+    "'"
+#define _LT_FW_VER_ARG(v) (((v) >> 24) & 0xFF), (((v) >> 16) & 0xFF), (((v) >> 8) & 0xFF), ((v) & 0xFF)
+
+    lt_header_boot_v2_t fw_header;
+    uint16_t read_header_size;
+    lt_mutable_fw_update_chunk_0_t *cpu_fw_chunk_0 = (lt_mutable_fw_update_chunk_0_t *)(cpu_fw_data);
+    lt_mutable_fw_update_chunk_0_t *spect_fw_chunk_0 =
+        (lt_mutable_fw_update_chunk_0_t *)(spect_fw_data);
+
+    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_FW1, (uint8_t *)&fw_header, sizeof(fw_header),
+                              &read_header_size);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to read FW header from RISC-V FW bank 1.");
+        return ret;
+    }
+    if (cpu_fw_chunk_0->version != fw_header.ver) {
+        LT_LOG_ERROR(
+            "RISC-V FW version from bank 1 mismatch: expected "_LT_FW_VER_FMT
+            ", read "_LT_FW_VER_FMT,
+            _LT_FW_VER_ARG(cpu_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
+        return LT_FAIL;
+    }
+
+    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_SPECT1, (uint8_t *)&fw_header, sizeof(fw_header),
+                              &read_header_size);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to read FW header from SPECT FW bank 1.");
+        return ret;
+    }
+    if (spect_fw_chunk_0->version != fw_header.ver) {
+        LT_LOG_ERROR(
+            "SPECT FW version from bank 1 mismatch: expected "_LT_FW_VER_FMT
+            ", read "_LT_FW_VER_FMT,
+            _LT_FW_VER_ARG(spect_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
+        return LT_FAIL;
+    }
+
+    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_FW2, (uint8_t *)&fw_header, sizeof(fw_header),
+                              &read_header_size);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to read FW header from RISC-V FW bank 2.");
+        return ret;
+    }
+    if (cpu_fw_chunk_0->version != fw_header.ver) {
+        LT_LOG_ERROR(
+            "RISC-V FW version from bank 2 mismatch: expected "_LT_FW_VER_FMT
+            ", read "_LT_FW_VER_FMT,
+            _LT_FW_VER_ARG(cpu_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
+        return LT_FAIL;
+    }
+
+    ret = lt_get_info_fw_bank(h, TR01_FW_BANK_SPECT2, (uint8_t *)&fw_header, sizeof(fw_header),
+                              &read_header_size);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to read FW header from SPECT FW bank 2.");
+        return ret;
+    }
+    if (spect_fw_chunk_0->version != fw_header.ver) {
+        LT_LOG_ERROR(
+            "SPECT FW version from bank 2 mismatch: expected "_LT_FW_VER_FMT
+            ", read "_LT_FW_VER_FMT,
+            _LT_FW_VER_ARG(spect_fw_chunk_0->version), _LT_FW_VER_ARG(fw_header.ver));
+        return LT_FAIL;
+    }
+#endif
+
+    // 6. Perform regular reboot (Application FW should boot).
+    ret = lt_reboot(h, TR01_REBOOT);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to boot Application FW.");
+        return ret;
+    }
+
+#ifndef LT_SILICON_REV_ABAB
+    // 7. Check the updated FW version was booted.
+    uint8_t riscv_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+    ret = lt_get_info_riscv_fw_ver(h, riscv_ver);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to read RISC-V FW version.");
+        return ret;
+    }
+    if (0 != memcmp(riscv_ver, (uint8_t *)&cpu_fw_chunk_0->version, sizeof(riscv_ver))) {
+        LT_LOG_ERROR(
+            "Unexpected RISC-V FW version was booted: expected "_LT_FW_VER_FMT
+            ", read "_LT_FW_VER_FMT,
+            _LT_FW_VER_ARG(cpu_fw_chunk_0->version), riscv_ver[3], riscv_ver[2], riscv_ver[1],
+            riscv_ver[0]);
+        return LT_FAIL;
+    }
+#endif
+
+    // 8. Reinitialize TROPIC01 attributes based on its Application FW version.
+    ret = lt_init_tr01_attrs(h);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("lt_init_tr01_attrs() failed.");
+        return ret;
+    }
 
     return LT_OK;
 }

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -2130,8 +2130,9 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
     }
 
 #if !defined(LT_SILICON_REV_ABAB)
-    // 7. Check the updated FW version was booted.
+    // 7. Check the updated FW versions were booted.
     uint8_t riscv_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+    uint8_t spect_ver[TR01_L2_GET_INFO_SPECT_FW_SIZE];
 
     ret = lt_get_info_riscv_fw_ver(h, riscv_ver);
     if (ret != LT_OK) {
@@ -2147,6 +2148,23 @@ lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
             ", read "_LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT,
             _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(cpu_fw_chunk_0->version),
             _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(riscv_ver_read));
+        return LT_FAIL;
+    }
+
+    ret = lt_get_info_spect_fw_ver(h, spect_ver);
+    if (ret != LT_OK) {
+        LT_LOG_ERROR("Failed to read SPECT FW version.");
+        return ret;
+    }
+    const uint32_t spect_ver_read = ((uint32_t)spect_ver[3] << 24) | ((uint32_t)spect_ver[2] << 16) |
+                                    ((uint32_t)spect_ver[1] << 8) | (uint32_t)spect_ver[0];
+
+    if (spect_ver_read != spect_fw_chunk_0->version) {
+        LT_LOG_ERROR(
+            "Unexpected SPECT FW version was booted: expected "_LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT
+            ", read "_LT_DO_MUTABLE_FW_UPDATE_FW_VER_FMT,
+            _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(spect_fw_chunk_0->version),
+            _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(spect_ver_read));
         return LT_FAIL;
     }
 #endif

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -712,7 +712,7 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size
     struct lt_l2_mutable_fw_update_rsp_t *p_l2_resp = (struct lt_l2_mutable_fw_update_rsp_t *)
                                                           h->l2.buff;
 
-    // Setup a pointer to incomming data
+    // Setup a pointer to incoming data
     const struct lt_mutable_fw_update_chunk_0_t *fw_chunk_0 =
         (const struct lt_mutable_fw_update_chunk_0_t *)(fw_data);
 

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -701,7 +701,8 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size
 #elif defined(LT_SILICON_REV_ACAB)
 lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size_t fw_data_size)
 {
-    if (!h || !fw_data || fw_data_size < sizeof(lt_mutable_fw_update_chunk_0_t)) {
+    if (!h || !fw_data || fw_data_size < sizeof(lt_mutable_fw_update_chunk_0_t) ||
+        fw_data_size > TR01_MUTABLE_FW_UPDATE_SIZE_MAX) {
         return LT_PARAM_ERR;
     }
 

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -705,18 +705,6 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *update_request)
         return LT_PARAM_ERR;
     }
 
-    // This structure reflects incomming data and is used for passing those data into l2 frame
-    struct data_format_t {
-        uint8_t req_len;       /**< Length byte */
-        uint8_t signature[64]; /**< Signature of SHA256 hash of all following data in this packet */
-        uint8_t
-            hash[32];  /**< SHA256 HASH of first FW chunk of data sent using Mutable_FW_Update_Data */
-        uint16_t type; /**< FW type which is going to be updated */
-        uint8_t padding;        /**< Padding, zero value */
-        uint8_t header_version; /**< Version of used header */
-        uint32_t version;       /**< Version of FW */
-    } __attribute__((__packed__));
-
     // Setup a request pointer to l2 buffer, which is placed in handle
     struct lt_l2_mutable_fw_update_req_t *p_l2_req = (struct lt_l2_mutable_fw_update_req_t *)
                                                          h->l2.buff;
@@ -725,18 +713,19 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *update_request)
                                                           h->l2.buff;
 
     // Setup a pointer to incomming data
-    struct data_format_t *data_p = (struct data_format_t *)(update_request);
+    struct lt_mutable_fw_update_chunk_0_t *fw_chunk_0 =
+        (struct lt_mutable_fw_update_chunk_0_t *)(update_request);
 
     p_l2_req->req_id = TR01_L2_MUTABLE_FW_UPDATE_REQ_ID;
     p_l2_req->req_len = TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN;
 
-    memcpy(p_l2_req->signature, data_p->signature, sizeof(data_p->signature));
-    memcpy(p_l2_req->hash, data_p->hash, sizeof(data_p->hash));
+    memcpy(p_l2_req->signature, fw_chunk_0->signature, sizeof(fw_chunk_0->signature));
+    memcpy(p_l2_req->hash, fw_chunk_0->hash, sizeof(fw_chunk_0->hash));
 
-    p_l2_req->type = data_p->type;
-    p_l2_req->padding = data_p->padding;
-    p_l2_req->header_version = data_p->header_version;
-    p_l2_req->version = data_p->version;
+    p_l2_req->type = fw_chunk_0->type;
+    p_l2_req->padding = fw_chunk_0->padding;
+    p_l2_req->header_version = fw_chunk_0->header_version;
+    p_l2_req->version = fw_chunk_0->version;
 
     lt_ret_t ret = lt_l2_send(&h->l2);
     if (ret != LT_OK) {

--- a/tests/functional/src/lt_test_rev_param_check.c
+++ b/tests/functional/src/lt_test_rev_param_check.c
@@ -292,8 +292,10 @@ void lt_test_rev_param_check(lt_handle_t *h)
 #elif defined(LT_SILICON_REV_ACAB)
     {
         uint8_t dummy_data[1];
-        LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_update(NULL, dummy_data));
-        LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_update(h, NULL));
+        LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_update(NULL, dummy_data, sizeof(dummy_data)));
+        LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_update(h, NULL, sizeof(dummy_data)));
+        LT_TEST_ASSERT(LT_PARAM_ERR, lt_mutable_fw_update(h, dummy_data,
+                                                          sizeof(lt_mutable_fw_update_chunk_0_t) - 1));
 
         LT_TEST_ASSERT(LT_PARAM_ERR,
                        lt_mutable_fw_update_data(NULL, dummy_data, TR01_L2_MUTABLE_FW_UPDATE_REQ_LEN));
@@ -357,11 +359,16 @@ void lt_test_rev_param_check(lt_handle_t *h)
     {
         uint8_t data[1] = {0};
         LT_TEST_ASSERT(LT_PARAM_ERR,
-                       lt_do_mutable_fw_update(NULL, data, sizeof(data), TR01_FW_BANK_FW1));
-        LT_TEST_ASSERT(LT_PARAM_ERR, lt_do_mutable_fw_update(h, NULL, sizeof(data), TR01_FW_BANK_FW1));
-        LT_TEST_ASSERT(LT_PARAM_ERR, lt_do_mutable_fw_update(
-                                         h, data, (uint16_t)(TR01_MUTABLE_FW_UPDATE_SIZE_MAX + 1),
-                                         TR01_FW_BANK_FW1));
+                       lt_do_mutable_fw_update(NULL, data, sizeof(data), data, sizeof(data)));
+        LT_TEST_ASSERT(LT_PARAM_ERR,
+                       lt_do_mutable_fw_update(h, NULL, sizeof(data), data, sizeof(data)));
+        LT_TEST_ASSERT(LT_PARAM_ERR,
+                       lt_do_mutable_fw_update(h, data, (TR01_MUTABLE_FW_UPDATE_SIZE_MAX + 1), data,
+                                               sizeof(data)));
+        LT_TEST_ASSERT(LT_PARAM_ERR,
+                       lt_do_mutable_fw_update(h, data, sizeof(data), NULL, sizeof(data)));
+        LT_TEST_ASSERT(LT_PARAM_ERR, lt_do_mutable_fw_update(h, data, sizeof(data), data,
+                                                             (TR01_MUTABLE_FW_UPDATE_SIZE_MAX + 1)));
     }
 
     {


### PR DESCRIPTION
## Description

This PR mainly reworks the current `lt_do_mutable_fw_update()` helper:
- it does all the steps from the FW update appnote (its old version was transformed into a `static` function, which is utilized in the new version),
- simplifies its API,
- reinitializes libtropic's tropic01 attributes (used to determine behavior based on App FW at runtime) in the end.

Moreover, this PR also implements the following:
- FW update documentation update,
- updated all FW update examples to use the reworked `lt_do_mutable_fw_update()` helper and to print the version that is about to be updated (was only in linux examples),
- Enhances descriptions of all FW update related functions,
- Unified parameter names of all FW update related functions,
- `fw_data_size` parameter was missing in `lt_mutable_fw_update()` ACAB version, in the other functions the type was changed to `size_t` (future-proofing),
- locally declared `struct data_format_t` in `lt_mutable_fw_update()` renamed to `struct lt_mutable_fw_update_chunk_0_t` and moved to `libtropic_common.h`, so it can be used in multiple API functions,
- updated the current CI job to also build FW update example for ABAB.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [x] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---