### PR TITLE
feat(stm32 examples): add support for TROPIC01 GPO pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - STM32L4xx HAL: support for TROPIC01 GPO pin.
 - Arrays to firmware update files which contain firmware version of the update: `fw_CPU_ver`, `fw_SPECT_ver`.
 - `fw_data_size` parameter to `lt_mutable_fw_update()` (ACAB version).
+- STM32 L432KC examples: support for TROPIC01 GPO pin.
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
@@ -39,10 +39,6 @@ project(
 #                                                                         #
 ###########################################################################
 
-if (LT_USE_INT_PIN)
-    message(FATAL_ERROR "Using interrupt pin is currently not supported on Nucleo L432KC board")
-endif()
-
 # Serial number of the STLink device which will be used for flashing.
 # You need to define this only if you have multiple STM32s connected using built-in STLink or 
 # problems with OpenOCD's autodetection.

--- a/examples/stm32/nucleo_l432kc/fw_update/Inc/main.h
+++ b/examples/stm32/nucleo_l432kc/fw_update/Inc/main.h
@@ -71,6 +71,16 @@
 #define SPIx_MOSI_GPIO_PORT GPIOA
 #define SPIx_MOSI_AF GPIO_AF5_SPI1
 
+#if LT_USE_INT_PIN
+/* Definition for GPIO interrupt pin clock resources
+ * Following GPIO is used to check on INT pin for READY signal during communication.
+ */
+#define LT_INT_BANK GPIOA
+#define LT_INT_PIN GPIO_PIN_11
+/* Definition for GPIO interrupt pin clock resources */
+#define LT_INT_CLK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
+#endif
+
 /* Exported variables ------------------------------------------------------- */
 extern RNG_HandleTypeDef RNGHandle;
 

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -291,6 +291,13 @@ int main(void)
         at the beginning of your application using HAL_RNG_Init()! */
     device.rng_handle = &RNGHandle;
 
+#ifdef LT_USE_INT_PIN
+    /* Enable clock of the GPIO bank where interrupt input is present. */
+    LT_INT_CLK_ENABLE(); /* Defined in main.h. */
+    device.int_gpio_bank = LT_INT_BANK;
+    device.int_gpio_pin = LT_INT_PIN;
+#endif
+
     lt_handle.l2.device = &device;
 
     /* Crypto abstraction layer (CAL) context. */

--- a/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
@@ -39,10 +39,6 @@ project(
 #                                                                         #
 ###########################################################################
 
-if(LT_USE_INT_PIN)
-    message(FATAL_ERROR "Using interrupt pin is currently not supported on Nucleo L432KC board")
-endif()
-
 # Serial number of the STLink device which will be used for flashing.
 # You need to define this only if you have multiple STM32s connected using built-in STLink or 
 # problems with OpenOCD's autodetection.

--- a/examples/stm32/nucleo_l432kc/hello_world/Inc/main.h
+++ b/examples/stm32/nucleo_l432kc/hello_world/Inc/main.h
@@ -71,6 +71,16 @@
 #define SPIx_MOSI_GPIO_PORT GPIOA
 #define SPIx_MOSI_AF GPIO_AF5_SPI1
 
+#if LT_USE_INT_PIN
+/* Definition for GPIO interrupt pin clock resources
+ * Following GPIO is used to check on INT pin for READY signal during communication.
+ */
+#define LT_INT_BANK GPIOA
+#define LT_INT_PIN GPIO_PIN_11
+/* Definition for GPIO interrupt pin clock resources */
+#define LT_INT_CLK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
+#endif
+
 /* Exported variables ------------------------------------------------------- */
 extern RNG_HandleTypeDef RNGHandle;
 

--- a/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
@@ -262,6 +262,13 @@ int main(void)
         at the beginning of your application using HAL_RNG_Init()! */
     device.rng_handle = &RNGHandle;
 
+#ifdef LT_USE_INT_PIN
+    /* Enable clock of the GPIO bank where interrupt input is present. */
+    LT_INT_CLK_ENABLE(); /* Defined in main.h. */
+    device.int_gpio_bank = LT_INT_BANK;
+    device.int_gpio_pin = LT_INT_PIN;
+#endif
+
     lt_handle.l2.device = &device;
 
     /* Crypto abstraction layer (CAL) context. */

--- a/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
@@ -39,10 +39,6 @@ project(
 #                                                                         #
 ###########################################################################
 
-if(LT_USE_INT_PIN)
-    message(FATAL_ERROR "Using interrupt pin is currently not supported on Nucleo L432KC board")
-endif()
-
 # Serial number of the STLink device which will be used for flashing.
 # You need to define this only if you have multiple STM32s connected using built-in STLink or 
 # problems with OpenOCD's autodetection.

--- a/examples/stm32/nucleo_l432kc/identify_chip/Inc/main.h
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Inc/main.h
@@ -71,6 +71,16 @@
 #define SPIx_MOSI_GPIO_PORT GPIOA
 #define SPIx_MOSI_AF GPIO_AF5_SPI1
 
+#if LT_USE_INT_PIN
+/* Definition for GPIO interrupt pin clock resources
+ * Following GPIO is used to check on INT pin for READY signal during communication.
+ */
+#define LT_INT_BANK GPIOA
+#define LT_INT_PIN GPIO_PIN_11
+/* Definition for GPIO interrupt pin clock resources */
+#define LT_INT_CLK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
+#endif
+
 /* Exported variables ------------------------------------------------------- */
 extern RNG_HandleTypeDef RNGHandle;
 

--- a/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
@@ -259,6 +259,13 @@ int main(void)
         at the beginning of your application using HAL_RNG_Init()! */
     device.rng_handle = &RNGHandle;
 
+#ifdef LT_USE_INT_PIN
+    /* Enable clock of the GPIO bank where interrupt input is present. */
+    LT_INT_CLK_ENABLE(); /* Defined in main.h. */
+    device.int_gpio_bank = LT_INT_BANK;
+    device.int_gpio_pin = LT_INT_PIN;
+#endif
+
     lt_handle.l2.device = &device;
 
     /* Crypto abstraction layer (CAL) context. */


### PR DESCRIPTION
## Description

This should have been added in [this PR](https://github.com/tropicsquare/libtropic/pull/503), but it was forgotten. All examples for STM32 L432KC now support the GPO pin.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---