### PR TITLE
ETR01SDK-623: Fix DOWNLOAD_EXTRACT_TIMESTAMP not supported in CMake versions before 3.24

### DIFF
--- a/examples/linux/spi/full_chain_verification/CMakeLists.txt
+++ b/examples/linux/spi/full_chain_verification/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -50,7 +54,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/spi/fw_update/CMakeLists.txt
+++ b/examples/linux/spi/fw_update/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -53,7 +57,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/spi/hello_world/CMakeLists.txt
+++ b/examples/linux/spi/hello_world/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -75,7 +79,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/spi/identify_chip/CMakeLists.txt
+++ b/examples/linux/spi/identify_chip/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -53,7 +57,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/ecc_eddsa/CMakeLists.txt
+++ b/examples/linux/usb_devkit/ecc_eddsa/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -69,7 +73,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/full_chain_verification/CMakeLists.txt
+++ b/examples/linux/usb_devkit/full_chain_verification/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -44,7 +48,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/fw_update/CMakeLists.txt
+++ b/examples/linux/usb_devkit/fw_update/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -48,7 +52,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/hello_world/CMakeLists.txt
+++ b/examples/linux/usb_devkit/hello_world/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -69,7 +73,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/linux/usb_devkit/identify_chip/CMakeLists.txt
+++ b/examples/linux/usb_devkit/identify_chip/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -48,7 +52,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/model/hello_world/CMakeLists.txt
+++ b/examples/model/hello_world/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -47,7 +51,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/model/hw_wallet/CMakeLists.txt
+++ b/examples/model/hw_wallet/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -47,7 +51,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)
@@ -58,7 +61,6 @@ FetchContent_Declare(
     ed25519
     URL https://github.com/orlp/ed25519/archive/b1f19fab4aebe607805620d25a5e42566ce46a0e.zip
     URL_HASH SHA256=75f39e64f22ec7474e7881315a3f9135afe6c990737388fb16a6950911b55721
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(ed25519)
 

--- a/examples/model/mac_and_destroy/CMakeLists.txt
+++ b/examples/model/mac_and_destroy/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -47,7 +51,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/model/separate_api/CMakeLists.txt
+++ b/examples/model/separate_api/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up projects and paths                                             #
@@ -47,7 +51,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(mbedtls_v4)
 target_link_libraries(tropic PUBLIC mbedtls)

--- a/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up project and paths                                              #
@@ -86,7 +90,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_f439zi/hello_world/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/hello_world/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up project and paths                                              #
@@ -86,7 +90,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up project and paths                                              #
@@ -85,7 +89,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up project and paths                                              #
@@ -90,7 +94,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/hello_world/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up project and paths                                              #
@@ -90,7 +94,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21.0)
 include (FetchContent)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up project and paths                                              #
@@ -90,7 +94,6 @@ FetchContent_Declare(
     mbedtls_v4
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
     URL_HASH SHA256=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 
 # We configure MbedTLS using config file with following configuration:

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.21)
 
 project(libtropic_functional_mock_tests)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # Timestamp extraction policy
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Paths and setup                                                       #
@@ -68,7 +72,6 @@ add_subdirectory("${PATH_TO_LIBTROPIC}cal/mbedtls_v4" "cal_mbedtls_v4")
 FetchContent_Declare(
     mbedtls
     URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.0.0/mbedtls-4.0.0.tar.bz2
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 set(ENABLE_TESTING OFF CACHE BOOL "Disable mbedtls_v4 test building.")
 set(ENABLE_PROGRAMS OFF CACHE BOOL "Disable mbedtls_v4 examples building.")


### PR DESCRIPTION
## Description

CMake versions before 3.24 does not support DOWNLOAD_EXTRACT_TIMESTAMP. In this PR I solve it by removing the parameter and setting CMP0135 policy based on CMake version. The policy allows us to "globally" define the behavior across the whole file, thus eliminating the need of having `if version` branches on each `FetchDeclare` occurence in the file.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage