### PR TITLE
ETR01SDK-262: optimize CRC error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - STM32 L432KC examples: support for TROPIC01 GPO pin.
 - FW update examples: recommended handling of Maintenance Mode to reduce the attack surface.
 - Examples: Added examples for STM32 Nucleo U545RE-Q board: Hello World, FW Update, Chip Identification.
+- Diagnostic counters for tracking CRC errors to `lt_l2_state`: `l2_crc_error_count`, `l2_in_crc_error_count`.
+- Implemented retry mechanism on L2 Layer in the case of CRC errors:
+  - Count of retries can be configured using `LT_CRC_ERR_RETRY_ATTEMPTS` parameter/macro. Default value is 3 retries.
+  - See [`LT_CRC_ERR_RETRY_ATTEMPTS` section](https://tropicsquare.github.io/libtropic/latest/reference/integrating_libtropic/how_to_configure/#lt_crc_err_retry_attempts) in "How to Configure" page of the documentation to learn how the retry mechanism works.
+- FAQ section covering `LT_L2_CRC_ERR` and `LT_L2_IN_CRC_ERR`.
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - STM32 L432KC examples: support for TROPIC01 GPO pin.
 - FW update examples: recommended handling of Maintenance Mode to reduce the attack surface.
 - Examples: Added examples for STM32 Nucleo U545RE-Q board: Hello World, FW Update, Chip Identification.
+- `lt_l2_transfer`: this function combines `lt_l2_send`, `lt_l2_receive` and implements retry mechanism on CRC errors. If using separate API functionality, it is recommended to use `lt_l2_transfer`.
 - Diagnostic counters for tracking CRC errors to `lt_l2_state`: `l2_crc_error_count`, `l2_in_crc_error_count`.
 - Implemented retry mechanism on L2 Layer in the case of CRC errors:
   - Count of retries can be configured using `LT_CRC_ERR_RETRY_ATTEMPTS` parameter/macro. Default value is 3 retries.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,4 +294,4 @@ if(LT_RETRIEVE_ALARM_LOG)
     target_compile_definitions(tropic PUBLIC LT_RETRIEVE_ALARM_LOG)
 endif()
 
-target_compile_definitions(tropic PRIVATE LT_CRC_ERR_RESEND_ATTEMPTS=${LT_CRC_ERR_RESEND_ATTEMPTS)
+target_compile_definitions(tropic PRIVATE LT_CRC_ERR_RESEND_ATTEMPTS=${LT_CRC_ERR_RESEND_ATTEMPTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,16 @@ else()
     message(FATAL_ERROR "Incorrect logging level specified: '${LT_LOG_LVL}'\nAvailable logging levels: ${lt_log_lvl_choices}")
 endif()
 
+# Set count of attempts to:
+# - resend request in case of LT_L2_CRC_ERR is received
+# - ask TROPIC01 to resend response in case of LT_L2_IN_CRC_ERR is received
+# Must be non-negative. Set to 0 to disable automatic resending.
+set(LT_CRC_ERR_RESEND_ATTEMPTS "3" CACHE STRING "Count of attempts to resend request/response on CRC or IN_CRC error.")
+
+if(NOT LT_CRC_ERR_RESEND_ATTEMPTS MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "LT_CRC_ERR_RESEND_ATTEMPTS must be a non-negative integer, got '${LT_CRC_ERR_RESEND_ATTEMPTS}'")
+endif()
+
 # Check whether compiling standalone (e.g. as a library) or as a child project (= has parent scope)
 # and save result to HAS_PARENT_SCOPE.
 get_directory_property(HAS_PARENT_SCOPE PARENT_DIRECTORY)
@@ -283,3 +293,5 @@ endif()
 if(LT_RETRIEVE_ALARM_LOG)
     target_compile_definitions(tropic PUBLIC LT_RETRIEVE_ALARM_LOG)
 endif()
+
+target_compile_definitions(tropic PRIVATE LT_CRC_ERR_RESEND_ATTEMPTS=${LT_CRC_ERR_RESEND_ATTEMPTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,8 @@ endif()
 # Must be non-negative. Set to 0 to disable automatic resending.
 set(LT_CRC_ERR_RETRY_ATTEMPTS "3" CACHE STRING "Count of attempts to resend request/response on CRC or IN_CRC error.")
 
-if(NOT LT_CRC_ERR_RETRY_ATTEMPTS MATCHES "^[0-9]+$")
-    message(FATAL_ERROR "LT_CRC_ERR_RETRY_ATTEMPTS must be a non-negative integer, got '${LT_CRC_ERR_RETRY_ATTEMPTS}'")
+if(NOT LT_CRC_ERR_RETRY_ATTEMPTS MATCHES "^(0|[1-9][0-9]*)$")
+    message(FATAL_ERROR "LT_CRC_ERR_RETRY_ATTEMPTS must be a non-negative integer without leading zeros unless the value is exactly '0', got '${LT_CRC_ERR_RETRY_ATTEMPTS}'")
 endif()
 
 # Check whether compiling standalone (e.g. as a library) or as a child project (= has parent scope)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,4 +294,4 @@ if(LT_RETRIEVE_ALARM_LOG)
     target_compile_definitions(tropic PUBLIC LT_RETRIEVE_ALARM_LOG)
 endif()
 
-target_compile_definitions(tropic PRIVATE LT_CRC_ERR_RETRY_ATTEMPTS=${LT_CRC_ERR_RETRY_ATTEMPTS})
+target_compile_definitions(tropic PUBLIC LT_CRC_ERR_RETRY_ATTEMPTS=${LT_CRC_ERR_RETRY_ATTEMPTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,10 +101,10 @@ endif()
 # - resend request in case of LT_L2_CRC_ERR is received
 # - ask TROPIC01 to resend response in case of LT_L2_IN_CRC_ERR is received
 # Must be non-negative. Set to 0 to disable automatic resending.
-set(LT_CRC_ERR_RESEND_ATTEMPTS "3" CACHE STRING "Count of attempts to resend request/response on CRC or IN_CRC error.")
+set(LT_CRC_ERR_RETRY_ATTEMPTS "3" CACHE STRING "Count of attempts to resend request/response on CRC or IN_CRC error.")
 
-if(NOT LT_CRC_ERR_RESEND_ATTEMPTS MATCHES "^[0-9]+$")
-    message(FATAL_ERROR "LT_CRC_ERR_RESEND_ATTEMPTS must be a non-negative integer, got '${LT_CRC_ERR_RESEND_ATTEMPTS}'")
+if(NOT LT_CRC_ERR_RETRY_ATTEMPTS MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "LT_CRC_ERR_RETRY_ATTEMPTS must be a non-negative integer, got '${LT_CRC_ERR_RETRY_ATTEMPTS}'")
 endif()
 
 # Check whether compiling standalone (e.g. as a library) or as a child project (= has parent scope)
@@ -294,4 +294,4 @@ if(LT_RETRIEVE_ALARM_LOG)
     target_compile_definitions(tropic PUBLIC LT_RETRIEVE_ALARM_LOG)
 endif()
 
-target_compile_definitions(tropic PRIVATE LT_CRC_ERR_RESEND_ATTEMPTS=${LT_CRC_ERR_RESEND_ATTEMPTS})
+target_compile_definitions(tropic PRIVATE LT_CRC_ERR_RETRY_ATTEMPTS=${LT_CRC_ERR_RETRY_ATTEMPTS})

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,6 +66,18 @@ ERROR   [ 101] Error opening serial at "/dev/ttyACM0".
 
 This is likely a permissions issue. Try adding your user account to the groups that provide access to the device you are using (for example, `dialout` or `plugdev` for USB serial devices, and `spi` for SPI devices). Refer to documentation of your distribution for details.
 
+### `LT_L2_CRC_ERR` or `LT_L2_IN_CRC_ERR`
+This error means that either TROPIC01 received a corrupted frame (`LT_L2_CRC_ERR`) or the MCU received a corrupted frame (`LT_L2_IN_CRC_ERR`).
+
+Libtropic will try to retry the communication by default and return the error only after all retry attempts are depleted.
+
+It hints that the connection is unstable. You can try the following:
+
+- Use high-quality wiring and firm connectors.
+- Minimize the length of the connections as much as possible.
+- Try to lower the communication speed.
+- Increase the number of retries: see [`LT_CRC_ERR_RETRY_ATTEMPTS` parameter](reference/integrating_libtropic/how_to_configure/index.md#lt_crc_err_retry_attempts). This is not recommended, it is always better to find the cause of the connection instability.
+
 ## I cannot establish a Secure Session
 There are two main causes:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -83,7 +83,7 @@ These counters are reset automatically on Libtropic initialization (in `lt_init`
 
 #### Possible causes and solutions
 
-CRC errors hints that the connection is unstable. You can try the following:
+CRC errors hint that the connection is unstable. You can try the following:
 
 - Use high-quality wiring and firm connectors. Poor DuPont (jump) wires combined with cheap breadboards are common causes of connection issues.
 - Minimize the length of the connections as much as possible.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,6 +81,9 @@ To diagnose CRC-related errors, we provide two counters in `lt_l2_state_t`:
 
 These counters are reset automatically on Libtropic initialization (in `lt_init`).
 
+!!! important "Counters and separate API"
+    If you use separate API, you need to use `lt_l2_transfer` for counters to be updated automatically, not `lt_l2_send` and `lt_l2_receive`.
+
 #### Possible causes and solutions
 
 CRC errors hint that the connection is unstable. You can try the following:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,6 +10,7 @@ This list might help you resolve some issues.
     - [`LT_L3_DATA_LEN_ERROR`](#lt_l3_data_len_error)
     - [`LT_L3_INVALID_CMD` or `LT_L2_UNKNOWN_REQ`](#lt_l3_invalid_cmd-or-lt_l2_unknown_req)
     - [`LT_FAIL`](#lt_fail)
+    - [`LT_L2_CRC_ERR` or `LT_L2_IN_CRC_ERR`](#lt_l2_crc_err-or-lt_l2_in_crc_err)
   - [I cannot establish a Secure Session](#i-cannot-establish-a-secure-session)
   - [FW update failed](#fw-update-failed)
   - [What is the part number (P/N) of my TROPIC01?](#what-is-the-part-number-pn-of-my-tropic01)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,13 +67,24 @@ ERROR   [ 101] Error opening serial at "/dev/ttyACM0".
 This is likely a permissions issue. Try adding your user account to the groups that provide access to the device you are using (for example, `dialout` or `plugdev` for USB serial devices, and `spi` for SPI devices). Refer to documentation of your distribution for details.
 
 ### `LT_L2_CRC_ERR` or `LT_L2_IN_CRC_ERR`
-This error means that either TROPIC01 received a corrupted frame (`LT_L2_CRC_ERR`) or the MCU received a corrupted frame (`LT_L2_IN_CRC_ERR`).
+This error means that either TROPIC01 received a corrupted frame (`LT_L2_CRC_ERR`) or the host received a corrupted frame (`LT_L2_IN_CRC_ERR`).
 
 Libtropic will try to retry the communication by default and return the error only after all retry attempts are depleted.
 
-It hints that the connection is unstable. You can try the following:
+#### Diagnostics
 
-- Use high-quality wiring and firm connectors.
+To diagnose CRC-related errors, we provide two counters in `lt_l2_state_t`: 
+
+- `l2_in_crc_error_count` tracks number of corrupted frames received by the host.
+- `l2_crc_error_count` tracks number of corrupted frames received by the TROPIC01.
+
+These counters are reset automatically on Libtropic initialization (in `lt_init`).
+
+#### Possible causes and solutions
+
+CRC errors hints that the connection is unstable. You can try the following:
+
+- Use high-quality wiring and firm connectors. Poor DuPont (jump) wires combined with cheap breadboards are common causes of connection issues.
 - Minimize the length of the connections as much as possible.
 - Try to lower the communication speed.
 - Increase the number of retries: see [`LT_CRC_ERR_RETRY_ATTEMPTS` parameter](reference/integrating_libtropic/how_to_configure/index.md#lt_crc_err_retry_attempts). This is not recommended, it is always better to find the cause of the connection instability.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -82,3 +82,30 @@ Defines the TROPIC01's RISC-V CPU FW version (e.g. `"1_0_1"`) to update to. It i
 
 !!! tip "See Current Configuration"
     Use `cmake -LAH | grep -B 1 LT_` to check current value of all Libtropic options.
+
+### `LT_CRC_ERR_RETRY_ATTEMPTS`
+- integer (non-negative)
+- default value: 3
+
+Defines a count of attempts to retry the communication after recieving a frame with `STATUS` field equal to `CRC_ERR` (`LT_L2_CRC_ERR`) or a frame with invalid CRC (`LT_L2_IN_CRC_ERR`).
+
+In the first case, Libtropic will try send the original Request again. In the second case, Libtropic will send the Resend Request (`Resend_Req`).
+
+Both errors share a counter.
+
+!!! example
+    If Libtropic receives a frame with `STATUS=CRC_ERR` followed by two frames with invalid CRC (during retry attempts), counter is depleted for that communication (single invocation of L2 API function or a single L3 chunk, see below).
+
+Error counter applies always to a single L2 frame and resets itself:
+
+- it starts at zero on each invocation of L2 API function (e.g., `lt_get_info_chip_id`),
+    
+    !!! example
+        Even if the first call `lt_get_info_chip_id` depletes all retry attempts, second call of `lt_get_info_chip_id` (or any other L2 API function) starts with all retry attempts available again.
+
+- it starts at zero on each chunk of L3 Command/Result in L3 API functions (e.g., `lt_ping`).
+
+    !!! example
+        Even if two errors occur during transmission of the first chunk, the second chunk starts with all retry attempts available again.
+
+You can disable this functionality by setting the parameter to zero.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -87,10 +87,10 @@ Defines the TROPIC01's RISC-V CPU FW version (e.g. `"1_0_1"`) to update to. It i
 - integer (non-negative)
 - default value: 3
 
-Defines how many times Libtropic retries communication after one of the following CRC-related errors:
+Defines how many times Libtropic retries communication after either of the following CRC-related errors:
 
 - An L2 Response frame with `STATUS=CRC_ERR` (`LT_L2_CRC_ERR`).
-- An L2 Response frame with an invalid CRC in `RSP_CRC` field (`LT_L2_IN_CRC_ERR`).
+- An L2 Response frame with an invalid CRC in the `RSP_CRC` field (`LT_L2_IN_CRC_ERR`).
 
 Retry behavior:
 
@@ -100,7 +100,7 @@ Retry behavior:
 Both error types use the same retry counter.
 
 !!! example
-    If Libtropic receives a frame with `STATUS=CRC_ERR` and then two L2 Response frames with invalid CRC (during retries), the retry counter is exhausted for that communication (a single L2 API call or a single L3 chunk; see below).
+    If Libtropic receives a frame with `STATUS=CRC_ERR` and then two L2 Response frames with invalid CRC during retries, the retry counter is exhausted for that communication (a single L2 API call or a single L3 chunk; see below).
 
 !!! important
     This retry counter is independent of CRC diagnostic counters (see [FAQ](../../../faq.md)). CRC diagnostic counters track the total number of CRC errors since initialization (`lt_init`).
@@ -117,4 +117,4 @@ The counter scope is always one L2 frame operation:
     !!! example
         Even if two errors occur while transmitting the first chunk, the second chunk starts with a fresh retry counter.
 
-Set this parameter to zero to disable retrying.
+Set this parameter to zero to disable retries.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -87,25 +87,34 @@ Defines the TROPIC01's RISC-V CPU FW version (e.g. `"1_0_1"`) to update to. It i
 - integer (non-negative)
 - default value: 3
 
-Defines a count of attempts to retry the communication after recieving a frame with `STATUS` field equal to `CRC_ERR` (`LT_L2_CRC_ERR`) or a frame with invalid CRC (`LT_L2_IN_CRC_ERR`).
+Defines how many times Libtropic retries communication after one of the following CRC-related errors:
 
-In the first case, Libtropic will try send the original Request again. In the second case, Libtropic will send the Resend Request (`Resend_Req`).
+- A frame with `STATUS=CRC_ERR` (`LT_L2_CRC_ERR`).
+- A frame with an invalid incoming CRC (`LT_L2_IN_CRC_ERR`).
 
-Both errors share a counter.
+Retry behavior:
+
+- For `STATUS=CRC_ERR`, Libtropic resends the original Request.
+- For invalid incoming CRC, Libtropic sends a Resend Request (`Resend_Req`).
+
+Both error types use the same retry counter.
 
 !!! example
-    If Libtropic receives a frame with `STATUS=CRC_ERR` followed by two frames with invalid CRC (during retry attempts), counter is depleted for that communication (single invocation of L2 API function or a single L3 chunk, see below).
+    If Libtropic receives a frame with `STATUS=CRC_ERR` and then two frames with invalid CRC (during retries), the retry counter is exhausted for that communication (a single L2 API call or a single L3 chunk; see below).
 
-Error counter applies always to a single L2 frame and resets itself:
+!!! important
+    This retry counter is independent of CRC diagnostic counters (see [FAQ](../../../faq.md)). CRC diagnostic counters track the total number of CRC errors since initialization (`lt_init`).
 
-- it starts at zero on each invocation of L2 API function (e.g., `lt_get_info_chip_id`),
-    
-    !!! example
-        Even if the first call `lt_get_info_chip_id` depletes all retry attempts, second call of `lt_get_info_chip_id` (or any other L2 API function) starts with all retry attempts available again.
+The counter scope is always one L2 frame operation:
 
-- it starts at zero on each chunk of L3 Command/Result in L3 API functions (e.g., `lt_ping`).
+- It starts at zero for each invocation of an L2 API function (for example, `lt_get_info_chip_id`).
 
     !!! example
-        Even if two errors occur during transmission of the first chunk, the second chunk starts with all retry attempts available again.
+        Even if the first call to `lt_get_info_chip_id` exhausts all retry attempts, the next call to `lt_get_info_chip_id` (or any other L2 API function) starts with a fresh retry counter.
 
-You can disable this functionality by setting the parameter to zero.
+- It also starts at zero for each L3 Command/Result chunk in L3 API functions (for example, `lt_ping`).
+
+    !!! example
+        Even if two errors occur while transmitting the first chunk, the second chunk starts with a fresh retry counter.
+
+Set this parameter to zero to disable retrying.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -89,18 +89,18 @@ Defines the TROPIC01's RISC-V CPU FW version (e.g. `"1_0_1"`) to update to. It i
 
 Defines how many times Libtropic retries communication after one of the following CRC-related errors:
 
-- A frame with `STATUS=CRC_ERR` (`LT_L2_CRC_ERR`).
-- A frame with an invalid incoming CRC (`LT_L2_IN_CRC_ERR`).
+- An L2 Response frame with `STATUS=CRC_ERR` (`LT_L2_CRC_ERR`).
+- An L2 Response frame with an invalid CRC in `RSP_CRC` field (`LT_L2_IN_CRC_ERR`).
 
 Retry behavior:
 
-- For `STATUS=CRC_ERR`, Libtropic resends the original Request.
-- For invalid incoming CRC, Libtropic sends a Resend Request (`Resend_Req`).
+- `LT_L2_CRC_ERR`: Libtropic resends the original L2 Request.
+- `LT_L2_IN_CRC_ERR`: Libtropic sends a Resend Request (`Resend_Req`).
 
 Both error types use the same retry counter.
 
 !!! example
-    If Libtropic receives a frame with `STATUS=CRC_ERR` and then two frames with invalid CRC (during retries), the retry counter is exhausted for that communication (a single L2 API call or a single L3 chunk; see below).
+    If Libtropic receives a frame with `STATUS=CRC_ERR` and then two L2 Response frames with invalid CRC (during retries), the retry counter is exhausted for that communication (a single L2 API call or a single L3 chunk; see below).
 
 !!! important
     This retry counter is independent of CRC diagnostic counters (see [FAQ](../../../faq.md)). CRC diagnostic counters track the total number of CRC errors since initialization (`lt_init`).

--- a/docs/tutorials/model/separate_api.md
+++ b/docs/tutorials/model/separate_api.md
@@ -7,8 +7,7 @@ This example showcases the Libtropic's Separate API. It is functionally similar 
 You will learn about some of the low-level API functions used to process outgoing and incoming data. For example:
 
 - `lt_out__session_start()`: prepare Handshake_Req L2 request (for Secure Session establishment),
-- `lt_l2_send()`: send L2 request,
-- `lt_l2_receive()`: receive L2 response,
+- `lt_l2_transfer()`: send L2 request and receive L2 response,
 - `lt_in__session_start()`: process L2 response to the Handshake_Req.
 
 ## Build and Run
@@ -39,3 +38,8 @@ Now, you can build and run the example:
 
     === ":fontawesome-brands-windows: Windows"
         TBA
+
+## Notes
+While it is also possible to use `lt_l2_send` and `lt_l2_receive` pair for transferring L2 frames instead
+of `lt_l2_transfer`, it is not recommended, as those functions do not implement retry mechanism on CRC
+errors. Prefer using `lt_l2_transfer`.

--- a/docs/tutorials/model/separate_api.md
+++ b/docs/tutorials/model/separate_api.md
@@ -42,4 +42,4 @@ Now, you can build and run the example:
 ## Notes
 While it is also possible to use `lt_l2_send` and `lt_l2_receive` pair for transferring L2 frames instead
 of `lt_l2_transfer`, it is not recommended, as those functions do not implement retry mechanism on CRC
-errors. Prefer using `lt_l2_transfer`.
+errors and do not increment CRC diagnostic counters. Prefer using `lt_l2_transfer`.

--- a/examples/model/separate_api/main.c
+++ b/examples/model/separate_api/main.c
@@ -151,7 +151,7 @@ int main(void)
     // handle's buffer (lt_handle.l2_buff) now contains data which must be transferred over a tunnel to
     // TROPIC01.
 
-    // Following L2 functions are called on a remote host.
+    // Following L2 function is called on a remote host.
     printf("Executing lt_l2_transfer()...");
     ret = lt_l2_transfer(&lt_handle.l2);
     if (LT_OK != ret) {

--- a/examples/model/separate_api/main.c
+++ b/examples/model/separate_api/main.c
@@ -152,20 +152,10 @@ int main(void)
     // TROPIC01.
 
     // Following L2 functions are called on a remote host.
-    printf("Executing lt_l2_send()...");
-    ret = lt_l2_send(&lt_handle.l2);
+    printf("Executing lt_l2_transfer()...");
+    ret = lt_l2_transfer(&lt_handle.l2);
     if (LT_OK != ret) {
-        fprintf(stderr, "\nlt_l2_send() failed, ret=%s\n", lt_ret_verbose(ret));
-        lt_deinit(&lt_handle);
-        mbedtls_psa_crypto_free();
-        return -1;
-    }
-    printf("OK\n");
-
-    printf("Executing lt_l2_receive()...");
-    ret = lt_l2_receive(&lt_handle.l2);
-    if (LT_OK != ret) {
-        fprintf(stderr, "\nlt_l2_receive() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr, "\nlt_l2_transfer() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -416,13 +416,13 @@ typedef enum lt_ret_t {
 
 //--------------------------------------------------------------------------------------------------------------------//
 
-#ifndef LT_CRC_ERR_RESEND_ATTEMPTS
+#ifndef LT_CRC_ERR_RETRY_ATTEMPTS
 /** @brief Count of attempts to resend request/response on LT_L2_CRC_ERR or LT_L2_IN_CRC_ERR error.
  *
  * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
  * parameters.
  */
-#define LT_CRC_ERR_RESEND_ATTEMPTS 3
+#define LT_CRC_ERR_RETRY_ATTEMPTS 3
 #endif
 
 //--------------------------------------------------------------------------------------------------------------------//

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -210,9 +210,12 @@ typedef enum lt_tr01_mode_t {
 } lt_tr01_mode_t;
 
 //--------------------------------------------------------------------------------------------------------------------//
+/** @brief Size of the buffer for Requests/Responses in L2 state structure. */
+#define LT_SIZE_OF_L2_BUFF TR01_L1_LEN_MAX
+
 typedef struct lt_l2_state_t {
     void *device;
-    uint8_t buff[TR01_L1_CHIP_STATUS_SIZE + TR01_L2_MAX_FRAME_SIZE];
+    uint8_t buff[LT_SIZE_OF_L2_BUFF];
     bool startup_req_sent;
 
     uint32_t l2_in_crc_error_count;

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -214,6 +214,9 @@ typedef struct lt_l2_state_t {
     void *device;
     uint8_t buff[TR01_L1_CHIP_STATUS_SIZE + TR01_L2_MAX_FRAME_SIZE];
     bool startup_req_sent;
+
+    uint32_t l2_in_crc_error_count;
+    uint32_t l2_crc_error_count;
 } lt_l2_state_t;
 
 // #define LT_SIZE_OF_L3_BUFF (1000)
@@ -408,6 +411,17 @@ typedef enum lt_ret_t {
 } lt_ret_t;
 
 #define LT_TR01_REBOOT_DELAY_MS 250
+
+//--------------------------------------------------------------------------------------------------------------------//
+
+#ifndef LT_CRC_ERR_RESEND_ATTEMPTS
+/** @brief Count of attempts to resend request/response on LT_L2_CRC_ERR or LT_L2_IN_CRC_ERR error.
+ *
+ * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
+ * parameters.
+ */
+#define LT_CRC_ERR_RESEND_ATTEMPTS 3
+#endif
 
 //--------------------------------------------------------------------------------------------------------------------//
 /** @brief Maximal size of TROPIC01's certificate */

--- a/include/libtropic_common.h
+++ b/include/libtropic_common.h
@@ -219,7 +219,6 @@ typedef struct lt_l2_state_t {
     uint32_t l2_crc_error_count;
 } lt_l2_state_t;
 
-// #define LT_SIZE_OF_L3_BUFF (1000)
 #ifndef LT_SIZE_OF_L3_BUFF
 #define LT_SIZE_OF_L3_BUFF TR01_L3_PACKET_MAX_SIZE
 #endif

--- a/include/libtropic_l2.h
+++ b/include/libtropic_l2.h
@@ -27,6 +27,9 @@ extern "C" {
  * @note Before calling this function, place request's data into handle's internal L2 buffer.
  * Structures defined in lt_l2_api_structs.h might help with encoding the data.
  *
+ * @warning This function does not handle retries on CRC errors. It is recommended to use
+ * lt_l2_transfer which combines send/receive functionality and implements retries.
+ *
  * @param s2          Structure holding l2 state
  *
  * @retval            LT_OK Function executed successfully
@@ -50,6 +53,9 @@ lt_ret_t lt_l2_resend_response(lt_l2_state_t *s2);
  *
  * After successful execution, handle's `l2_buff` will contain response.
  * @note Structures defined in lt_l2_api_structs.h migh help with decoding.
+ *
+ * @warning This function does not handle retries on CRC errors. It is recommended to use
+ * lt_l2_transfer which combines send/receive functionality and implements retries.
  *
  * @param s2          Structure holding l2 state
  *

--- a/include/libtropic_l2.h
+++ b/include/libtropic_l2.h
@@ -52,7 +52,7 @@ lt_ret_t lt_l2_resend_response(lt_l2_state_t *s2);
  * @brief Receives L2 response.
  *
  * After successful execution, handle's `l2_buff` will contain response.
- * @note Structures defined in lt_l2_api_structs.h migh help with decoding.
+ * @note Structures defined in lt_l2_api_structs.h might help with decoding.
  *
  * @warning This function does not handle retries on CRC errors. It is recommended to use
  * lt_l2_transfer which combines send/receive functionality and implements retries.

--- a/include/libtropic_l2.h
+++ b/include/libtropic_l2.h
@@ -67,7 +67,7 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2);
  * @param s2          Structure holding l2 state
  *
  * @retval            LT_OK Function executed successfully
- * @retval            other Function did not execute successully
+ * @retval            other Function did not execute successfully
  */
 lt_ret_t lt_l2_transfer(lt_l2_state_t *s2);
 

--- a/include/libtropic_l2.h
+++ b/include/libtropic_l2.h
@@ -62,7 +62,9 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2);
  * @brief Send L2 Request and receive L2 Response.
  *
  * This function combines lt_l2_send and lt_l2_receive with additional
- * handling of resending outgoing frames on LT_L2_CRC_ERR errors.
+ * handling of retrying the transfer: resending outgoing frames on
+ * LT_L2_CRC_ERR errors and sending Resend_Req on LT_L2_IN_CRC_ERR
+ * errors when an invalid incoming CRC is detected.
  *
  * @param s2          Structure holding l2 state
  *

--- a/include/libtropic_l2.h
+++ b/include/libtropic_l2.h
@@ -59,6 +59,19 @@ lt_ret_t lt_l2_resend_response(lt_l2_state_t *s2);
 lt_ret_t lt_l2_receive(lt_l2_state_t *s2);
 
 /**
+ * @brief Send L2 Request and receive L2 Response.
+ *
+ * This function combines lt_l2_send and lt_l2_receive with additional
+ * handling of resending outgoing frames on LT_L2_CRC_ERROR errors.
+ *
+ * @param s2          Structure holding l2 state
+ *
+ * @retval            LT_OK Function executed successfully
+ * @retval            other Function did not execute successully
+ */
+lt_ret_t lt_l2_transfer(lt_l2_state_t *s2);
+
+/**
  * @brief Sends content of encrypted L3 command's buffer over Layer 2.
  *
  * Data are sent from handle's `l3_buff`.

--- a/include/libtropic_l2.h
+++ b/include/libtropic_l2.h
@@ -62,7 +62,7 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2);
  * @brief Send L2 Request and receive L2 Response.
  *
  * This function combines lt_l2_send and lt_l2_receive with additional
- * handling of resending outgoing frames on LT_L2_CRC_ERROR errors.
+ * handling of resending outgoing frames on LT_L2_CRC_ERR errors.
  *
  * @param s2          Structure holding l2 state
  *

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -220,7 +220,7 @@ lt_ret_t lt_get_info_cert_store(lt_handle_t *h, struct lt_cert_store_t *store)
         p_l2_req->object_id = TR01_L2_GET_INFO_REQ_OBJECT_ID_X509_CERTIFICATE;
         p_l2_req->block_index = i;
 
-        lt_ret_t ret = lt_l2_transfer(&h->l2);
+        ret = lt_l2_transfer(&h->l2);
         if (ret != LT_OK) {
             return ret;
         }

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -57,6 +57,10 @@ lt_ret_t lt_init(lt_handle_t *h)
         return ret;
     }
 
+    // Init CRC error counters
+    h->l2.l2_crc_error_count = 0;
+    h->l2.l2_in_crc_error_count = 0;
+
     ret = lt_crypto_ctx_init(h->l3.crypto_ctx);
     if (ret != LT_OK) {
         goto l1_cleanup;

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -220,12 +220,7 @@ lt_ret_t lt_get_info_cert_store(lt_handle_t *h, struct lt_cert_store_t *store)
         p_l2_req->object_id = TR01_L2_GET_INFO_REQ_OBJECT_ID_X509_CERTIFICATE;
         p_l2_req->block_index = i;
 
-        ret = lt_l2_send(&h->l2);
-        if (ret != LT_OK) {
-            return ret;
-        }
-
-        ret = lt_l2_receive(&h->l2);
+        lt_ret_t ret = lt_l2_transfer(&h->l2);
         if (ret != LT_OK) {
             return ret;
         }
@@ -330,11 +325,7 @@ lt_ret_t lt_get_info_chip_id(lt_handle_t *h, struct lt_chip_id_t *chip_id)
     p_l2_req->object_id = TR01_L2_GET_INFO_REQ_OBJECT_ID_CHIP_ID;
     p_l2_req->block_index = TR01_L2_GET_INFO_REQ_BLOCK_INDEX_DATA_CHUNK_0_127;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -365,11 +356,7 @@ lt_ret_t lt_get_info_riscv_fw_ver(lt_handle_t *h, uint8_t *ver)
     p_l2_req->object_id = TR01_L2_GET_INFO_REQ_OBJECT_ID_RISCV_FW_VERSION;
     p_l2_req->block_index = TR01_L2_GET_INFO_REQ_BLOCK_INDEX_DATA_CHUNK_0_127;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -399,11 +386,7 @@ lt_ret_t lt_get_info_spect_fw_ver(lt_handle_t *h, uint8_t *ver)
     p_l2_req->object_id = TR01_L2_GET_INFO_REQ_OBJECT_ID_SPECT_FW_VERSION;
     p_l2_req->block_index = TR01_L2_GET_INFO_REQ_BLOCK_INDEX_DATA_CHUNK_0_127;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -436,11 +419,7 @@ lt_ret_t lt_get_info_fw_bank(lt_handle_t *h, const lt_bank_id_t bank_id, uint8_t
     p_l2_req->object_id = TR01_L2_GET_INFO_REQ_OBJECT_ID_FW_BANK;
     p_l2_req->block_index = bank_id;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -477,11 +456,7 @@ lt_ret_t lt_session_start(lt_handle_t *h, const uint8_t *stpub, const lt_pkey_in
         goto cleanup;
     }
 
-    ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        goto cleanup;
-    }
-    ret = lt_l2_receive(&h->l2);
+    ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         goto cleanup;
     }
@@ -519,11 +494,7 @@ lt_ret_t lt_session_abort(lt_handle_t *h)
     p_l2_req->req_id = TR01_L2_ENCRYPTED_SESSION_ABT_ID;
     p_l2_req->req_len = TR01_L2_ENCRYPTED_SESSION_ABT_LEN;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -550,11 +521,7 @@ lt_ret_t lt_sleep(lt_handle_t *h, const uint8_t sleep_kind)
     p_l2_req->req_len = TR01_L2_SLEEP_REQ_LEN;
     p_l2_req->startup_id = sleep_kind;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -581,13 +548,8 @@ lt_ret_t lt_reboot(lt_handle_t *h, const lt_startup_id_t startup_id)
     p_l2_req->req_len = TR01_L2_STARTUP_REQ_LEN;
     p_l2_req->startup_id = startup_id;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
     h->l2.startup_req_sent = true;
-    if (ret != LT_OK) {
-        h->l2.startup_req_sent = false;
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     h->l2.startup_req_sent = false;
     if (ret != LT_OK) {
         return ret;
@@ -639,11 +601,7 @@ lt_ret_t lt_mutable_fw_erase(lt_handle_t *h, const lt_bank_id_t bank_id)
     p_l2_req->req_len = TR01_L2_MUTABLE_FW_ERASE_REQ_LEN;
     p_l2_req->bank_id = bank_id;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -681,11 +639,7 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size
         p_l2_req->offset = i * 128;
         memcpy(p_l2_req->data, fw_data + (i * 128), 128);
 
-        lt_ret_t ret = lt_l2_send(&h->l2);
-        if (ret != LT_OK) {
-            return ret;
-        }
-        ret = lt_l2_receive(&h->l2);
+        lt_ret_t ret = lt_l2_transfer(&h->l2);
         if (ret != LT_OK) {
             return ret;
         }
@@ -702,11 +656,7 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size
         p_l2_req->offset = loops * 128;
         memcpy(p_l2_req->data, fw_data + (loops * 128), rest);
 
-        lt_ret_t ret = lt_l2_send(&h->l2);
-        if (ret != LT_OK) {
-            return ret;
-        }
-        ret = lt_l2_receive(&h->l2);
+        lt_ret_t ret = lt_l2_transfer(&h->l2);
         if (ret != LT_OK) {
             return ret;
         }
@@ -748,11 +698,7 @@ lt_ret_t lt_mutable_fw_update(lt_handle_t *h, const uint8_t *fw_data, const size
     p_l2_req->header_version = fw_chunk_0->header_version;
     p_l2_req->version = fw_chunk_0->version;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }
@@ -798,11 +744,7 @@ lt_ret_t lt_mutable_fw_update_data(lt_handle_t *h, const uint8_t *fw_data, const
         p2_l2_req->req_id = TR01_L2_MUTABLE_FW_UPDATE_DATA_REQ;
         memcpy((uint8_t *)&p2_l2_req->req_len, fw_data + chunk_index, copy_len);
 
-        lt_ret_t ret = lt_l2_send(&h->l2);
-        if (ret != LT_OK) {
-            return ret;
-        }
-        ret = lt_l2_receive(&h->l2);
+        lt_ret_t ret = lt_l2_transfer(&h->l2);
         if (ret != LT_OK) {
             return ret;
         }
@@ -833,11 +775,7 @@ lt_ret_t lt_get_log_req(lt_handle_t *h, uint8_t *log_msg, const uint16_t log_msg
     p_l2_req->req_id = TR01_L2_GET_LOG_REQ_ID;
     p_l2_req->req_len = TR01_L2_GET_LOG_REQ_LEN;
 
-    lt_ret_t ret = lt_l2_send(&h->l2);
-    if (ret != LT_OK) {
-        return ret;
-    }
-    ret = lt_l2_receive(&h->l2);
+    lt_ret_t ret = lt_l2_transfer(&h->l2);
     if (ret != LT_OK) {
         return ret;
     }

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -81,18 +81,41 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2)
 
     ret = lt_l2_frame_check(s2->buff);
 
-    if (ret == LT_L2_IN_CRC_ERR) {
-        for (int i = 0; i < LT_CRC_ERR_RESEND_ATTEMPTS; i++) {
-            s2->l2_in_crc_error_count++;
+    // Rest of errors are reported directly to upper layers, without trying to resend response.
+    return ret;
+}
 
-            ret = lt_l2_resend_response(s2);
-            if (ret == LT_OK || ret != LT_L2_IN_CRC_ERR) {
-                break;
+lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
+{
+    uint8_t req_buff_backup[LT_SIZE_OF_L2_BUFF];
+    memcpy(req_buff_backup, s2->buff, LT_SIZE_OF_L2_BUFF);
+
+    lt_ret_t ret;
+    for (int i = 0; i < LT_CRC_ERR_RESEND_ATTEMPTS; i++) {
+        ret = lt_l2_send(s2);
+        if (ret != LT_OK) {
+            return ret;
+        }
+
+        ret = lt_l2_receive(s2);
+        if (ret == LT_L2_IN_CRC_ERR) {
+            for (int j = 0; j < LT_CRC_ERR_RESEND_ATTEMPTS; j++) {
+                s2->l2_in_crc_error_count++;
+
+                ret = lt_l2_resend_response(s2);
+                if (ret == LT_OK || ret != LT_L2_IN_CRC_ERR) {
+                    break;
+                }
             }
+        }
+        else if (ret == LT_L2_CRC_ERR) {
+            memcpy(s2->buff, req_buff_backup, LT_SIZE_OF_L2_BUFF);
+        }
+        else {
+            break;
         }
     }
 
-    // Rest of errors are reported directly to upper layers, without trying to resend response.
     return ret;
 }
 

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -176,7 +176,7 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
 
     uint16_t buff_offset = 0;
 
-    // Count of attempts to resend the frame on LT_L2_CRC_ERR.
+    // Count of retries to resend the frame on LT_L2_CRC_ERR or LT_L2_IN_CRC_ERR.
     uint32_t frame_resend_counter = 0;
 
     // req->req_len gets overwritten, so we need to keep copy to increment
@@ -213,29 +213,23 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
         // Check status byte of this frame
         ret = lt_l2_frame_check(s2->buff);
 
-        // In case of IN_CRC error, request to resend the last frame.
+        // In case of IN_CRC error, request to resend the last frame if there's still some retry
+        // attempts.
         if (ret == LT_L2_IN_CRC_ERR) {
-            for (int attempt = 0; attempt < LT_CRC_ERR_RETRY_ATTEMPTS; attempt++) {
-                s2->l2_in_crc_error_count++;
+            s2->l2_in_crc_error_count++;
+            while (frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
+                frame_resend_counter++;
 
                 ret = lt_l2_resend_response(s2);
-                if (ret == LT_OK || ret == LT_L2_REQ_CONT) {
+                if (ret == LT_OK || ret == LT_L2_REQ_CONT || ret != LT_L2_IN_CRC_ERR) {
                     break;
                 }
-                // Return immediately on other errors.
-                else if (ret != LT_L2_IN_CRC_ERR) {
-                    return ret;
-                }
+                s2->l2_in_crc_error_count++;
             }
         }
 
-        // In case of CRC error, resend the last frame.
-        if (ret == LT_L2_CRC_ERR) {
-            if (frame_resend_counter > LT_CRC_ERR_RETRY_ATTEMPTS) {
-                LT_LOG_ERROR("Received LT_L2_CRC_ERR after reaching resend attempt limit of " PRIu32);
-                return ret;
-            }
-
+        // In case of CRC error, resend the last frame if there's still some retry attempts.
+        if (ret == LT_L2_CRC_ERR && frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
             s2->l2_crc_error_count++;
             frame_resend_counter++;
             i--;

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -318,8 +318,10 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
         }
 
         // Prevent receiving more data than is the size of the provided L3 buffer.
-        if (offset + resp->rsp_len > max_len) {
-            return LT_L2_RSP_LEN_ERROR;
+        if (ret == LT_OK || ret == LT_L2_RES_CONT) {
+            if (offset + resp->rsp_len > max_len) {
+                return LT_L2_RSP_LEN_ERROR;
+            }
         }
 
         switch (ret) {

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -81,11 +81,10 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2)
 
     ret = lt_l2_frame_check(s2->buff);
 
-    if ((ret == LT_L2_CRC_ERR) || (ret == LT_L2_GEN_ERR)) {
-        // There was an error when checking received data.
-        // Let's consider that length byte is correct, but CRC is not.
-        // We try three times to resend the last response.
-        for (int i = 0; i < 3; i++) {
+    if (ret == LT_L2_IN_CRC_ERR) {
+        s2->l2_in_crc_error_count++;
+
+        for (int i = 0; i < LT_CRC_ERR_RESEND_ATTEMPTS; i++) {
             ret = lt_l2_resend_response(s2);
             if (ret == LT_OK) {
                 break;

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -353,5 +353,6 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
 
     } while (chunks_received < LT_L2_RECV_ENC_RES_MAX_CHUNKS);
 
-    return LT_FAIL;
+    LT_LOG_ERROR("Maximal number of received chunks (%d) exceeded!", LT_L2_RECV_ENC_RES_MAX_CHUNKS);
+    return LT_L3_DATA_LEN_ERROR;
 }

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -291,11 +291,24 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
     // Count of attempts to resend the frame on LT_L2_IN_CRC_ERR.
     uint32_t frame_resend_counter = 0;
 
+    // Whether to resend previous chunk or continue with the next one.
+    bool resend_response = false;
+
     do {
-        // Get one L2 frame of a device's response
-        ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_TIMEOUT_MS_DEFAULT);
-        if (ret != LT_OK) {
-            return ret;
+        // Get one L2 frame of a device's response.
+        // If previous frame was received OK, read a next frame. Otherwise, ask to resend
+        // the previous frame.
+        if (!resend_response) {
+            ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_TIMEOUT_MS_DEFAULT);
+            if (ret != LT_OK) {
+                return ret;
+            }
+
+            // Check status byte of this frame
+            ret = lt_l2_frame_check(s2->buff);
+        }
+        else {
+            ret = lt_l2_resend_response(s2);
         }
 
         // Prevent receiving more data than is the size of the provided L3 buffer.
@@ -303,10 +316,10 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
             return LT_L2_RSP_LEN_ERROR;
         }
 
-        // Check status byte of this frame
-        ret = lt_l2_frame_check(s2->buff);
         switch (ret) {
             case LT_L2_RES_CONT:
+                // Frame received OK, resetting resend counter.
+                frame_resend_counter = 0;
                 // Copy content of L2 into current offset of the L3 buffer
                 memcpy(buff + offset, (struct l2_encrypted_rsp_t *)resp->l3_chunk, resp->rsp_len);
                 offset += resp->rsp_len;
@@ -315,31 +328,13 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
             case LT_L2_IN_CRC_ERR:
                 // Host received corrupted frame. Ask for resend.
                 s2->l2_in_crc_error_count++;
-
                 if (frame_resend_counter >= LT_CRC_ERR_RETRY_ATTEMPTS) {
                     return ret;
                 }
-
-                while (frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
+                else {
                     frame_resend_counter++;
-
-                    ret = lt_l2_resend_response(s2);
-                    if (ret == LT_L2_IN_CRC_ERR) {
-                        s2->l2_in_crc_error_count++;
-
-                        if (frame_resend_counter >= LT_CRC_ERR_RETRY_ATTEMPTS) {
-                            return ret;
-                        }
-                        continue;
-                    }
-                    else if (ret == LT_OK || ret == LT_L2_RES_CONT) {
-                        break;
-                    }
-                    else {
-                        return ret;
-                    }
+                    resend_response = true;
                 }
-
                 break;
             case LT_OK:
                 // This was last L2 frame of L3 packet, copy it and return
@@ -349,9 +344,6 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                 // Any other frame status is not expected
                 return ret;
         }
-
-        // Frame received OK, resetting resend counter.
-        frame_resend_counter = 0;
 
     } while (loops < LT_L2_RECV_ENC_RES_MAX_LOOPS);
 

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -106,15 +106,15 @@ lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
 
         // If CRC of incoming Response is invalid, try to get a new Reponse.
         if (ret == LT_L2_IN_CRC_ERR) {
+            s2->l2_in_crc_error_count++;
             while (total_retry_count < LT_CRC_ERR_RETRY_ATTEMPTS) {
-                s2->l2_in_crc_error_count++;
+                total_retry_count++;
 
                 ret = lt_l2_resend_response(s2);
                 if (ret == LT_OK || ret != LT_L2_IN_CRC_ERR) {
                     break;
                 }
-
-                total_retry_count++;
+                s2->l2_in_crc_error_count++;
             }
         }
 

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -18,12 +18,12 @@
 #include "lt_l2_api_structs.h"
 #include "lt_l2_frame_check.h"
 
-/** Safety number - limit number of loops during l3 chunks reception. TROPIC01 divides data into 128B
+/** Safety number. Limit number of loops during L3 chunks reception. TROPIC01 divides data into 128B
  *  chunks, length of L3 buffer is (2 + 4096 + 16).
  *  Divided by typical chunk length: (2 + 4096 + 16) / 128 => 32,
- *  with a few added loops it is set to 42
+ *  with a few added loops it is set to 42.
  */
-#define LT_L2_RECV_ENC_RES_MAX_LOOPS 42
+#define LT_L2_RECV_ENC_RES_MAX_CHUNKS 42
 
 lt_ret_t lt_l2_send(lt_l2_state_t *s2)
 {
@@ -289,8 +289,10 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
 
     // Position into L3 buffer where processed L2 chunk will be copied into
     uint16_t offset = 0;
-    // Tropic can respond with various lengths of chunks, this loop should be limited
-    uint16_t loops = 0;
+    // Tropic can respond with various counts and lengths of chunks.
+    // This counter tracks number of chunks received, so we can terminate the communication
+    // if it exceeds a certain amount.
+    uint16_t chunks_received = 0;
 
     // Count of attempts to resend the frame on LT_L2_IN_CRC_ERR.
     uint32_t frame_resend_counter = 0;
@@ -327,7 +329,7 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                 // Copy content of L2 into current offset of the L3 buffer
                 memcpy(buff + offset, (struct l2_encrypted_rsp_t *)resp->l3_chunk, resp->rsp_len);
                 offset += resp->rsp_len;
-                loops++;
+                chunks_received++;
                 break;
             case LT_L2_IN_CRC_ERR:
                 // Host received corrupted frame. Ask for resend.
@@ -349,7 +351,7 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                 return ret;
         }
 
-    } while (loops < LT_L2_RECV_ENC_RES_MAX_LOOPS);
+    } while (chunks_received < LT_L2_RECV_ENC_RES_MAX_CHUNKS);
 
     return LT_FAIL;
 }

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -344,6 +344,18 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                     resend_response = true;
                 }
                 break;
+            case LT_L2_CRC_ERR:
+                // CRC_ERR can be returned only as a response to Resend_Req.
+                // Ask for resend again.
+                s2->l2_crc_error_count++;
+                if (frame_resend_counter >= LT_CRC_ERR_RETRY_ATTEMPTS) {
+                    return ret;
+                }
+                else {
+                    frame_resend_counter++;
+                    resend_response = true;
+                }
+                break;
             case LT_OK:
                 // This was last L2 frame of L3 packet, copy it and return
                 memcpy(buff + offset, (struct l2_encrypted_rsp_t *)resp->l3_chunk, resp->rsp_len);

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -120,7 +120,7 @@ lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
                 retry_communication = true;
             }
         }
-        // If CRC of incoming Response is invalid, try to get a new Reponse.
+        // If CRC of incoming Response is invalid, try to get a new Response.
         else if (ret == LT_L2_IN_CRC_ERR) {
             s2->l2_in_crc_error_count++;
             while (total_retry_count < LT_CRC_ERR_RETRY_ATTEMPTS) {

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -137,23 +137,30 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
 
     uint16_t buff_offset = 0;
 
+    // Count of attempts to resend the frame on LT_L2_CRC_ERR.
+    uint32_t frame_resend_counter = 0;
+
+    // req->req_len gets overwritten, so we need to keep copy to increment
+    // buff_offset at the end of the loop.
+    uint16_t req_len;
+
     // Split encrypted buffer into chunks and proceed them into L2 transfers:
     for (int i = 0; i < chunk_num; i++) {
         req->req_id = TR01_L2_ENCRYPTED_CMD_REQ_ID;
         // If the currently processed chunk is the last one, get its length (may be shorter than
         // L2_CHUNK_MAX_DATA_SIZE)
         if (i == (chunk_num - 1)) {
-            req->req_len = last_chunk_len;
+            req_len = last_chunk_len;
         }
         else {
-            req->req_len = TR01_L2_CHUNK_MAX_DATA_SIZE;
+            req_len = TR01_L2_CHUNK_MAX_DATA_SIZE;
         }
-        memcpy(req->l3_chunk, buff + buff_offset, req->req_len);
-        buff_offset += req->req_len;  // Move offset for next chunk
+        req->req_len = req_len;
+        memcpy(req->l3_chunk, buff + buff_offset, req_len);
         add_crc(req);
 
         // Send L2 request containing a chunk from L3 buff
-        ret = lt_l1_write(s2, 2 + req->req_len + 2, LT_L1_TIMEOUT_MS_DEFAULT);
+        ret = lt_l1_write(s2, 2 + req_len + 2, LT_L1_TIMEOUT_MS_DEFAULT);
         if (ret != LT_OK) {
             return ret;
         }
@@ -166,9 +173,43 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
 
         // Check status byte of this frame
         ret = lt_l2_frame_check(s2->buff);
+
+        // In case of IN_CRC error, request to resend the last frame.
+        if (ret == LT_L2_IN_CRC_ERR) {
+            for (int attempt = 0; attempt < LT_CRC_ERR_RESEND_ATTEMPTS; attempt++) {
+                s2->l2_in_crc_error_count++;
+
+                ret = lt_l2_resend_response(s2);
+                if (ret == LT_OK || ret == LT_L2_REQ_CONT) {
+                    break;
+                }
+                // Return immediately on other errors.
+                else if (ret != LT_L2_IN_CRC_ERR) {
+                    return ret;
+                }
+            }
+        }
+
+        // In case of CRC error, resend the last frame.
+        if (ret == LT_L2_CRC_ERR) {
+            if (frame_resend_counter > LT_CRC_ERR_RESEND_ATTEMPTS) {
+                LT_LOG_ERROR("Received LT_L2_CRC_ERR after reaching resend attempt limit of " PRIu32);
+                return ret;
+            }
+
+            s2->l2_crc_error_count++;
+            frame_resend_counter++;
+            i--;
+            continue;
+        }
+
+        // In other cases, return immediately.
         if (ret != LT_OK && ret != LT_L2_REQ_CONT) {
             return ret;
         }
+
+        buff_offset += req_len;    // Move offset for next chunk
+        frame_resend_counter = 0;  // Frame sent successfully, reset the counter.
     }
 
     return LT_OK;
@@ -191,6 +232,9 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
     // Tropic can respond with various lengths of chunks, this loop should be limited
     uint16_t loops = 0;
 
+    // Count of attempts to resend the frame on LT_L2_IN_CRC_ERR.
+    uint32_t frame_resend_counter = 0;
+
     do {
         // Get one L2 frame of a device's response
         ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_TIMEOUT_MS_DEFAULT);
@@ -212,6 +256,19 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                 offset += resp->rsp_len;
                 loops++;
                 break;
+            case LT_L2_IN_CRC_ERR:
+                // Host received corrupted frame. Ask for resend.
+                frame_resend_counter++;
+
+                struct lt_l2_resend_req_t *p_l2_req = (struct lt_l2_resend_req_t *)s2->buff;
+                p_l2_req->req_id = TR01_L2_RESEND_REQ_ID;
+                p_l2_req->req_len = TR01_L2_RESEND_REQ_LEN;
+
+                ret = lt_l2_send(s2);
+                if (ret != LT_OK) {
+                    return ret;
+                }
+                break;
             case LT_OK:
                 // This was last L2 frame of L3 packet, copy it and return
                 memcpy(buff + offset, (struct l2_encrypted_rsp_t *)resp->l3_chunk, resp->rsp_len);
@@ -220,6 +277,10 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                 // Any other frame status is not expected
                 return ret;
         }
+
+        // Frame received OK, resetting resend counter.
+        frame_resend_counter = 0;
+
     } while (loops < LT_L2_RECV_ENC_RES_MAX_LOOPS);
 
     return LT_FAIL;

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -82,11 +82,11 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2)
     ret = lt_l2_frame_check(s2->buff);
 
     if (ret == LT_L2_IN_CRC_ERR) {
-        s2->l2_in_crc_error_count++;
-
         for (int i = 0; i < LT_CRC_ERR_RESEND_ATTEMPTS; i++) {
+            s2->l2_in_crc_error_count++;
+
             ret = lt_l2_resend_response(s2);
-            if (ret == LT_OK) {
+            if (ret == LT_OK || ret != LT_L2_IN_CRC_ERR) {
                 break;
             }
         }

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -108,20 +108,6 @@ lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
 
         ret = lt_l2_receive(s2);
 
-        // If CRC of incoming Response is invalid, try to get a new Reponse.
-        if (ret == LT_L2_IN_CRC_ERR) {
-            s2->l2_in_crc_error_count++;
-            while (total_retry_count < LT_CRC_ERR_RETRY_ATTEMPTS) {
-                total_retry_count++;
-
-                ret = lt_l2_resend_response(s2);
-                if (ret == LT_OK || ret != LT_L2_IN_CRC_ERR) {
-                    break;
-                }
-                s2->l2_in_crc_error_count++;
-            }
-        }
-
         // After receiving Response frame with correct CRC (or exceeded count of attempts),
         // check if TROPIC01 received our Request OK. If not, and total number
         // of retries was not exhausted yet, retry whole communication.
@@ -134,6 +120,28 @@ lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
                 retry_communication = true;
             }
         }
+        // If CRC of incoming Response is invalid, try to get a new Reponse.
+        else if (ret == LT_L2_IN_CRC_ERR) {
+            s2->l2_in_crc_error_count++;
+            while (total_retry_count < LT_CRC_ERR_RETRY_ATTEMPTS) {
+                total_retry_count++;
+
+                ret = lt_l2_resend_response(s2);
+                if (ret == LT_L2_IN_CRC_ERR) {
+                    s2->l2_in_crc_error_count++;
+                }
+                // If we receive LT_L2_CRC_ERR to Resend_Req, we should not retry
+                // whole communication, rather the Resend_Req again, as we cannot be sure that
+                // the CRC error appeared in the original frame or only later in the Resend_Req frame.
+                else if (ret == LT_L2_CRC_ERR) {
+                    s2->l2_crc_error_count++;
+                }
+                else {
+                    break;
+                }
+            }
+        }
+
     } while (retry_communication);
 
     return ret;

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -250,11 +250,15 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
             }
         }
         // In case of CRC error, resend the last frame if there're still some retry attempts.
-        else if (ret == LT_L2_CRC_ERR && frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
-            s2->l2_crc_error_count++;
-            frame_resend_counter++;
-            i--;
-            continue;
+        else if (ret == LT_L2_CRC_ERR) {
+            s2->l2_crc_error_count++;  // Counter has to be increased even if retry attempts were
+                                       // depleted.
+
+            if (frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
+                frame_resend_counter++;
+                i--;
+                continue;
+            }
         }
 
         // In other cases, return immediately.

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -304,11 +304,7 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                 while (frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
                     frame_resend_counter++;
 
-                    struct lt_l2_resend_req_t *p_l2_req = (struct lt_l2_resend_req_t *)s2->buff;
-                    p_l2_req->req_id = TR01_L2_RESEND_REQ_ID;
-                    p_l2_req->req_len = TR01_L2_RESEND_REQ_LEN;
-
-                    ret = lt_l2_send(s2);
+                    ret = lt_l2_resend_response(s2);
                     if (ret == LT_L2_IN_CRC_ERR) {
                         s2->l2_in_crc_error_count++;
 

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -130,9 +130,9 @@ lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
                 if (ret == LT_L2_IN_CRC_ERR) {
                     s2->l2_in_crc_error_count++;
                 }
-                // If we receive LT_L2_CRC_ERR to Resend_Req, we should not retry
-                // whole communication, rather the Resend_Req again, as we cannot be sure that
-                // the CRC error appeared in the original frame or only later in the Resend_Req frame.
+                // If we receive LT_L2_CRC_ERR to Resend_Req, we should not retry whole communication,
+                // rather the Resend_Req again, as we cannot be sure that the CRC error appeared in the
+                // original frame or only later in the Resend_Req frame.
                 else if (ret == LT_L2_CRC_ERR) {
                     s2->l2_crc_error_count++;
                 }
@@ -189,6 +189,7 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
     uint16_t buff_offset = 0;
 
     // Count of retries to resend the frame on LT_L2_CRC_ERR or LT_L2_IN_CRC_ERR.
+    // This counter is reset on each successful chunk (frame).
     uint32_t frame_resend_counter = 0;
 
     // req->req_len gets overwritten, so we need to keep copy to increment

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -297,16 +297,36 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
                 break;
             case LT_L2_IN_CRC_ERR:
                 // Host received corrupted frame. Ask for resend.
-                frame_resend_counter++;
+                s2->l2_in_crc_error_count++;
 
-                struct lt_l2_resend_req_t *p_l2_req = (struct lt_l2_resend_req_t *)s2->buff;
-                p_l2_req->req_id = TR01_L2_RESEND_REQ_ID;
-                p_l2_req->req_len = TR01_L2_RESEND_REQ_LEN;
-
-                ret = lt_l2_send(s2);
-                if (ret != LT_OK) {
+                if (frame_resend_counter >= LT_CRC_ERR_RETRY_ATTEMPTS) {
                     return ret;
                 }
+
+                while (frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
+                    frame_resend_counter++;
+
+                    struct lt_l2_resend_req_t *p_l2_req = (struct lt_l2_resend_req_t *)s2->buff;
+                    p_l2_req->req_id = TR01_L2_RESEND_REQ_ID;
+                    p_l2_req->req_len = TR01_L2_RESEND_REQ_LEN;
+
+                    ret = lt_l2_send(s2);
+                    if (ret == LT_L2_IN_CRC_ERR) {
+                        s2->l2_in_crc_error_count++;
+
+                        if (frame_resend_counter >= LT_CRC_ERR_RETRY_ATTEMPTS) {
+                            return ret;
+                        }
+                        continue;
+                    }
+                    else if (ret == LT_OK || ret == LT_L2_RES_CONT) {
+                        break;
+                    }
+                    else {
+                        return ret;
+                    }
+                }
+
                 break;
             case LT_OK:
                 // This was last L2 frame of L3 packet, copy it and return

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -294,7 +294,8 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
     // if it exceeds a certain amount.
     uint16_t chunks_received = 0;
 
-    // Count of attempts to resend the frame on LT_L2_IN_CRC_ERR.
+    // Count of retries to resend the frame on LT_L2_CRC_ERR or LT_L2_IN_CRC_ERR.
+    // This counter is reset on each successful chunk (frame).
     uint32_t frame_resend_counter = 0;
 
     // Whether to resend previous chunk or continue with the next one.

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -315,6 +315,7 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
         }
         else {
             ret = lt_l2_resend_response(s2);
+            resend_response = false;
         }
 
         // Prevent receiving more data than is the size of the provided L3 buffer.

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -91,30 +91,46 @@ lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
     memcpy(req_buff_backup, s2->buff, LT_SIZE_OF_L2_BUFF);
 
     lt_ret_t ret;
-    for (int i = 0; i < LT_CRC_ERR_RESEND_ATTEMPTS; i++) {
+    bool retry_communication;
+    int total_retry_count = 0;
+
+    do {
+        retry_communication = false;
+
         ret = lt_l2_send(s2);
         if (ret != LT_OK) {
             return ret;
         }
 
         ret = lt_l2_receive(s2);
+
+        // If CRC of incoming Response is invalid, try to get a new Reponse.
         if (ret == LT_L2_IN_CRC_ERR) {
-            for (int j = 0; j < LT_CRC_ERR_RESEND_ATTEMPTS; j++) {
+            while (total_retry_count < LT_CRC_ERR_RETRY_ATTEMPTS) {
                 s2->l2_in_crc_error_count++;
 
                 ret = lt_l2_resend_response(s2);
                 if (ret == LT_OK || ret != LT_L2_IN_CRC_ERR) {
                     break;
                 }
+
+                total_retry_count++;
             }
         }
-        else if (ret == LT_L2_CRC_ERR) {
-            memcpy(s2->buff, req_buff_backup, LT_SIZE_OF_L2_BUFF);
+
+        // After receiving Response frame with correct CRC (or exceeded count of attempts),
+        // check if TROPIC01 received our Request OK. If not, and total number
+        // of retries was not exhausted yet, retry whole communication.
+        if (ret == LT_L2_CRC_ERR) {
+            s2->l2_crc_error_count++;
+
+            if (total_retry_count < LT_CRC_ERR_RETRY_ATTEMPTS) {
+                memcpy(s2->buff, req_buff_backup, LT_SIZE_OF_L2_BUFF);
+                total_retry_count++;
+                retry_communication = true;
+            }
         }
-        else {
-            break;
-        }
-    }
+    } while (retry_communication);
 
     return ret;
 }
@@ -199,7 +215,7 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
 
         // In case of IN_CRC error, request to resend the last frame.
         if (ret == LT_L2_IN_CRC_ERR) {
-            for (int attempt = 0; attempt < LT_CRC_ERR_RESEND_ATTEMPTS; attempt++) {
+            for (int attempt = 0; attempt < LT_CRC_ERR_RETRY_ATTEMPTS; attempt++) {
                 s2->l2_in_crc_error_count++;
 
                 ret = lt_l2_resend_response(s2);
@@ -215,7 +231,7 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
 
         // In case of CRC error, resend the last frame.
         if (ret == LT_L2_CRC_ERR) {
-            if (frame_resend_counter > LT_CRC_ERR_RESEND_ATTEMPTS) {
+            if (frame_resend_counter > LT_CRC_ERR_RETRY_ATTEMPTS) {
                 LT_LOG_ERROR("Received LT_L2_CRC_ERR after reaching resend attempt limit of " PRIu32);
                 return ret;
             }

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -234,15 +234,23 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
                 frame_resend_counter++;
 
                 ret = lt_l2_resend_response(s2);
-                if (ret == LT_OK || ret == LT_L2_REQ_CONT || ret != LT_L2_IN_CRC_ERR) {
+                if (ret == LT_L2_IN_CRC_ERR) {
+                    s2->l2_in_crc_error_count++;
+                }
+                // If we receive LT_L2_CRC_ERR to Resend_Req, we should not retry whole communication,
+                // rather the Resend_Req again, as we cannot be sure that the CRC error appeared in the
+                // original frame or only later in the Resend_Req frame.
+                else if (ret == LT_L2_CRC_ERR) {
+                    s2->l2_crc_error_count++;
+                }
+                // Do not retry on OK or other errors.
+                else {
                     break;
                 }
-                s2->l2_in_crc_error_count++;
             }
         }
-
-        // In case of CRC error, resend the last frame if there's still some retry attempts.
-        if (ret == LT_L2_CRC_ERR && frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
+        // In case of CRC error, resend the last frame if there're still some retry attempts.
+        else if (ret == LT_L2_CRC_ERR && frame_resend_counter < LT_CRC_ERR_RETRY_ATTEMPTS) {
             s2->l2_crc_error_count++;
             frame_resend_counter++;
             i--;
@@ -253,9 +261,11 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
         if (ret != LT_OK && ret != LT_L2_REQ_CONT) {
             return ret;
         }
-
-        buff_offset += req_len;    // Move offset for next chunk
-        frame_resend_counter = 0;  // Frame sent successfully, reset the counter.
+        // OK - we can move forward in buffer and reset retry counter.
+        else {
+            buff_offset += req_len;    // Move offset for next chunk
+            frame_resend_counter = 0;  // Frame sent successfully, reset the counter.
+        }
     }
 
     return LT_OK;

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -87,6 +87,10 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2)
 
 lt_ret_t lt_l2_transfer(lt_l2_state_t *s2)
 {
+    if (!s2) {
+        return LT_PARAM_ERR;
+    }
+
     uint8_t req_buff_backup[LT_SIZE_OF_L2_BUFF];
     memcpy(req_buff_backup, s2->buff, LT_SIZE_OF_L2_BUFF);
 

--- a/tests/functional_mock/CMakeLists.txt
+++ b/tests/functional_mock/CMakeLists.txt
@@ -117,6 +117,7 @@ target_include_directories(libtropic_functional_mock_tests_objs PUBLIC ${CMAKE_C
 
 set(LIBTROPIC_MOCK_TEST_LIST
     lt_test_mock_attrs
+    lt_test_mock_invalid_crc
     lt_test_mock_invalid_in_crc
     lt_test_mock_hardware_fail
     lt_test_mock_invalid_app_fw_init

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -112,7 +112,7 @@ lt_ret_t mock_session_abort(lt_handle_t *h)
 }
 
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
-                        const size_t result_plaintext_size, bool corrupt_crc)
+                        const size_t result_plaintext_size, const bool corrupt_crc)
 {
     uint8_t l2_frame[TR01_L2_MAX_FRAME_SIZE];
 
@@ -170,7 +170,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
     return LT_OK;
 }
 
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc,
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, const bool corrupt_crc,
                                    const uint8_t custom_resp_frame[5])
 {
     if (chunk_count > 1) {

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -112,7 +112,7 @@ lt_ret_t mock_session_abort(lt_handle_t *h)
 }
 
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
-                        const size_t result_plaintext_size)
+                        const size_t result_plaintext_size, bool corrupt_crc)
 {
     uint8_t l2_frame[TR01_L2_MAX_FRAME_SIZE];
 
@@ -154,6 +154,9 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
 
     uint16_t crc = crc16(&l2_frame[TR01_L2_STATUS_OFFSET],
                          TR01_L2_STATUS_SIZE + TR01_L2_REQ_RSP_LEN_SIZE + packet_size);
+    if (corrupt_crc) {
+        crc = ~crc;
+    }
     size_t crc_offset = TR01_L2_RSP_DATA_RSP_CRC_OFFSET + packet_size;
     l2_frame[crc_offset] = crc >> 8;
     l2_frame[crc_offset + 1] = crc & 0x00FF;

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -167,7 +167,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
     return LT_OK;
 }
 
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count)
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc)
 {
     if (chunk_count > 1) {
         LT_LOG_ERROR("Only single chunk supported now!");
@@ -189,6 +189,11 @@ lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count)
     };
 
     uint16_t crc = crc16(req_ok_frame + 1, 2);
+
+    if (corrupt_crc) {
+        crc = ~crc;
+    }
+
     req_ok_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET] = crc >> 8;
     req_ok_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET + 1] = crc & 0x00FF;
 

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -170,7 +170,8 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
     return LT_OK;
 }
 
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc)
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc,
+                                   const uint8_t custom_resp_frame[5])
 {
     if (chunk_count > 1) {
         LT_LOG_ERROR("Only single chunk supported now!");
@@ -184,12 +185,15 @@ lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, boo
         return ret;
     }
 
-    uint8_t req_ok_frame[5] = {
-        TR01_L1_CHIP_MODE_READY_bit, TR01_L2_STATUS_REQUEST_OK,
-        0x00,  // Zero RSP length
-        0x00,  // | Dummy CRC -- will be calculated later
-        0x00   // |
-    };
+    uint8_t req_ok_frame[5] = {0};
+    if (custom_resp_frame == NULL) {
+        req_ok_frame[TR01_L2_CHIP_STATUS_OFFSET] = TR01_L1_CHIP_MODE_READY_bit;
+        req_ok_frame[TR01_L2_STATUS_OFFSET] = TR01_L2_STATUS_REQUEST_OK;
+        req_ok_frame[TR01_L2_RSP_LEN_OFFSET] = 0x00;
+    }
+    else {
+        memcpy(req_ok_frame, custom_resp_frame, sizeof(req_ok_frame));
+    }
 
     uint16_t crc = crc16(req_ok_frame + 1, 2);
 

--- a/tests/functional_mock/helpers/lt_mock_helpers.c
+++ b/tests/functional_mock/helpers/lt_mock_helpers.c
@@ -112,7 +112,8 @@ lt_ret_t mock_session_abort(lt_handle_t *h)
 }
 
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
-                        const size_t result_plaintext_size, const bool corrupt_crc)
+                        const size_t result_plaintext_size, const uint8_t status,
+                        const bool corrupt_crc)
 {
     uint8_t l2_frame[TR01_L2_MAX_FRAME_SIZE];
 
@@ -135,7 +136,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
     }
 
     l2_frame[TR01_L2_CHIP_STATUS_OFFSET] = TR01_L1_CHIP_MODE_READY_bit;
-    l2_frame[TR01_L2_STATUS_OFFSET] = TR01_L2_STATUS_RESULT_OK;
+    l2_frame[TR01_L2_STATUS_OFFSET] = status;
     l2_frame[TR01_L2_RSP_LEN_OFFSET] = (uint8_t)packet_size;
 
     l2_frame[TR01_L2_RSP_DATA_RSP_CRC_OFFSET] = result_plaintext_size;

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -112,10 +112,13 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
  * @param chunk_count Count of the L3 Command chunks. Only single chunk supported now.
  * @param corrupt_crc If true, CRC will be intentionally corrupted (e.g., to test CRC handling).
+ * @param custom_resp_frame Optional custom 5-byte L2 response frame. If NULL, a default
+ * frame with STATUS=REQ_OK and zero response length is used.
  *
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc);
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc,
+                                   const uint8_t custom_resp_frame[5]);
 
 #ifdef __cplusplus
 }

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -98,7 +98,7 @@ lt_ret_t mock_session_abort(lt_handle_t *h);
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
-                        const size_t result_plaintext_size, bool corrupt_crc);
+                        const size_t result_plaintext_size, const bool corrupt_crc);
 
 /**
  * @brief Mock replies to a L3 Command.
@@ -117,7 +117,7 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
  *
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc,
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, const bool corrupt_crc,
                                    const uint8_t custom_resp_frame[5]);
 
 #ifdef __cplusplus

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -93,12 +93,14 @@ lt_ret_t mock_session_abort(lt_handle_t *h);
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
  * @param result_plaintext Plaintext of the L3 Result data to use.
  * @param result_plaintext_size Size of the result_plaintext.
+ * @param status Value of the STATUS field of the frame.
  * @param corrupt_crc If true, CRC will be intentionally corrupted (e.g., to test CRC handling).
  *
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
-                        const size_t result_plaintext_size, const bool corrupt_crc);
+                        const size_t result_plaintext_size, const uint8_t status,
+                        const bool corrupt_crc);
 
 /**
  * @brief Mock replies to a L3 Command.

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -110,10 +110,11 @@ lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
  *
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
  * @param chunk_count Count of the L3 Command chunks. Only single chunk supported now.
+ * @param corrupt_crc If true, CRC will be intentionally corrupted (e.g., to test CRC handling).
  *
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
-lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count);
+lt_ret_t mock_l3_command_responses(lt_handle_t *h, const size_t chunk_count, bool corrupt_crc);
 
 #ifdef __cplusplus
 }

--- a/tests/functional_mock/helpers/lt_mock_helpers.h
+++ b/tests/functional_mock/helpers/lt_mock_helpers.h
@@ -93,11 +93,12 @@ lt_ret_t mock_session_abort(lt_handle_t *h);
  * @param h Pointer to an lt_handle_t to use (for encryption and enqueuing).
  * @param result_plaintext Plaintext of the L3 Result data to use.
  * @param result_plaintext_size Size of the result_plaintext.
+ * @param corrupt_crc If true, CRC will be intentionally corrupted (e.g., to test CRC handling).
  *
  * @return LT_OK on success, or an appropriate lt_ret_t error code on failure.
  */
 lt_ret_t mock_l3_result(lt_handle_t *h, const uint8_t *result_plaintext,
-                        const size_t result_plaintext_size);
+                        const size_t result_plaintext_size, bool corrupt_crc);
 
 /**
  * @brief Mock replies to a L3 Command.

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -38,13 +38,13 @@ void lt_test_mock_attrs(lt_handle_t *h);
  *  1. Mock init sequence and initialize Libtropic handle.
  *  2. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Deplete all retry attempts and check if
  *     LT_L2_IN_CRC_ERR was returned.
- *  3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send one corrupted frame and then a correct
- *     one and check if LT_OK is returned.
+ *  3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send random number of corrupted frames
+ *     (in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]) and then a correct one and check if LT_OK is returned.
  *  4. Start mocked Secure Session.
  *  5. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Deplete all retry attempts and check if
  *     LT_L2_IN_CRC_ERR was returned.
- *  6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send one corrupted frame and then a correct
- *     one and check if LT_OK is returned.
+ *  6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send random number of corrupted frames
+ *     (in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]) and then a correct one and check if LT_OK is returned.
  *  7. Terminate the session and deinitialize the Libtropic handle.
  *
  * @param h Handle for communication with TROPIC01

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -38,14 +38,22 @@ void lt_test_mock_attrs(lt_handle_t *h);
  *  1. Mock init sequence and initialize Libtropic handle.
  *  2. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Deplete all retry attempts and check if
  *     LT_L2_IN_CRC_ERR was returned.
- *  3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send random number of corrupted frames
- *     (in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]) and then a correct one and check if LT_OK is returned.
+ *  3. Test LT_L2_IN_CRC_ERR retry mechanism on L2:  Send random number of corrupted frames (with
+ *     incorrect CRC) and then a correct one and check if LT_OK is returned.
  *  4. Start mocked Secure Session.
- *  5. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Deplete all retry attempts and check if
- *     LT_L2_IN_CRC_ERR was returned.
- *  6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send random number of corrupted frames
- *     (in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]) and then a correct one and check if LT_OK is returned.
- *  7. Terminate the session and deinitialize the Libtropic handle.
+ *  5. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send corrupted CRCs in
+ *     the reponses to commands. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned.
+ *     Use lt_ping as a dummy command.
+ *  6. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send random number of
+ *     corrupted frames (with incorrect CRC) in the reponses to commands and then a correct one and
+ *     check if LT_OK is returned. Use lt_ping as a dummy command.
+ *  7. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res: send corrupted CRCs in
+ *     Results. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned. Use lt_ping as a
+ *     dummy command.
+ *  8. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res: send random number of
+ *     corrupted Results (with incorrect CRC) then a correct one and check if LT_OK is returned. Use
+ *     lt_ping as a dummy command.
+ *  9. Terminate the session and deinitialize the Libtropic handle.
  *
  * @param h Handle for communication with TROPIC01
  */

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -45,7 +45,11 @@ void lt_test_mock_attrs(lt_handle_t *h);
  *     STATUS=CRC_ERR until all retry attempts are depleted and verify LT_L2_CRC_ERR is returned.
  *  6. Test LT_L2_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd with a random number
  *     of STATUS=CRC_ERR frames followed by STATUS=OK and verify LT_OK is returned.
- *  7. Terminate Secure Session and deinitialize the Libtropic handle.
+ *  7. Test LT_L2_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res by returning
+ *     STATUS=CRC_ERR until all retry attempts are depleted and verify LT_L2_CRC_ERR is returned.
+ *  8. Test LT_L2_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res with a random number
+ *     of STATUS=CRC_ERR frames followed by STATUS=OK and verify LT_OK is returned.
+ *  9. Terminate Secure Session and deinitialize the Libtropic handle.
  *
  * @param h Handle for communication with TROPIC01
  */

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -30,6 +30,28 @@ extern "C" {
 void lt_test_mock_attrs(lt_handle_t *h);
 
 /**
+ * @brief Test for handling invalid CRC in requests sent to TROPIC01.
+ *
+ * @note Get_Info Request is used for testing on L2, and Ping is used on L3.
+ *
+ * Test steps:
+ *  1. Mock init sequence and initialize Libtropic handle.
+ *  2. Test LT_L2_CRC_ERR retry mechanism on L2 by returning STATUS=CRC_ERR until all retry
+ *     attempts are depleted and verify LT_L2_CRC_ERR is returned.
+ *  3. Test LT_L2_CRC_ERR retry mechanism on L2 with a random number of STATUS=CRC_ERR frames
+ *     followed by STATUS=OK and verify LT_OK is returned.
+ *  4. Start mocked Secure Session.
+ *  5. Test LT_L2_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd by returning
+ *     STATUS=CRC_ERR until all retry attempts are depleted and verify LT_L2_CRC_ERR is returned.
+ *  6. Test LT_L2_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd with a random number
+ *     of STATUS=CRC_ERR frames followed by STATUS=OK and verify LT_OK is returned.
+ *  7. Terminate Secure Session and deinitialize the Libtropic handle.
+ *
+ * @param h Handle for communication with TROPIC01
+ */
+void lt_test_mock_invalid_crc(lt_handle_t *h);
+
+/**
  * @brief Test for handling invalid CRC in TROPIC01 responses.
  *
  * @note Get_Info Request is used for testing on L2, and Ping is used on L3.

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -32,13 +32,20 @@ void lt_test_mock_attrs(lt_handle_t *h);
 /**
  * @brief Test for handling invalid CRC in TROPIC01 responses.
  *
- * @note Get_Info Request is used for testing.
+ * @note Get_Info Request is used for testing on L2, and Ping is used on L3.
  *
  * Test steps:
  *  1. Mock init sequence and initialize Libtropic handle.
- *  2. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned.
- *  3. Send one corrupted frame and then a correct one and check if LT_OK is returned.
- *  4. Deinitialize Libtropic handle.
+ *  2. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Deplete all retry attempts and check if
+ *     LT_L2_IN_CRC_ERR was returned.
+ *  3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send one corrupted frame and then a correct
+ *     one and check if LT_OK is returned.
+ *  4. Start mocked Secure Session.
+ *  5. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Deplete all retry attempts and check if
+ *     LT_L2_IN_CRC_ERR was returned.
+ *  6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send one corrupted frame and then a correct
+ *     one and check if LT_OK is returned.
+ *  7. Terminate the session and deinitialize the Libtropic handle.
  *
  * @param h Handle for communication with TROPIC01
  */

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -64,10 +64,10 @@ void lt_test_mock_invalid_crc(lt_handle_t *h);
  *     incorrect CRC) and then a correct one and check if LT_OK is returned.
  *  4. Start mocked Secure Session.
  *  5. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send corrupted CRCs in
- *     the reponses to commands. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned.
- *     Use lt_ping as a dummy command.
+ *     the responses to commands. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was
+ *     returned. Use lt_ping as a dummy command.
  *  6. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send random number of
- *     corrupted frames (with incorrect CRC) in the reponses to commands and then a correct one and
+ *     corrupted frames (with incorrect CRC) in the responses to commands and then a correct one and
  *     check if LT_OK is returned. Use lt_ping as a dummy command.
  *  7. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res: send corrupted CRCs in
  *     Results. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned. Use lt_ping as a

--- a/tests/functional_mock/lt_functional_mock_tests.h
+++ b/tests/functional_mock/lt_functional_mock_tests.h
@@ -32,10 +32,13 @@ void lt_test_mock_attrs(lt_handle_t *h);
 /**
  * @brief Test for handling invalid CRC in TROPIC01 responses.
  *
+ * @note Get_Info Request is used for testing.
+ *
  * Test steps:
- *  1. Mock a response with an invalid CRC for a dummy request (Get_Info is used).
- *  2. Send request.
- *  3. Verify that Libtropic correctly identifies the invalid CRC and returns an error.
+ *  1. Mock init sequence and initialize Libtropic handle.
+ *  2. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned.
+ *  3. Send one corrupted frame and then a correct one and check if LT_OK is returned.
+ *  4. Deinitialize Libtropic handle.
  *
  * @param h Handle for communication with TROPIC01
  */

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -60,7 +60,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
             TR01_L3_RESULT_HARDWARE_FAIL,
         };
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_write_plaintext,
-                                             sizeof(pairing_key_write_plaintext)));
+                                             sizeof(pairing_key_write_plaintext), false));
 
         LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, dummy_key, sizeof(dummy_key)));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_write(h, dummy_key, slot));
@@ -79,7 +79,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
             TR01_L3_RESULT_HARDWARE_FAIL,
         };
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_invalidate_plaintext,
-                                             sizeof(pairing_key_invalidate_plaintext)));
+                                             sizeof(pairing_key_invalidate_plaintext), false));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_invalidate(h, slot));
     }
 
@@ -93,8 +93,8 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     uint8_t r_config_write_plaintext[] = {
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
-    LT_TEST_ASSERT(LT_OK,
-                   mock_l3_result(h, r_config_write_plaintext, sizeof(r_config_write_plaintext)));
+    LT_TEST_ASSERT(
+        LT_OK, mock_l3_result(h, r_config_write_plaintext, sizeof(r_config_write_plaintext), false));
     LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL,
                    lt_r_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
@@ -108,8 +108,8 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     uint8_t i_config_write_plaintext[] = {
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
-    LT_TEST_ASSERT(LT_OK,
-                   mock_l3_result(h, i_config_write_plaintext, sizeof(i_config_write_plaintext)));
+    LT_TEST_ASSERT(
+        LT_OK, mock_l3_result(h, i_config_write_plaintext, sizeof(i_config_write_plaintext), false));
     LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL,
                    lt_i_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
@@ -123,8 +123,8 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     uint8_t r_mem_data_write_plaintext[] = {
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
-    LT_TEST_ASSERT(LT_OK,
-                   mock_l3_result(h, r_mem_data_write_plaintext, sizeof(r_mem_data_write_plaintext)));
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, r_mem_data_write_plaintext,
+                                         sizeof(r_mem_data_write_plaintext), false));
 
     uint16_t random_r_mem_slot;
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_r_mem_slot, sizeof(random_r_mem_slot)));

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -53,7 +53,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++) {
         LT_LOG_INFO("Mocking for slot %d...", slot);
         // Mock replies to the command.
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
 
         // Mock command result itself.
         uint8_t pairing_key_write_plaintext[] = {
@@ -72,7 +72,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++) {
         LT_LOG_INFO("Mocking for slot %d...", slot);
         // Mock replies to the command.
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
 
         // Mock command result itself.
         uint8_t pairing_key_invalidate_plaintext[] = {
@@ -87,7 +87,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in R_Config_Write reply...");
     // Mock replies to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
 
     // Mock command result itself.
     uint8_t r_config_write_plaintext[] = {
@@ -102,7 +102,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in I_Config_Write reply...");
     // Mock replies to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
 
     // Mock command result itself.
     uint8_t i_config_write_plaintext[] = {
@@ -117,7 +117,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in R_Mem_Data_Write reply...");
     // Mock replies to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
 
     // Mock command result itself.
     uint8_t r_mem_data_write_plaintext[] = {

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -53,7 +53,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++) {
         LT_LOG_INFO("Mocking for slot %d...", slot);
         // Mock replies to the command.
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
         // Mock command result itself.
         uint8_t pairing_key_write_plaintext[] = {
@@ -72,7 +72,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     for (int slot = TR01_PAIRING_KEY_SLOT_INDEX_0; slot <= TR01_PAIRING_KEY_SLOT_INDEX_3; slot++) {
         LT_LOG_INFO("Mocking for slot %d...", slot);
         // Mock replies to the command.
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
         // Mock command result itself.
         uint8_t pairing_key_invalidate_plaintext[] = {
@@ -87,7 +87,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in R_Config_Write reply...");
     // Mock replies to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
     // Mock command result itself.
     uint8_t r_config_write_plaintext[] = {
@@ -102,7 +102,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in I_Config_Write reply...");
     // Mock replies to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
     // Mock command result itself.
     uint8_t i_config_write_plaintext[] = {
@@ -117,7 +117,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
 
     LT_LOG_INFO("Mocking HARDWARE_FAIL in R_Mem_Data_Write reply...");
     // Mock replies to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
     // Mock command result itself.
     uint8_t r_mem_data_write_plaintext[] = {

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -61,7 +61,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
         };
         LT_TEST_ASSERT(
             LT_OK, mock_l3_result(h, pairing_key_write_plaintext, sizeof(pairing_key_write_plaintext),
-                                  TR01_L2_STATUS_REQUEST_OK, false));
+                                  TR01_L2_STATUS_RESULT_OK, false));
 
         LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, dummy_key, sizeof(dummy_key)));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_write(h, dummy_key, slot));
@@ -81,7 +81,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
         };
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_invalidate_plaintext,
                                              sizeof(pairing_key_invalidate_plaintext),
-                                             TR01_L2_STATUS_REQUEST_OK, false));
+                                             TR01_L2_STATUS_RESULT_OK, false));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_invalidate(h, slot));
     }
 
@@ -96,7 +96,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, r_config_write_plaintext, sizeof(r_config_write_plaintext),
-                                         TR01_L2_STATUS_REQUEST_OK, false));
+                                         TR01_L2_STATUS_RESULT_OK, false));
     LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL,
                    lt_r_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
@@ -111,7 +111,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, i_config_write_plaintext, sizeof(i_config_write_plaintext),
-                                         TR01_L2_STATUS_REQUEST_OK, false));
+                                         TR01_L2_STATUS_RESULT_OK, false));
     LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL,
                    lt_i_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
@@ -127,7 +127,7 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     };
     LT_TEST_ASSERT(LT_OK,
                    mock_l3_result(h, r_mem_data_write_plaintext, sizeof(r_mem_data_write_plaintext),
-                                  TR01_L2_STATUS_REQUEST_OK, false));
+                                  TR01_L2_STATUS_RESULT_OK, false));
 
     uint16_t random_r_mem_slot;
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_r_mem_slot, sizeof(random_r_mem_slot)));

--- a/tests/functional_mock/lt_test_mock_hardware_fail.c
+++ b/tests/functional_mock/lt_test_mock_hardware_fail.c
@@ -59,8 +59,9 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
         uint8_t pairing_key_write_plaintext[] = {
             TR01_L3_RESULT_HARDWARE_FAIL,
         };
-        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_write_plaintext,
-                                             sizeof(pairing_key_write_plaintext), false));
+        LT_TEST_ASSERT(
+            LT_OK, mock_l3_result(h, pairing_key_write_plaintext, sizeof(pairing_key_write_plaintext),
+                                  TR01_L2_STATUS_REQUEST_OK, false));
 
         LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, dummy_key, sizeof(dummy_key)));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_write(h, dummy_key, slot));
@@ -79,7 +80,8 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
             TR01_L3_RESULT_HARDWARE_FAIL,
         };
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, pairing_key_invalidate_plaintext,
-                                             sizeof(pairing_key_invalidate_plaintext), false));
+                                             sizeof(pairing_key_invalidate_plaintext),
+                                             TR01_L2_STATUS_REQUEST_OK, false));
         LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL, lt_pairing_key_invalidate(h, slot));
     }
 
@@ -93,8 +95,8 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     uint8_t r_config_write_plaintext[] = {
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
-    LT_TEST_ASSERT(
-        LT_OK, mock_l3_result(h, r_config_write_plaintext, sizeof(r_config_write_plaintext), false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, r_config_write_plaintext, sizeof(r_config_write_plaintext),
+                                         TR01_L2_STATUS_REQUEST_OK, false));
     LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL,
                    lt_r_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
@@ -108,8 +110,8 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     uint8_t i_config_write_plaintext[] = {
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
-    LT_TEST_ASSERT(
-        LT_OK, mock_l3_result(h, i_config_write_plaintext, sizeof(i_config_write_plaintext), false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, i_config_write_plaintext, sizeof(i_config_write_plaintext),
+                                         TR01_L2_STATUS_REQUEST_OK, false));
     LT_TEST_ASSERT(LT_L3_HARDWARE_FAIL,
                    lt_i_config_write(h, TR01_CFG_START_UP_ADDR, 0x00));  // Dummy object
 
@@ -123,8 +125,9 @@ void lt_test_mock_hardware_fail(lt_handle_t *h)
     uint8_t r_mem_data_write_plaintext[] = {
         TR01_L3_RESULT_HARDWARE_FAIL,
     };
-    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, r_mem_data_write_plaintext,
-                                         sizeof(r_mem_data_write_plaintext), false));
+    LT_TEST_ASSERT(LT_OK,
+                   mock_l3_result(h, r_mem_data_write_plaintext, sizeof(r_mem_data_write_plaintext),
+                                  TR01_L2_STATUS_REQUEST_OK, false));
 
     uint16_t random_r_mem_slot;
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_r_mem_slot, sizeof(random_r_mem_slot)));

--- a/tests/functional_mock/lt_test_mock_invalid_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_crc.c
@@ -191,7 +191,7 @@ void lt_test_mock_invalid_crc(lt_handle_t *h)
         // Enqueue successful L3 result payload returned by lt_ping.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                             TR01_L2_STATUS_REQUEST_OK, false));
+                                             TR01_L2_STATUS_RESULT_OK, false));
 
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
         uint8_t msg_in[sizeof(msg_out)];
@@ -272,7 +272,7 @@ void lt_test_mock_invalid_crc(lt_handle_t *h)
 
         // Enqueue successful L3 result payload returned by lt_ping.
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                             TR01_L2_STATUS_REQUEST_OK, false));
+                                             TR01_L2_STATUS_RESULT_OK, false));
 
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
         uint8_t msg_in[sizeof(msg_out)];

--- a/tests/functional_mock/lt_test_mock_invalid_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_crc.c
@@ -190,7 +190,8 @@ void lt_test_mock_invalid_crc(lt_handle_t *h)
 
         // Enqueue successful L3 result payload returned by lt_ping.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
-        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                             TR01_L2_STATUS_REQUEST_OK, false));
 
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
         uint8_t msg_in[sizeof(msg_out)];
@@ -202,9 +203,90 @@ void lt_test_mock_invalid_crc(lt_handle_t *h)
         h->l2.l2_crc_error_count = 0;
     }
 
-    // 7. Terminate Secure Session and deinitialize the Libtropic handle.
+    // 7. L3 result path (lt_l2_recv_encrypted_res): return frames with STATUS=CRC_ERR until
+    // retries are depleted and verify LT_L2_CRC_ERR from lt_ping.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("7. Terminate Secure Session and deinitialize the Libtropic handle.");
+    {
+        LT_LOG_INFO(
+            "7. L3 result path (lt_l2_recv_encrypted_res): return frames with STATUS=CRC_ERR until "
+            "retries are depleted and verify LT_L2_CRC_ERR from lt_ping.");
+
+        // Mock a command response (STATUS=OK)
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
+
+        // Enqueue L3 result with STATUS=CRC_ERR.
+        uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                             TR01_L2_STATUS_CRC_ERR, false));
+
+        // Enqueue responses to Resend_Req and L3 results with STATUS=CRC_ERR.
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        for (int i = 0; i < LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+            // Response to Resend_Req.
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+            // Resent frame, again with STATUS=CRC_ERR.
+            LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                                 TR01_L2_STATUS_CRC_ERR, false));
+        }
+
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_L2_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+        // Verify error counter and reset for next test step.
+        LT_TEST_ASSERT(0, h->l2.l2_in_crc_error_count);
+        LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_crc_error_count);
+        h->l2.l2_crc_error_count = 0;
+    }
+
+    // 8. L3 result path (lt_l2_recv_encrypted_res): return random number of frames with
+    // STATUS=CRC_ERR, then a correct frame, and verify LT_OK from lt_ping.
+    // ---------------------------------------------------------------------------------------------
+    {
+        LT_LOG_INFO(
+            "8. L3 result path (lt_l2_recv_encrypted_res): return random number of frames with "
+            "STATUS=CRC_ERR, then a correct frame, and verify LT_OK from lt_ping.");
+
+        // Generate number of CRC_ERR responses in range [1, LT_CRC_ERR_RETRY_ATTEMPTS].
+        uint8_t random_byte;
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+        int num_corrupted_results = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+        LT_LOG_INFO("Sending %d corrupted result frames before correct frame", num_corrupted_results);
+
+        // Mock a command response (STATUS=OK)
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
+
+        // Enqueue responses to Resend_Req and L3 results with STATUS=CRC_ERR.
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
+        for (int i = 0; i < num_corrupted_results; i++) {
+            // Enqueue L3 result with STATUS=CRC_ERR.
+            LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                                 TR01_L2_STATUS_CRC_ERR, false));
+
+            // Response to Resend_Req.
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        }
+
+        // Enqueue successful L3 result payload returned by lt_ping.
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                             TR01_L2_STATUS_REQUEST_OK, false));
+
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+        // Verify error counter and reset for next test step.
+        LT_TEST_ASSERT(0, h->l2.l2_in_crc_error_count);
+        LT_TEST_ASSERT(num_corrupted_results, h->l2.l2_crc_error_count);
+        h->l2.l2_crc_error_count = 0;
+    }
+
+    // 9. Terminate Secure Session and deinitialize the Libtropic handle.
+    // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("9. Terminate Secure Session and deinitialize the Libtropic handle.");
 
     LT_LOG_INFO("Terminating the Secure Session...");
     LT_TEST_ASSERT(LT_OK, mock_session_abort(h));

--- a/tests/functional_mock/lt_test_mock_invalid_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_crc.c
@@ -1,0 +1,214 @@
+/**
+ * @file lt_test_mock_invalid_crc.c
+ * @brief Test for handling invalid CRC in requests sent to TROPIC01.
+ * @copyright Copyright (c) 2020-2026 Tropic Square s.r.o.
+ *
+ * @license For the license see LICENSE.md in the root directory of this source tree.
+ */
+
+#include <string.h>
+
+#include "libtropic.h"
+#include "libtropic_common.h"
+#include "libtropic_logging.h"
+#include "libtropic_port_mock.h"
+#include "lt_functional_mock_tests.h"
+#include "lt_l1.h"
+#include "lt_l2_api_structs.h"
+#include "lt_l2_frame_check.h"
+#include "lt_l3_process.h"
+#include "lt_mock_helpers.h"
+#include "lt_port_wrap.h"
+#include "lt_test_common.h"
+
+void lt_test_mock_invalid_crc(lt_handle_t *h)
+{
+    LT_LOG_INFO("----------------------------------------------");
+    LT_LOG_INFO("lt_test_mock_invalid_crc()");
+    LT_LOG_INFO("----------------------------------------------");
+
+    if (LT_CRC_ERR_RETRY_ATTEMPTS < 1) {
+        LT_LOG_ERROR("This test requires that at least one retry attempt is configured.");
+        LT_TEST_ASSERT(0, 1);  // Forcefully fail the test.
+    }
+
+    // 1. Mock init sequence and initialize Libtropic handle.
+    // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("1. Mock init sequence and initialize Libtropic handle.");
+
+    lt_mock_hal_reset(&h->l2);
+    LT_LOG_INFO("Mocking initialization...");
+    LT_TEST_ASSERT(LT_OK,
+                   mock_init_communication(h, (uint8_t[]){0x00, 0x00, 0x00, 0x02}));  // Version 2.0.0
+
+    LT_LOG_INFO("Initializing handle");
+    LT_TEST_ASSERT(LT_OK, lt_init(h));
+
+    // 2. L2 path: return STATUS=CRC_ERR until retries are depleted and verify LT_L2_CRC_ERR.
+    // ---------------------------------------------------------------------------------------------
+    {
+        LT_LOG_INFO(
+            "2. L2 path: return STATUS=CRC_ERR until retries are depleted and verify LT_L2_CRC_ERR.");
+
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        struct lt_l2_get_info_rsp_t get_info_resp_crc_error_status = {
+            .chip_status = TR01_L1_CHIP_MODE_READY_bit,
+            .status = TR01_L2_STATUS_CRC_ERR,
+            .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
+            .object = {0x00, 0x00, 0x00, 0x02}  // dummy data
+        };
+        add_resp_crc(&get_info_resp_crc_error_status);
+
+        // Enqueue one initial response plus all retry responses.
+        // Total count is 1 + LT_CRC_ERR_RETRY_ATTEMPTS.
+        for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+            LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(
+                                      &h->l2, (uint8_t *)&get_info_resp_crc_error_status,
+                                      calc_mocked_resp_len(&get_info_resp_crc_error_status)));
+        }
+
+        uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+        LT_TEST_ASSERT(LT_L2_CRC_ERR, lt_get_info_riscv_fw_ver(h, dummy_out));
+
+        // Verify error counters and reset CRC counter for next test step.
+        LT_TEST_ASSERT(0, h->l2.l2_in_crc_error_count);
+        LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_crc_error_count);
+        h->l2.l2_crc_error_count = 0;
+    }
+    // 3. L2 path: return random number of STATUS=CRC_ERR frames, then STATUS=OK, and verify LT_OK.
+    // ---------------------------------------------------------------------------------------------
+    {
+        LT_LOG_INFO(
+            "3. L2 path: return random number of STATUS=CRC_ERR frames, then STATUS=OK, and verify "
+            "LT_OK.");
+
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        struct lt_l2_get_info_rsp_t get_info_resp_crc_error_status = {
+            .chip_status = TR01_L1_CHIP_MODE_READY_bit,
+            .status = TR01_L2_STATUS_CRC_ERR,
+            .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
+            .object = {0x00, 0x00, 0x00, 0x02}  // dummy data
+        };
+        add_resp_crc(&get_info_resp_crc_error_status);
+
+        uint8_t random_byte;
+        // Generate number of CRC_ERR responses in range [1, LT_CRC_ERR_RETRY_ATTEMPTS].
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+        int num_corrupted_l2 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+        LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l2);
+
+        // Enqueue randomized number of CRC_ERR responses.
+        for (int i = 0; i < num_corrupted_l2; i++) {
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+            LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(
+                                      &h->l2, (uint8_t *)&get_info_resp_crc_error_status,
+                                      calc_mocked_resp_len(&get_info_resp_crc_error_status)));
+        }
+
+        // Enqueue one STATUS=OK response.
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        struct lt_l2_get_info_rsp_t get_info_resp = {.chip_status = TR01_L1_CHIP_MODE_READY_bit,
+                                                     .status = TR01_L2_STATUS_REQUEST_OK,
+                                                     .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
+                                                     .object = {0x00, 0x00, 0x00, 0x02}};
+        add_resp_crc(&get_info_resp);
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp,
+                                                           calc_mocked_resp_len(&get_info_resp)));
+
+        uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+        LT_TEST_ASSERT(LT_OK, lt_get_info_riscv_fw_ver(h, dummy_out));
+
+        // Verify error counters and reset CRC counter for next test step.
+        LT_TEST_ASSERT(0, h->l2.l2_in_crc_error_count);
+        LT_TEST_ASSERT(num_corrupted_l2, h->l2.l2_crc_error_count);
+        h->l2.l2_crc_error_count = 0;
+    }
+
+    // 4. Start mocked Secure Session.
+    // ---------------------------------------------------------------------------------------------
+    {
+        LT_LOG_INFO("4. Start mocked Secure Session.");
+        uint8_t kcmd[TR01_AES256_KEY_LEN];
+        uint8_t kres[TR01_AES256_KEY_LEN];
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, kcmd, sizeof(kcmd)));
+        memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
+        LT_TEST_ASSERT(LT_OK, mock_session_start(h, kcmd, kres));
+    }
+
+    // 5. L3 command path (lt_l2_send_encrypted_cmd): return STATUS=CRC_ERR until retries are depleted
+    // and verify LT_L2_CRC_ERR from lt_ping.
+    // ---------------------------------------------------------------------------------------------
+    {
+        LT_LOG_INFO(
+            "5. L3 command path (lt_l2_send_encrypted_cmd): return STATUS=CRC_ERR until retries are "
+            "depleted and verify LT_L2_CRC_ERR from lt_ping.");
+
+        // Enqueue one initial response plus all retry responses.
+        // Total count is 1 + LT_CRC_ERR_RETRY_ATTEMPTS.
+        const uint8_t resp_with_crc_error_status[5] = {TR01_L1_CHIP_MODE_READY_bit,
+                                                       TR01_L2_STATUS_CRC_ERR, 0x00};
+
+        for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+            LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, resp_with_crc_error_status));
+        }
+
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_L2_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+        // Verify error counters and reset CRC counter for next test step.
+        LT_TEST_ASSERT(0, h->l2.l2_in_crc_error_count);
+        LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_crc_error_count);
+        h->l2.l2_crc_error_count = 0;
+    }
+    // 6. L3 command path (lt_l2_send_encrypted_cmd): return random number of STATUS=CRC_ERR frames,
+    // then STATUS=OK, and verify LT_OK from lt_ping.
+    // ---------------------------------------------------------------------------------------------
+    {
+        LT_LOG_INFO(
+            "6. L3 command path (lt_l2_send_encrypted_cmd): return random number of STATUS=CRC_ERR "
+            "frames, then STATUS=OK, and verify LT_OK from lt_ping.");
+
+        // Generate number of CRC_ERR responses in range [1, LT_CRC_ERR_RETRY_ATTEMPTS].
+        uint8_t random_byte;
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+        int num_corrupted_l2 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+        LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l2);
+
+        // Enqueue randomized number of CRC_ERR responses.
+        const uint8_t resp_with_crc_error_status[5] = {TR01_L1_CHIP_MODE_READY_bit,
+                                                       TR01_L2_STATUS_CRC_ERR, 0x00};
+
+        for (int i = 0; i < num_corrupted_l2; i++) {
+            LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, resp_with_crc_error_status));
+        }
+        // Enqueue frame with STATUS=OK.
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
+
+        // Enqueue successful L3 result payload returned by lt_ping.
+        uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
+
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+        // Verify error counters and reset CRC counter for next test step.
+        LT_TEST_ASSERT(0, h->l2.l2_in_crc_error_count);
+        LT_TEST_ASSERT(num_corrupted_l2, h->l2.l2_crc_error_count);
+        h->l2.l2_crc_error_count = 0;
+    }
+
+    // 7. Terminate Secure Session and deinitialize the Libtropic handle.
+    // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("7. Terminate Secure Session and deinitialize the Libtropic handle.");
+
+    LT_LOG_INFO("Terminating the Secure Session...");
+    LT_TEST_ASSERT(LT_OK, mock_session_abort(h));
+
+    LT_LOG_INFO("Deinitializing handle");
+    LT_TEST_ASSERT(LT_OK, lt_deinit(h));
+}

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -125,7 +125,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     // Enqueue count of responses based on configured resend attempts.
     // 1 + LT_CRC_ERR_RETRY_ATTEMPTS, because first is normal Request, remaining are retries.
     for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true));
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true, NULL));
     }
 
     const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
@@ -149,11 +149,11 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
     // Enqueue random number of corrupted responses
     for (int i = 0; i < num_corrupted_l3; i++) {
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true));
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true, NULL));
     }
 
     // Enqueue one correct response
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
     // Mock command result itself.
     uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
@@ -172,7 +172,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     // ---------------------------------------------------------------------------------------------
 
     // Answer with correct Reponse frame to Command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
     // Return Result with corrupted CRC.
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
@@ -195,7 +195,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     // ---------------------------------------------------------------------------------------------
 
     // Answer with correct Reponse frame to Command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
     // Generate random number of corrupted Results in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -177,7 +177,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
         // Mock command result itself.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                             TR01_L2_STATUS_REQUEST_OK, false));
+                                             TR01_L2_STATUS_RESULT_OK, false));
 
         // Send the command, check the message.
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
@@ -202,7 +202,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
         // Return a Result payload that has an invalid CRC.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                             TR01_L2_STATUS_REQUEST_OK, true));
+                                             TR01_L2_STATUS_RESULT_OK, true));
 
         // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
         // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
@@ -211,7 +211,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
             LT_TEST_ASSERT(LT_OK,
                            lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
             LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                                 TR01_L2_STATUS_REQUEST_OK, true));
+                                                 TR01_L2_STATUS_RESULT_OK, true));
         }
 
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
@@ -238,7 +238,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
         // Send the first corrupted Result.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                             TR01_L2_STATUS_REQUEST_OK, true));
+                                             TR01_L2_STATUS_RESULT_OK, true));
 
         // Enqueue additional corrupted Results (if any) to simulate resend cycles.
         const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
@@ -247,13 +247,13 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
             LT_TEST_ASSERT(LT_OK,
                            lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
             LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                                 TR01_L2_STATUS_REQUEST_OK, true));
+                                                 TR01_L2_STATUS_RESULT_OK, true));
         }
 
         // Finally, enqueue a valid Result with correct CRC.
         LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
-                                             TR01_L2_STATUS_REQUEST_OK, false));
+                                             TR01_L2_STATUS_RESULT_OK, false));
 
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
         uint8_t msg_in[sizeof(msg_out)];

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -32,6 +32,8 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
         LT_TEST_ASSERT(0, 1);  // Forcefully fail the test.
     }
 
+    uint8_t random_byte;
+
     // 1. Mock init sequence and initialize Libtropic handle
     // ---------------------------------------------------------------------------------------------
 
@@ -71,15 +73,14 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send random number of corrupted frames and then
-    // a correct one and check if LT_OK is returned.
+    // 3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send random number of corrupted frames (with
+    // incorrect CRC) and then a correct one and check if LT_OK is returned.
     // ---------------------------------------------------------------------------------------------
     LT_LOG_INFO("Mocking reponses to Get_Info request with random corrupted and one correct CRC...");
 
     // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
-    uint8_t random_byte_l2;
-    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte_l2, sizeof(random_byte_l2)));
-    int num_corrupted_l2 = (random_byte_l2 % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+    int num_corrupted_l2 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
     LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l2);
 
     // Enqueue random number of corrupted responses
@@ -115,8 +116,9 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
     LT_TEST_ASSERT(LT_OK, mock_session_start(h, kcmd, kres));
 
-    // 5. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Deplete all retry attempts and check if
-    // LT_L2_IN_CRC_ERR was returned. Use lt_ping as a dummy command.
+    // 5. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send corrupted CRCs
+    // in the reponses to commands. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was
+    // returned. Use lt_ping as a dummy command.
     // ---------------------------------------------------------------------------------------------
     LT_LOG_INFO("Mocking responses to lt_ping with invalid CRC...");
 
@@ -134,15 +136,15 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send random number of corrupted frames and then
-    // a correct one and check if LT_OK is returned. Use lt_ping as a dummy command.
+    // 6. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send random number
+    // of corrupted frames (with incorrect CRC) in the reponses to commands and then a correct one and
+    // check if LT_OK is returned. Use lt_ping as a dummy command.
     // ---------------------------------------------------------------------------------------------
     LT_LOG_INFO("Mocking responses to lt_ping with random corrupted and one correct CRC...");
 
     // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
-    uint8_t random_byte_l3;
-    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte_l3, sizeof(random_byte_l3)));
-    int num_corrupted_l3 = (random_byte_l3 % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+    int num_corrupted_l3 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
     LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l3);
 
     // Enqueue random number of corrupted responses
@@ -155,15 +157,73 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
     // Mock command result itself.
     uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
-    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext)));
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
 
     LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+    LT_TEST_ASSERT(0, memcmp(msg_out, msg_in, sizeof(msg_out)));
 
     // Check IN_CRC error counter and restart it.
     LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 7. Terminate the session and deinitialize the Libtropic handle
+    // 7. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res: send corrupted
+    // CRCs in Results. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned. Use
+    // lt_ping as a dummy command.
+    // ---------------------------------------------------------------------------------------------
+
+    // Answer with correct Reponse frame to Command.
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+
+    // Return Result with corrupted CRC.
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+    // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
+    // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
+    for (int i = 0; i < LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+    }
+
+    LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+    // Check IN_CRC error counter and restart it.
+    LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
+    h->l2.l2_in_crc_error_count = 0;
+
+    // 8. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res: send random number
+    // of corrupted Results (with incorrect CRC) then a correct one and check if LT_OK is returned. Use
+    // lt_ping as a dummy command.
+    // ---------------------------------------------------------------------------------------------
+
+    // Answer with correct Reponse frame to Command.
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+
+    // Generate random number of corrupted Results in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+    num_corrupted_l3 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+    LT_LOG_INFO("Sending %d corrupted Results before correct one", num_corrupted_l3);
+
+    // Return Result with corrupted CRC.
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+    // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
+    // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
+    for (int i = 1; i < num_corrupted_l3;
+         i++) {  // i = 1, because one L3 Result was already sent above
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+    }
+
+    // The last Result will have correct CRC.
+    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
+
+    LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+    LT_TEST_ASSERT(0, memcmp(msg_out, msg_in, sizeof(msg_out)));
+
+    // Check IN_CRC error counter and restart it.
+    LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
+    h->l2.l2_in_crc_error_count = 0;
+
+    // 9. Terminate the session and deinitialize the Libtropic handle
     // ---------------------------------------------------------------------------------------------
 
     LT_LOG_INFO("Terminating the Secure Session...");

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -34,7 +34,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
     uint8_t random_byte;
 
-    // 1. Mock init sequence and initialize Libtropic handle
+    // 1. Mock init sequence and initialize Libtropic handle.
     // ---------------------------------------------------------------------------------------------
 
     lt_mock_hal_reset(&h->l2);
@@ -45,10 +45,10 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(h));
 
-    // 2. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Deplete all retry attempts and check if
-    // LT_L2_IN_CRC_ERR was returned.
+    // 2. L2 path: enqueue Get_Info responses that contain invalid CRCs repeatedly
+    //    until retry attempts are exhausted, then verify LT_L2_IN_CRC_ERR is returned.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("Mocking responses to Get_Info request with invalid CRC...");
+    LT_LOG_INFO("2. L2: enqueue Get_Info responses with invalid CRCs for retry tests");
 
     const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
     struct lt_l2_get_info_rsp_t get_info_resp_corrupted_crc = {
@@ -59,8 +59,8 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     };
     uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
 
-    // Enqueue count of responses based on configured resend attempts.
-    // 1 + LT_CRC_ERR_RETRY_ATTEMPTS, because first is normal Request, remaining are retries.
+    // Enqueue the initial response plus the configured number of retry responses
+    // (1 initial + LT_CRC_ERR_RETRY_ATTEMPTS retries).
     for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
         LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
         LT_TEST_ASSERT(
@@ -73,12 +73,12 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send random number of corrupted frames (with
-    // incorrect CRC) and then a correct one and check if LT_OK is returned.
+    // 3. L2 path: send a randomized number of Get_Info frames with invalid CRC,
+    //    then a correct frame, and verify the call succeeds (LT_OK).
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("Mocking reponses to Get_Info request with random corrupted and one correct CRC...");
+    LT_LOG_INFO("3. L2: enqueue randomized invalid-CRC Get_Info responses, then a valid one");
 
-    // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
+    // Generate a random count of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
     int num_corrupted_l2 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
     LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l2);
@@ -109,18 +109,17 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
     // 4. Start mocked Secure Session.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("Setting up session...");
+    LT_LOG_INFO("4. Start mocked Secure Session.");
     uint8_t kcmd[TR01_AES256_KEY_LEN];
     uint8_t kres[TR01_AES256_KEY_LEN];
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, kcmd, sizeof(kcmd)));
     memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
     LT_TEST_ASSERT(LT_OK, mock_session_start(h, kcmd, kres));
 
-    // 5. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send corrupted CRCs
-    // in the reponses to commands. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was
-    // returned. Use lt_ping as a dummy command.
+    // 5. L3 command path: send command responses with invalid CRCs until retries
+    //    are depleted and verify lt_ping returns LT_L2_IN_CRC_ERR.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("Mocking responses to lt_ping with invalid CRC...");
+    LT_LOG_INFO("5. L3: enqueue command responses containing invalid CRCs for retry test");
 
     // Enqueue count of responses based on configured resend attempts.
     // 1 + LT_CRC_ERR_RETRY_ATTEMPTS, because first is normal Request, remaining are retries.
@@ -136,11 +135,10 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 6. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_send_encrypted_cmd: send random number
-    // of corrupted frames (with incorrect CRC) in the reponses to commands and then a correct one and
-    // check if LT_OK is returned. Use lt_ping as a dummy command.
+    // 6. L3 command path: send a randomized number of invalid-CRC command responses,
+    //    then a correct response and verify lt_ping succeeds (LT_OK).
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("Mocking responses to lt_ping with random corrupted and one correct CRC...");
+    LT_LOG_INFO("6. L3: enqueue randomized invalid-CRC command responses, then a valid one");
 
     // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
@@ -166,15 +164,15 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 7. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res: send corrupted
-    // CRCs in Results. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned. Use
-    // lt_ping as a dummy command.
+    // 7. L3 result path: return Results with corrupted CRCs so the receive path
+    //    triggers resend handling; deplete retries and expect LT_L2_IN_CRC_ERR.
     // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("7. L3: sending Results with invalid CRC");
 
-    // Answer with correct Reponse frame to Command.
+    // Answer with a correct Response frame to the command.
     LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
-    // Return Result with corrupted CRC.
+    // Return a Result payload that has an invalid CRC.
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
     // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
     // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
@@ -189,42 +187,40 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 8. Test LT_L2_IN_CRC_ERR retry mechanism on L3 in lt_l2_recv_encrypted_res: send random number
-    // of corrupted Results (with incorrect CRC) then a correct one and check if LT_OK is returned. Use
-    // lt_ping as a dummy command.
+    // 8. L3 result path: send a randomized number of corrupted Results (invalid CRC)
+    //    before sending a correct Result and verify lt_ping succeeds (LT_OK).
     // ---------------------------------------------------------------------------------------------
 
-    // Answer with correct Reponse frame to Command.
+    // Answer with a correct Response frame to the command.
     LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
-    // Generate random number of corrupted Results in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
+    // Generate a random count of corrupted Results in range [1, LT_CRC_ERR_RETRY_ATTEMPTS].
     LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
     num_corrupted_l3 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
-    LT_LOG_INFO("Sending %d corrupted Results before correct one", num_corrupted_l3);
+    LT_LOG_INFO("8. L3: sending %d corrupted Results before a valid Result", num_corrupted_l3);
 
-    // Return Result with corrupted CRC.
+    // Send the first corrupted Result.
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
-    // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
-    // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
-    for (int i = 1; i < num_corrupted_l3;
-         i++) {  // i = 1, because one L3 Result was already sent above
+    // Enqueue additional corrupted Results (if any) to simulate resend cycles.
+    for (int i = 1; i < num_corrupted_l3; i++) {  // i = 1 because one corrupted Result already sent
         LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
     }
 
-    // The last Result will have correct CRC.
+    // Finally, enqueue a valid Result with correct CRC.
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
     LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
 
     LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
     LT_TEST_ASSERT(0, memcmp(msg_out, msg_in, sizeof(msg_out)));
 
-    // Check IN_CRC error counter and restart it.
+    // Verify IN_CRC error counter matches number of corrupted Results and reset it.
     LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
     // 9. Terminate the session and deinitialize the Libtropic handle
     // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("9. Terminate Secure Session and deinitialize the Libtropic handle.");
 
     LT_LOG_INFO("Terminating the Secure Session...");
     LT_TEST_ASSERT(LT_OK, mock_session_abort(h));

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -6,6 +6,8 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <string.h>
+
 #include "libtropic.h"
 #include "libtropic_common.h"
 #include "libtropic_logging.h"
@@ -14,7 +16,9 @@
 #include "lt_l1.h"
 #include "lt_l2_api_structs.h"
 #include "lt_l2_frame_check.h"
+#include "lt_l3_process.h"
 #include "lt_mock_helpers.h"
+#include "lt_port_wrap.h"
 #include "lt_test_common.h"
 
 void lt_test_mock_invalid_in_crc(lt_handle_t *h)
@@ -39,8 +43,10 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(h));
 
-    // 2. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned.
+    // 2. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Deplete all retry attempts and check if
+    // LT_L2_IN_CRC_ERR was returned.
     // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("Mocking responses to Get_Info request with invalid CRC...");
 
     const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
     struct lt_l2_get_info_rsp_t get_info_resp_corrupted_crc = {
@@ -60,11 +66,15 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
                                                 calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
     }
 
-    LT_LOG_INFO("Sending Get_Info request with invalid CRC in response...");
     LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_get_info_riscv_fw_ver(h, dummy_out));
+    // Check IN_CRC error counter and restart it.
+    LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
+    h->l2.l2_in_crc_error_count = 0;
 
-    // 3. Send one corrupted frame and then a correct one and check if LT_OK is returned.
+    // 3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send one corrupted frame and then a correct one
+    // and check if LT_OK is returned.
     // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("Mocking reponses to Get_Info request with one invalid and one correct CRC...");
 
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
     LT_TEST_ASSERT(LT_OK,
@@ -80,11 +90,64 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp,
                                                        calc_mocked_resp_len(&get_info_resp)));
 
-    LT_LOG_INFO("Sending Get_Info request with correct CRC...");
     LT_TEST_ASSERT(LT_OK, lt_get_info_riscv_fw_ver(h, dummy_out));
 
-    // 4. Deinitialize Libtropic handle
+    // Check IN_CRC error counter and restart it.
+    LT_TEST_ASSERT(1, h->l2.l2_in_crc_error_count);
+    h->l2.l2_in_crc_error_count = 0;
+
+    // 4. Start mocked Secure Session.
     // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("Setting up session...");
+    uint8_t kcmd[TR01_AES256_KEY_LEN];
+    uint8_t kres[TR01_AES256_KEY_LEN];
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, kcmd, sizeof(kcmd)));
+    memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
+    LT_TEST_ASSERT(LT_OK, mock_session_start(h, kcmd, kres));
+
+    // 5. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Deplete all retry attempts and check if
+    // LT_L2_IN_CRC_ERR was returned. Use lt_ping as a dummy command.
+    // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("Mocking responses to lt_ping with invalid CRC...");
+
+    // Enqueue count of responses based on configured resend attempts.
+    // 1 + LT_CRC_ERR_RETRY_ATTEMPTS, because first is normal Request, remaining are retries.
+    for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true));
+    }
+
+    const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+    uint8_t msg_in[sizeof(msg_out)];
+    LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+    // Check IN_CRC error counter and restart it.
+    LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
+    h->l2.l2_in_crc_error_count = 0;
+
+    // 6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send one corrupted frame and then a correct one
+    // and check if LT_OK is returned. Use lt_ping as a dummy command.
+    // ---------------------------------------------------------------------------------------------
+    LT_LOG_INFO("Mocking responses to lt_ping with one invalid and one correct CRC...");
+
+    // Enqueue one response with invalid CRC and one response with correct CRC.
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true));
+    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
+
+    // Mock command result itself.
+    uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
+    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext)));
+
+    LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+    // Check IN_CRC error counter and restart it.
+    LT_TEST_ASSERT(1, h->l2.l2_in_crc_error_count);
+    h->l2.l2_in_crc_error_count = 0;
+
+    // 7. Terminate the session and deinitialize the Libtropic handle
+    // ---------------------------------------------------------------------------------------------
+
+    LT_LOG_INFO("Terminating the Secure Session...");
+    LT_TEST_ASSERT(LT_OK, mock_session_abort(h));
 
     LT_LOG_INFO("Deinitializing handle");
     LT_TEST_ASSERT(LT_OK, lt_deinit(h));

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -48,175 +48,218 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     // 2. L2 path: enqueue Get_Info responses that contain invalid CRCs repeatedly
     //    until retry attempts are exhausted, then verify LT_L2_IN_CRC_ERR is returned.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("2. L2: enqueue Get_Info responses with invalid CRCs for retry tests");
+    {
+        LT_LOG_INFO("2. L2: enqueue Get_Info responses with invalid CRCs for retry tests");
 
-    const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
-    struct lt_l2_get_info_rsp_t get_info_resp_corrupted_crc = {
-        .chip_status = TR01_L1_CHIP_MODE_READY_bit,
-        .status = TR01_L2_STATUS_REQUEST_OK,
-        .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
-        .object = {0x00, 0x00, 0x00, 0x02, 0xFF, 0xFF}  // dummy data with invalid CRC appended
-    };
-    uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        struct lt_l2_get_info_rsp_t get_info_resp_corrupted_crc = {
+            .chip_status = TR01_L1_CHIP_MODE_READY_bit,
+            .status = TR01_L2_STATUS_REQUEST_OK,
+            .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
+            .object = {0x00, 0x00, 0x00, 0x02, 0xFF, 0xFF}  // dummy data with invalid CRC appended
+        };
 
-    // Enqueue the initial response plus the configured number of retry responses
-    // (1 initial + LT_CRC_ERR_RETRY_ATTEMPTS retries).
-    for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
-        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-        LT_TEST_ASSERT(
-            LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
-                                                calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
+        // Enqueue the initial response plus the configured number of retry responses
+        // (1 initial + LT_CRC_ERR_RETRY_ATTEMPTS retries).
+        for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+            LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(
+                                      &h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
+                                      calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
+        }
+
+        uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+        LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_get_info_riscv_fw_ver(h, dummy_out));
+
+        // Check IN_CRC error counter and restart it.
+        LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
+        h->l2.l2_in_crc_error_count = 0;
     }
-
-    LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_get_info_riscv_fw_ver(h, dummy_out));
-    // Check IN_CRC error counter and restart it.
-    LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
-    h->l2.l2_in_crc_error_count = 0;
 
     // 3. L2 path: send a randomized number of Get_Info frames with invalid CRC,
     //    then a correct frame, and verify the call succeeds (LT_OK).
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("3. L2: enqueue randomized invalid-CRC Get_Info responses, then a valid one");
+    {
+        LT_LOG_INFO("3. L2: enqueue randomized invalid-CRC Get_Info responses, then a valid one");
 
-    // Generate a random count of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
-    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
-    int num_corrupted_l2 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
-    LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l2);
+        // Generate a random count of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+        int num_corrupted_l2 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+        LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l2);
 
-    // Enqueue random number of corrupted responses
-    for (int i = 0; i < num_corrupted_l2; i++) {
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        struct lt_l2_get_info_rsp_t get_info_resp_corrupted_crc = {
+            .chip_status = TR01_L1_CHIP_MODE_READY_bit,
+            .status = TR01_L2_STATUS_REQUEST_OK,
+            .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
+            .object = {0x00, 0x00, 0x00, 0x02, 0xFF, 0xFF}  // dummy data with invalid CRC appended
+        };
+
+        // Enqueue random number of corrupted responses
+        for (int i = 0; i < num_corrupted_l2; i++) {
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+            LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(
+                                      &h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
+                                      calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
+        }
+
+        // Enqueue one correct response
         LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-        LT_TEST_ASSERT(
-            LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
-                                                calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
+        struct lt_l2_get_info_rsp_t get_info_resp = {.chip_status = TR01_L1_CHIP_MODE_READY_bit,
+                                                     .status = TR01_L2_STATUS_REQUEST_OK,
+                                                     .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
+                                                     .object = {0x00, 0x00, 0x00, 0x02}};
+        add_resp_crc(&get_info_resp);
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp,
+                                                           calc_mocked_resp_len(&get_info_resp)));
+
+        uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+        LT_TEST_ASSERT(LT_OK, lt_get_info_riscv_fw_ver(h, dummy_out));
+
+        // Check IN_CRC error counter and restart it.
+        LT_TEST_ASSERT(num_corrupted_l2, h->l2.l2_in_crc_error_count);
+        h->l2.l2_in_crc_error_count = 0;
     }
-
-    // Enqueue one correct response
-    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-    struct lt_l2_get_info_rsp_t get_info_resp = {.chip_status = TR01_L1_CHIP_MODE_READY_bit,
-                                                 .status = TR01_L2_STATUS_REQUEST_OK,
-                                                 .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
-                                                 .object = {0x00, 0x00, 0x00, 0x02}};
-    add_resp_crc(&get_info_resp);
-    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp,
-                                                       calc_mocked_resp_len(&get_info_resp)));
-
-    LT_TEST_ASSERT(LT_OK, lt_get_info_riscv_fw_ver(h, dummy_out));
-
-    // Check IN_CRC error counter and restart it.
-    LT_TEST_ASSERT(num_corrupted_l2, h->l2.l2_in_crc_error_count);
-    h->l2.l2_in_crc_error_count = 0;
 
     // 4. Start mocked Secure Session.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("4. Start mocked Secure Session.");
-    uint8_t kcmd[TR01_AES256_KEY_LEN];
-    uint8_t kres[TR01_AES256_KEY_LEN];
-    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, kcmd, sizeof(kcmd)));
-    memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
-    LT_TEST_ASSERT(LT_OK, mock_session_start(h, kcmd, kres));
+    {
+        LT_LOG_INFO("4. Start mocked Secure Session.");
+        uint8_t kcmd[TR01_AES256_KEY_LEN];
+        uint8_t kres[TR01_AES256_KEY_LEN];
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, kcmd, sizeof(kcmd)));
+        memcpy(kres, kcmd, TR01_AES256_KEY_LEN);
+        LT_TEST_ASSERT(LT_OK, mock_session_start(h, kcmd, kres));
+    }
 
     // 5. L3 command path: send command responses with invalid CRCs until retries
     //    are depleted and verify lt_ping returns LT_L2_IN_CRC_ERR.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("5. L3: enqueue command responses containing invalid CRCs for retry test");
+    {
+        LT_LOG_INFO("5. L3: enqueue command responses containing invalid CRCs for retry test");
 
-    // Enqueue count of responses based on configured resend attempts.
-    // 1 + LT_CRC_ERR_RETRY_ATTEMPTS, because first is normal Request, remaining are retries.
-    for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true, NULL));
+        // Enqueue count of responses based on configured resend attempts.
+        // 1 + LT_CRC_ERR_RETRY_ATTEMPTS, because first is normal Request, remaining are retries.
+        for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+            LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true, NULL));
+        }
+
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+        // Check IN_CRC error counter and restart it.
+        LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
+        h->l2.l2_in_crc_error_count = 0;
     }
-
-    const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
-    uint8_t msg_in[sizeof(msg_out)];
-    LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
-
-    // Check IN_CRC error counter and restart it.
-    LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
-    h->l2.l2_in_crc_error_count = 0;
 
     // 6. L3 command path: send a randomized number of invalid-CRC command responses,
     //    then a correct response and verify lt_ping succeeds (LT_OK).
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("6. L3: enqueue randomized invalid-CRC command responses, then a valid one");
+    {
+        LT_LOG_INFO("6. L3: enqueue randomized invalid-CRC command responses, then a valid one");
 
-    // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
-    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
-    int num_corrupted_l3 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
-    LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l3);
+        // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+        int num_corrupted_l3 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+        LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l3);
 
-    // Enqueue random number of corrupted responses
-    for (int i = 0; i < num_corrupted_l3; i++) {
-        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true, NULL));
+        // Enqueue random number of corrupted responses
+        for (int i = 0; i < num_corrupted_l3; i++) {
+            LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true, NULL));
+        }
+
+        // Enqueue one correct response
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
+
+        // Mock command result itself.
+        uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
+
+        // Send the command, check the message.
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+        LT_TEST_ASSERT(0, memcmp(msg_out, msg_in, sizeof(msg_out)));
+
+        // Check IN_CRC error counter and restart it.
+        LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
+        h->l2.l2_in_crc_error_count = 0;
     }
-
-    // Enqueue one correct response
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
-
-    // Mock command result itself.
-    uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
-    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
-
-    LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
-    LT_TEST_ASSERT(0, memcmp(msg_out, msg_in, sizeof(msg_out)));
-
-    // Check IN_CRC error counter and restart it.
-    LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
-    h->l2.l2_in_crc_error_count = 0;
 
     // 7. L3 result path: return Results with corrupted CRCs so the receive path
     //    triggers resend handling; deplete retries and expect LT_L2_IN_CRC_ERR.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("7. L3: sending Results with invalid CRC");
+    {
+        LT_LOG_INFO("7. L3: sending Results with invalid CRC");
 
-    // Answer with a correct Response frame to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
+        // Answer with a correct Response frame to the command.
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
-    // Return a Result payload that has an invalid CRC.
-    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
-    // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
-    // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
-    for (int i = 0; i < LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
-        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        // Return a Result payload that has an invalid CRC.
+        uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+
+        // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
+        // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        for (int i = 0; i < LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+            LT_TEST_ASSERT(LT_OK,
+                           mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+        }
+
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+
+        // Check IN_CRC error counter and restart it.
+        LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
+        h->l2.l2_in_crc_error_count = 0;
     }
-
-    LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
-
-    // Check IN_CRC error counter and restart it.
-    LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
-    h->l2.l2_in_crc_error_count = 0;
 
     // 8. L3 result path: send a randomized number of corrupted Results (invalid CRC)
     //    before sending a correct Result and verify lt_ping succeeds (LT_OK).
     // ---------------------------------------------------------------------------------------------
+    {
+        // Answer with a correct Response frame to the command.
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
 
-    // Answer with a correct Response frame to the command.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false, NULL));
+        // Generate a random count of corrupted Results in range [1, LT_CRC_ERR_RETRY_ATTEMPTS].
+        LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
+        int num_corrupted_l3 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+        LT_LOG_INFO("8. L3: sending %d corrupted Results before a valid Result", num_corrupted_l3);
 
-    // Generate a random count of corrupted Results in range [1, LT_CRC_ERR_RETRY_ATTEMPTS].
-    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte, sizeof(random_byte)));
-    num_corrupted_l3 = (random_byte % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
-    LT_LOG_INFO("8. L3: sending %d corrupted Results before a valid Result", num_corrupted_l3);
-
-    // Send the first corrupted Result.
-    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
-    // Enqueue additional corrupted Results (if any) to simulate resend cycles.
-    for (int i = 1; i < num_corrupted_l3; i++) {  // i = 1 because one corrupted Result already sent
-        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        // Send the first corrupted Result.
+        uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
         LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+
+        // Enqueue additional corrupted Results (if any) to simulate resend cycles.
+        const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+        for (int i = 1; i < num_corrupted_l3;
+             i++) {  // i = 1 because one corrupted Result already sent
+            LT_TEST_ASSERT(LT_OK,
+                           lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+            LT_TEST_ASSERT(LT_OK,
+                           mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+        }
+
+        // Finally, enqueue a valid Result with correct CRC.
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
+
+        const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
+        uint8_t msg_in[sizeof(msg_out)];
+        LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
+        LT_TEST_ASSERT(0, memcmp(msg_out, msg_in, sizeof(msg_out)));
+
+        // Verify IN_CRC error counter matches number of corrupted Results and reset it.
+        LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
+        h->l2.l2_in_crc_error_count = 0;
     }
-
-    // Finally, enqueue a valid Result with correct CRC.
-    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-    LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
-
-    LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
-    LT_TEST_ASSERT(0, memcmp(msg_out, msg_in, sizeof(msg_out)));
-
-    // Verify IN_CRC error counter matches number of corrupted Results and reset it.
-    LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
-    h->l2.l2_in_crc_error_count = 0;
 
     // 9. Terminate the session and deinitialize the Libtropic handle
     // ---------------------------------------------------------------------------------------------

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -71,16 +71,26 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send one corrupted frame and then a correct one
-    // and check if LT_OK is returned.
+    // 3. Test LT_L2_IN_CRC_ERR retry mechanism on L2: Send random number of corrupted frames and then
+    // a correct one and check if LT_OK is returned.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("Mocking reponses to Get_Info request with one invalid and one correct CRC...");
+    LT_LOG_INFO("Mocking reponses to Get_Info request with random corrupted and one correct CRC...");
 
-    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-    LT_TEST_ASSERT(LT_OK,
-                   lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
+    // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
+    uint8_t random_byte_l2;
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte_l2, sizeof(random_byte_l2)));
+    int num_corrupted_l2 = (random_byte_l2 % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+    LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l2);
+
+    // Enqueue random number of corrupted responses
+    for (int i = 0; i < num_corrupted_l2; i++) {
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        LT_TEST_ASSERT(
+            LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
                                                 calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
+    }
 
+    // Enqueue one correct response
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
     struct lt_l2_get_info_rsp_t get_info_resp = {.chip_status = TR01_L1_CHIP_MODE_READY_bit,
                                                  .status = TR01_L2_STATUS_REQUEST_OK,
@@ -93,7 +103,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(LT_OK, lt_get_info_riscv_fw_ver(h, dummy_out));
 
     // Check IN_CRC error counter and restart it.
-    LT_TEST_ASSERT(1, h->l2.l2_in_crc_error_count);
+    LT_TEST_ASSERT(num_corrupted_l2, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
     // 4. Start mocked Secure Session.
@@ -124,13 +134,23 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(1 + LT_CRC_ERR_RETRY_ATTEMPTS, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
-    // 6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send one corrupted frame and then a correct one
-    // and check if LT_OK is returned. Use lt_ping as a dummy command.
+    // 6. Test LT_L2_IN_CRC_ERR retry mechanism on L3: Send random number of corrupted frames and then
+    // a correct one and check if LT_OK is returned. Use lt_ping as a dummy command.
     // ---------------------------------------------------------------------------------------------
-    LT_LOG_INFO("Mocking responses to lt_ping with one invalid and one correct CRC...");
+    LT_LOG_INFO("Mocking responses to lt_ping with random corrupted and one correct CRC...");
 
-    // Enqueue one response with invalid CRC and one response with correct CRC.
-    LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true));
+    // Generate random number of corrupted frames in range [1, LT_CRC_ERR_RETRY_ATTEMPTS]
+    uint8_t random_byte_l3;
+    LT_TEST_ASSERT(LT_OK, lt_random_bytes(h, &random_byte_l3, sizeof(random_byte_l3)));
+    int num_corrupted_l3 = (random_byte_l3 % LT_CRC_ERR_RETRY_ATTEMPTS) + 1;
+    LT_LOG_INFO("Sending %d corrupted frames before correct frame", num_corrupted_l3);
+
+    // Enqueue random number of corrupted responses
+    for (int i = 0; i < num_corrupted_l3; i++) {
+        LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, true));
+    }
+
+    // Enqueue one correct response
     LT_TEST_ASSERT(LT_OK, mock_l3_command_responses(h, 1, false));
 
     // Mock command result itself.
@@ -140,7 +160,7 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_TEST_ASSERT(LT_OK, lt_ping(h, msg_out, msg_in, sizeof(msg_out)));
 
     // Check IN_CRC error counter and restart it.
-    LT_TEST_ASSERT(1, h->l2.l2_in_crc_error_count);
+    LT_TEST_ASSERT(num_corrupted_l3, h->l2.l2_in_crc_error_count);
     h->l2.l2_in_crc_error_count = 0;
 
     // 7. Terminate the session and deinitialize the Libtropic handle

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -23,6 +23,14 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_LOG_INFO("lt_test_mock_invalid_in_crc()");
     LT_LOG_INFO("----------------------------------------------");
 
+    if (LT_CRC_ERR_RETRY_ATTEMPTS < 1) {
+        LT_LOG_ERROR("This test requires that at least one retry attempt is configured.");
+        LT_TEST_ASSERT(0, 1);  // Forcefully fail the test.
+    }
+
+    // 1. Mock init sequence and initialize Libtropic handle
+    // ---------------------------------------------------------------------------------------------
+
     lt_mock_hal_reset(&h->l2);
     LT_LOG_INFO("Mocking initialization...");
     LT_TEST_ASSERT(LT_OK,
@@ -31,20 +39,52 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
     LT_LOG_INFO("Initializing handle");
     LT_TEST_ASSERT(LT_OK, lt_init(h));
 
-    uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
-    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-    struct lt_l2_get_info_rsp_t get_info_resp = {
+    // 2. Deplete all retry attempts and check if LT_L2_IN_CRC_ERR was returned.
+    // ---------------------------------------------------------------------------------------------
+
+    const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
+    struct lt_l2_get_info_rsp_t get_info_resp_corrupted_crc = {
         .chip_status = TR01_L1_CHIP_MODE_READY_bit,
         .status = TR01_L2_STATUS_REQUEST_OK,
         .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
         .object = {0x00, 0x00, 0x00, 0x02, 0xFF, 0xFF}  // dummy data with invalid CRC appended
     };
+    uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
+
+    // Enqueue count of responses based on configured resend attempts.
+    // 1 + LT_CRC_ERR_RETRY_ATTEMPTS, because first is normal Request, remaining are retries.
+    for (int i = 0; i < 1 + LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
+        LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+        LT_TEST_ASSERT(
+            LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
+                                                calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
+    }
+
+    LT_LOG_INFO("Sending Get_Info request with invalid CRC in response...");
+    LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_get_info_riscv_fw_ver(h, dummy_out));
+
+    // 3. Send one corrupted frame and then a correct one and check if LT_OK is returned.
+    // ---------------------------------------------------------------------------------------------
+
+    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+    LT_TEST_ASSERT(LT_OK,
+                   lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp_corrupted_crc,
+                                                calc_mocked_resp_len(&get_info_resp_corrupted_crc)));
+
+    LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
+    struct lt_l2_get_info_rsp_t get_info_resp = {.chip_status = TR01_L1_CHIP_MODE_READY_bit,
+                                                 .status = TR01_L2_STATUS_REQUEST_OK,
+                                                 .rsp_len = TR01_L2_GET_INFO_RISCV_FW_SIZE,
+                                                 .object = {0x00, 0x00, 0x00, 0x02}};
+    add_resp_crc(&get_info_resp);
     LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, (uint8_t *)&get_info_resp,
                                                        calc_mocked_resp_len(&get_info_resp)));
 
-    LT_LOG_INFO("Sending Get_Info request with invalid CRC in response...");
-    uint8_t dummy_out[TR01_L2_GET_INFO_RISCV_FW_SIZE];
-    LT_TEST_ASSERT(LT_L2_IN_CRC_ERR, lt_get_info_riscv_fw_ver(h, dummy_out));
+    LT_LOG_INFO("Sending Get_Info request with correct CRC...");
+    LT_TEST_ASSERT(LT_OK, lt_get_info_riscv_fw_ver(h, dummy_out));
+
+    // 4. Deinitialize Libtropic handle
+    // ---------------------------------------------------------------------------------------------
 
     LT_LOG_INFO("Deinitializing handle");
     LT_TEST_ASSERT(LT_OK, lt_deinit(h));

--- a/tests/functional_mock/lt_test_mock_invalid_in_crc.c
+++ b/tests/functional_mock/lt_test_mock_invalid_in_crc.c
@@ -176,7 +176,8 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
         // Mock command result itself.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
-        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                             TR01_L2_STATUS_REQUEST_OK, false));
 
         // Send the command, check the message.
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
@@ -200,7 +201,8 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
         // Return a Result payload that has an invalid CRC.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
-        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                             TR01_L2_STATUS_REQUEST_OK, true));
 
         // Libtropic will try to get correct frame using Resend_Req => enqueue responses to Resend_Req
         // and again a Result with corrupted CRC. Do this multiple times to deplete all attempts.
@@ -208,8 +210,8 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
         for (int i = 0; i < LT_CRC_ERR_RETRY_ATTEMPTS; i++) {
             LT_TEST_ASSERT(LT_OK,
                            lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-            LT_TEST_ASSERT(LT_OK,
-                           mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+            LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                                 TR01_L2_STATUS_REQUEST_OK, true));
         }
 
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
@@ -235,7 +237,8 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
 
         // Send the first corrupted Result.
         uint8_t lt_ping_plaintext[] = {TR01_L3_RESULT_OK, 'H', 'E', 'L', 'L', 'O'};
-        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                             TR01_L2_STATUS_REQUEST_OK, true));
 
         // Enqueue additional corrupted Results (if any) to simulate resend cycles.
         const uint8_t chip_ready = TR01_L1_CHIP_MODE_READY_bit;
@@ -243,13 +246,14 @@ void lt_test_mock_invalid_in_crc(lt_handle_t *h)
              i++) {  // i = 1 because one corrupted Result already sent
             LT_TEST_ASSERT(LT_OK,
                            lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-            LT_TEST_ASSERT(LT_OK,
-                           mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), true));
+            LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                                 TR01_L2_STATUS_REQUEST_OK, true));
         }
 
         // Finally, enqueue a valid Result with correct CRC.
         LT_TEST_ASSERT(LT_OK, lt_mock_hal_enqueue_response(&h->l2, &chip_ready, sizeof(chip_ready)));
-        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext), false));
+        LT_TEST_ASSERT(LT_OK, mock_l3_result(h, lt_ping_plaintext, sizeof(lt_ping_plaintext),
+                                             TR01_L2_STATUS_REQUEST_OK, false));
 
         const uint8_t msg_out[] = {'H', 'E', 'L', 'L', 'O'};
         uint8_t msg_in[sizeof(msg_out)];


### PR DESCRIPTION
## Description

In this PR, I fix/enhance handling of CRC errors.

This PR introduces refactored L2 layer implementation, which automatically asks to resend corrupted frames or repeat whole communication in case of CRC error in an outgoing frame (to TROPIC01). The changes are verified in new/modified tests: `lt_test_mock_invalid_crc`, `lt_test_mock_invalid_in_crc`.

Furthermore, there are following related changes:

- expanded functionality of lt_mock_helpers: ability to corrupt CRC, enqueue custom response to L3, set custom status in L3 Result,
- CRC error diagnostic counters,
- created a constant for the size of L2 buffer: `LT_SIZE_OF_L2_BUFF`
- new `lt_l2_transfer`, which combines send, receive and CRC handling,
- documenation updates.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage