### PR TITLE
ETR01SDK-592: Libtropic FW update examples: Maintenance Mode control extension

### DIFF
--- a/.github/workflows/esp32_build_examples.yml
+++ b/.github/workflows/esp32_build_examples.yml
@@ -23,21 +23,27 @@ jobs:
             . /opt/esp/idf/export.sh
             idf.py -C examples/esp32/ESP32-DevKitC-V4/hello_world/ build
             idf.py -C examples/esp32/ESP32-DevKitC-V4/identify_chip/ build
-            idf.py -C examples/esp32/ESP32-DevKitC-V4/fw_update/ build
-            idf.py -D LT_SILICON_REV=ABAB -C examples/esp32/ESP32-DevKitC-V4/fw_update/ -B build_abab_devkitc_v4 build
+            idf.py -D LT_DISABLE_MAINTENANCE_MODE=OFF -C examples/esp32/ESP32-DevKitC-V4/fw_update/ -B build_devkitc_v4 build
+            idf.py -D LT_DISABLE_MAINTENANCE_MODE=ON -C examples/esp32/ESP32-DevKitC-V4/fw_update/ -B build_dis_mm_devkitc_v4 build
+            idf.py -D LT_SILICON_REV=ABAB -D LT_DISABLE_MAINTENANCE_MODE=OFF -C examples/esp32/ESP32-DevKitC-V4/fw_update/ -B build_abab_devkitc_v4 build
+            idf.py -D LT_SILICON_REV=ABAB -D LT_DISABLE_MAINTENANCE_MODE=ON -C examples/esp32/ESP32-DevKitC-V4/fw_update/ -B build_abab_dis_mm_devkitc_v4 build
 
       - name: Build ESP32-S3-DevKitC-1 examples
         run: |
             . /opt/esp/idf/export.sh
             idf.py -C examples/esp32/ESP32-S3-DevKitC-1/hello_world/ build
             idf.py -C examples/esp32/ESP32-S3-DevKitC-1/identify_chip/ build
-            idf.py -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ build
-            idf.py -D LT_SILICON_REV=ABAB -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ -B build_abab_s3_devkitc_1 build
+            idf.py -D LT_DISABLE_MAINTENANCE_MODE=OFF -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ -B build_s3_devkitc_1 build
+            idf.py -D LT_DISABLE_MAINTENANCE_MODE=ON -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ -B build_dis_mm_s3_devkitc_1 build
+            idf.py -D LT_SILICON_REV=ABAB -D LT_DISABLE_MAINTENANCE_MODE=OFF -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ -B build_abab_s3_devkitc_1 build
+            idf.py -D LT_SILICON_REV=ABAB -D LT_DISABLE_MAINTENANCE_MODE=ON -C examples/esp32/ESP32-S3-DevKitC-1/fw_update/ -B build_abab_dis_mm_s3_devkitc_1 build
 
       - name: Build ESP32-C3-DevKit-RUST-1 examples
         run: |
             . /opt/esp/idf/export.sh
             idf.py -C examples/esp32/ESP32-C3-DevKit-RUST-1/hello_world/ build
             idf.py -C examples/esp32/ESP32-C3-DevKit-RUST-1/identify_chip/ build
-            idf.py -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ build
-            idf.py -D LT_SILICON_REV=ABAB -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ -B build_abab_c3_devkit_rust_1 build
+            idf.py -D LT_DISABLE_MAINTENANCE_MODE=OFF -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ -B build_c3_devkit_rust_1 build
+            idf.py -D LT_DISABLE_MAINTENANCE_MODE=ON -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ -B build_dis_mm_c3_devkit_rust_1 build
+            idf.py -D LT_SILICON_REV=ABAB -D LT_DISABLE_MAINTENANCE_MODE=OFF -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ -B build_abab_c3_devkit_rust_1 build
+            idf.py -D LT_SILICON_REV=ABAB -D LT_DISABLE_MAINTENANCE_MODE=ON -C examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/ -B build_abab_dis_mm_c3_devkit_rust_1 build

--- a/.github/workflows/linux_build_examples.yml
+++ b/.github/workflows/linux_build_examples.yml
@@ -39,12 +39,20 @@ jobs:
           cd build && ninja
 
           cd ../../fw_update
-          cmake ./ -B build -G Ninja
+          cmake ./ -B build -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build && ninja
 
           cd ..
-          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cmake ./ -B build_dis_mm -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_dis_mm && ninja
+
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build_abab && ninja
+
+          cd ..
+          cmake ./ -B build_abab_dis_mm -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_abab_dis_mm && ninja
 
           cd ../../full_chain_verification
           cmake ./ -B build -G Ninja
@@ -61,12 +69,20 @@ jobs:
           cd build && ninja
 
           cd ../../fw_update
-          cmake ./ -B build -G Ninja
+          cmake ./ -B build -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build && ninja
 
           cd ..
-          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cmake ./ -B build_dis_mm -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_dis_mm && ninja
+
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build_abab && ninja
+
+          cd ..
+          cmake ./ -B build_abab_dis_mm -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_abab_dis_mm && ninja
 
           cd ../../full_chain_verification
           cmake ./ -B build -G Ninja

--- a/.github/workflows/stm32_build_examples.yml
+++ b/.github/workflows/stm32_build_examples.yml
@@ -39,12 +39,20 @@ jobs:
           cd build && ninja
 
           cd ../../fw_update
-          cmake ./ -B build -G Ninja
+          cmake ./ -B build -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build && ninja
 
           cd ..
-          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cmake ./ -B build_dis_mm -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_dis_mm && ninja
+
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build_abab && ninja
+
+          cd ..
+          cmake ./ -B build_abab_dis_mm -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_abab_dis_mm && ninja
 
       - name: Compile L432KC examples
         run: |
@@ -57,9 +65,17 @@ jobs:
           cd build && ninja
 
           cd ../../fw_update
-          cmake ./ -B build -G Ninja
+          cmake ./ -B build -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build && ninja
 
           cd ..
-          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB
+          cmake ./ -B build_dis_mm -G Ninja -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_dis_mm && ninja
+
+          cd ..
+          cmake ./ -B build_abab -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=OFF
           cd build_abab && ninja
+
+          cd ..
+          cmake ./ -B build_abab_dis_mm -G Ninja -DLT_SILICON_REV=ABAB -DLT_DISABLE_MAINTENANCE_MODE=ON
+          cd build_abab_dis_mm && ninja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Arrays to firmware update files which contain firmware version of the update: `fw_CPU_ver`, `fw_SPECT_ver`.
 - `fw_data_size` parameter to `lt_mutable_fw_update()` (ACAB version).
 - STM32 L432KC examples: support for TROPIC01 GPO pin.
+- FW update examples: recommended handling of Maintenance Mode to reduce the attack surface.
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/docs/common/examples_descriptions/fw_update.md
+++ b/docs/common/examples_descriptions/fw_update.md
@@ -2,6 +2,7 @@ This example explains the firmware update process for both ABAB and ACAB silicon
 
 - How to read the current firmware versions.
 - How to update the firmware using `lt_do_mutable_fw_update()`, which performs the recommended FW update procedure.
+- How to handle TROPIC01 Maintenance Mode to **reduce the attack surface**.
 
 !!! info "TROPIC01 Firmware"
     For more information about the firmware itself, refer to the [TROPIC01 Firmware](/reference/tropic01_fw.md) section.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,7 +66,7 @@ There are two main causes:
    Reboot to Application Mode by calling `lt_reboot` with `TR01_REBOOT`.
 
 ## FW update failed
-If our firmware update example program in the tutorial failed:
+If one of our firmware update API functions or the `lt_do_mutable_fw_update()` helper function failed:
 
 1. Try the suggestions in [I received an error](#i-received-an-error).
 2. Make sure you have correct values set in the following CMake options:

--- a/docs/tutorials/esp32/fw_update.md
+++ b/docs/tutorials/esp32/fw_update.md
@@ -25,6 +25,39 @@
     === ":fontawesome-brands-windows: Windows"
         TBA
 
+If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
+!!! example "Switching to engineering sample pairing keys"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass any CMake option to `idf.py` as follows:
+        ```bash { .copy }
+        idf.py -DLT_SH0_KEYS="eng_sample" build flash monitor
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+
+If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
+!!! example "Keeping Maintenance Mode enabled after FW update"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass any CMake option to `idf.py` as follows:
+        ```bash { .copy }
+        idf.py -DLT_DISABLE_MAINTENANCE_MODE=0 build flash monitor
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+    !!! warning "Not recommended"
+        This step is not recommended because it can increase the attack surface.
+
 !!! failure "FW update failed"
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 

--- a/docs/tutorials/linux/spi/fw_update.md
+++ b/docs/tutorials/linux/spi/fw_update.md
@@ -48,7 +48,7 @@ If your TROPIC01 has engineering sample pairing keys, you can switch to them usi
     === ":fontawesome-brands-windows: Windows"
         TBA
 
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
 
 If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
 !!! example "Keeping Maintenance Mode enabled after FW update"

--- a/docs/tutorials/linux/spi/fw_update.md
+++ b/docs/tutorials/linux/spi/fw_update.md
@@ -33,6 +33,41 @@
     
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
+If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
+!!! example "Switching to engineering sample pairing keys"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass `LT_SH0_KEYS` to `cmake` as follows:
+        ```bash { .copy }
+        cmake -DLT_SH0_KEYS="eng_sample" ..
+        make
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+
+If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
+!!! example "Keeping Maintenance Mode enabled after FW update"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass `LT_DISABLE_MAINTENANCE_MODE` to `cmake` as follows:
+        ```bash { .copy }
+        cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
+        make
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+    !!! warning "Not recommended"
+        This step is not recommended because it can increase the attack surface.
+
 !!! failure "FW update failed"
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 

--- a/docs/tutorials/linux/usb_devkit/fw_update.md
+++ b/docs/tutorials/linux/usb_devkit/fw_update.md
@@ -48,7 +48,7 @@ If your TROPIC01 has engineering sample pairing keys, you can switch to them usi
     === ":fontawesome-brands-windows: Windows"
         TBA
 
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
 
 If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
 !!! example "Keeping Maintenance Mode enabled after FW update"

--- a/docs/tutorials/linux/usb_devkit/fw_update.md
+++ b/docs/tutorials/linux/usb_devkit/fw_update.md
@@ -33,6 +33,41 @@
     
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
+If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
+!!! example "Switching to engineering sample pairing keys"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass `LT_SH0_KEYS` to `cmake` as follows:
+        ```bash { .copy }
+        cmake -DLT_SH0_KEYS="eng_sample" ..
+        make
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+
+If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
+!!! example "Keeping Maintenance Mode enabled after FW update"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass `LT_DISABLE_MAINTENANCE_MODE` to `cmake` as follows:
+        ```bash { .copy }
+        cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
+        make
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+    !!! warning "Not recommended"
+        This step is not recommended because it can increase the attack surface.
+
 !!! failure "FW update failed"
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 

--- a/docs/tutorials/stm32/fw_update.md
+++ b/docs/tutorials/stm32/fw_update.md
@@ -39,6 +39,41 @@
 
     After this, you should see a colored output in your serial monitor.
 
+If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
+!!! example "Switching to engineering sample pairing keys"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass `LT_SH0_KEYS` to `cmake` as follows:
+        ```bash { .copy }
+        cmake -DLT_SH0_KEYS="eng_sample" ..
+        make
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+
+If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
+!!! example "Keeping Maintenance Mode enabled after FW update"
+    === ":fontawesome-brands-linux: Linux"
+        You can pass `LT_DISABLE_MAINTENANCE_MODE` to `cmake` as follows:
+        ```bash { .copy }
+        cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
+        make
+        ```
+
+    === ":fontawesome-brands-apple: macOS"
+        TBA
+
+    === ":fontawesome-brands-windows: Windows"
+        TBA
+
+    !!! warning "Not recommended"
+        This step is not recommended because it can increase the attack surface.
+
 !!! failure "FW update failed"
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/CMakeLists.txt
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/CMakeLists.txt
@@ -1,5 +1,32 @@
 cmake_minimum_required(VERSION 3.16)
 
+# Select pairing keys written during manufacturing into your TROPIC01.
+# Note for users: if you are writing your own application, the following logic
+# with LT_SH0_KEYS is not necessary - use specific key pair, e.g. your own or 
+# the ones from libtropic_common.h.
+set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
+set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
+
+# These are internal macros for selecting SH0 keys.
+set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
+set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
+
+if(LT_SH0_KEYS STREQUAL "eng_sample")
+	set(LT_USE_SH0_ENG_SAMPLE 1)
+	set(LT_USE_SH0_PROD0      0)
+elseif(LT_SH0_KEYS STREQUAL "prod0")
+	set(LT_USE_SH0_ENG_SAMPLE 0)
+	set(LT_USE_SH0_PROD0      1)
+else()
+	get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
+	message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
+endif()
+
+option(LT_DISABLE_MAINTENANCE_MODE "Disable Maintenance Mode in R-Config after successful FW update" ON)
+if (NOT LT_DISABLE_MAINTENANCE_MODE)
+    message(WARNING "Maintenance Mode will not be disabled in R-Config after successful FW update. This can increase the attack surface.")
+endif()
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 idf_build_set_property(MINIMAL_BUILD ON)
 project(fw_update)

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/CMakeLists.txt
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/CMakeLists.txt
@@ -1,3 +1,19 @@
 idf_component_register(SRCS "main.c"
                        INCLUDE_DIRS "."
                        REQUIRES mbedtls libtropic)
+
+# Propagate selected SH0 key macros into this component's compile definitions.
+# Note for users: if you are writing your own application, the following logic
+# with LT_SH0_KEYS is not necessary - use specific key pair, e.g. your own or 
+# the ones from libtropic_common.h.
+if(NOT DEFINED LT_USE_SH0_ENG_SAMPLE)
+    set(LT_USE_SH0_ENG_SAMPLE 0)
+endif()
+if(NOT DEFINED LT_USE_SH0_PROD0)
+    set(LT_USE_SH0_PROD0 0)
+endif()
+target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE}
+    LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0}
+    LT_DISABLE_MAINTENANCE_MODE=$<BOOL:${LT_DISABLE_MAINTENANCE_MODE}>
+)

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
@@ -32,6 +32,7 @@
 #define LT_EX_SH0_PUB lt_sh0pub_prod0
 #endif
 
+#if LT_DISABLE_MAINTENANCE_MODE
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
 bool g_maintenance_mode_was_enabled = false;
 
@@ -208,6 +209,7 @@ lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
 
     return LT_OK;
 }
+#endif
 
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
@@ -7,6 +7,7 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
@@ -23,6 +23,192 @@
 
 #define TAG "fw_update"
 
+// Choose pairing keypair for slot 0.
+#if LT_USE_SH0_ENG_SAMPLE
+#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
+#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
+#elif LT_USE_SH0_PROD0
+#define LT_EX_SH0_PRIV lt_sh0priv_prod0
+#define LT_EX_SH0_PUB lt_sh0pub_prod0
+#endif
+
+// Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
+bool g_mtnc_mode_was_enabled = false;
+
+lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "Checking if Maintenance Mode is enabled and enabling it in R-Config if needed:");
+
+    // Establish Secure Channel Session so we can read I-Config/R-Config.
+    ESP_LOGI(TAG, "  - Starting Secure Session with key slot %d...",
+             (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        ESP_LOGE(TAG, "Failed to start Secure Session with key %d, ret=%s",
+                 (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        ESP_LOGE(TAG,
+                 "Check if you use correct SH0 keys! Hint: if you use an engineering sample chip, "
+                 "compile with -DLT_SH0_KEYS=eng_sample");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    // Read I-Config and check if Maintenance Mode is enabled.
+    uint32_t i_config_cfg_startup;
+    ESP_LOGI(TAG, "  - Reading I-Config[CFG_START_UP]...");
+    ret = lt_i_config_read(lt_handle, TR01_CFG_START_UP_ADDR, &i_config_cfg_startup);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read I-Config[CFG_START_UP], ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Checking if Maintenance Mode is enabled in I-Config[CFG_START_UP]...");
+    if (!(i_config_cfg_startup & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        ESP_LOGE(TAG, "Maintenance Mode is not enabled in I-Config -> FW Update cannot be performed.");
+        return LT_FAIL;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    // Read R-Config and check if Maintenance Mode is enabled.
+    // The whole R-Config is read in case we need to modify it, as it has to be completely erased
+    // before writing again.
+    lt_config_t r_config;
+    ESP_LOGI(TAG, "  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Read R-Config (acts as a backup):");
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        ESP_LOGI(TAG, "    - %s= 0x%08" PRIx32, cfg_desc_table[i].desc, r_config.obj[i]);
+    }
+
+    ESP_LOGI(TAG, "  - Checking if Maintenance Mode is enabled in R-Config[CFG_START_UP]...");
+    if (!(r_config.obj[TR01_CFG_START_UP_IDX] & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        ESP_LOGI(TAG, "Disabled, will enable it");
+        ESP_LOGI(TAG, "    - Erasing R-Config...");
+        ret = lt_r_config_erase(lt_handle);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "Failed to erase R-Config, ret=%s", lt_ret_verbose(ret));
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+
+        r_config.obj[TR01_CFG_START_UP_IDX] |= BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+        ESP_LOGI(TAG, "    - Writing modified R-Config...");
+        ret = lt_write_whole_R_config(lt_handle, &r_config);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "Failed to write R-Config, ret=%s", lt_ret_verbose(ret));
+            ESP_LOGW(
+                TAG,
+                "R-Config is left in an erased state - the state before erasing is printed above.");
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+        g_mtnc_mode_was_enabled = true;
+
+        ESP_LOGI(TAG, "    - Rebooting TROPIC01 to apply R-Config changes...");
+        ret = lt_reboot(lt_handle, TR01_REBOOT);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+            ESP_LOGW(TAG,
+                     "R-Config (with Maintenance Mode enabled) was written but not applied yet. It "
+                     "will be applied on next TROPIC01 reboot/power-cycle.");
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+    }
+    else {
+        ESP_LOGI(TAG, "  OK");
+    }
+
+    return LT_OK;
+}
+
+lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "Disabling Maintenance Mode in R-Config (reduces the attack surface):");
+
+    ESP_LOGI(TAG, "  - Starting Secure Session with key slot %d...",
+             (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        ESP_LOGE(TAG, "Failed to start Secure Session with key %d, ret=%s",
+                 (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    lt_config_t r_config;
+    ESP_LOGI(TAG, "  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Erasing R-Config...");
+    ret = lt_r_config_erase(lt_handle);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to erase R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Disabling Maintenance Mode in R-Config...");
+    r_config.obj[TR01_CFG_START_UP_IDX] &= ~BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+    ret = lt_write_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to write R-Config, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGW(TAG,
+                 "R-Config is left in an erased state - the state before erasing is printed above.");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Rebooting TROPIC01 to apply R-Config changes...");
+    ret = lt_reboot(lt_handle, TR01_REBOOT);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGW(TAG,
+                 "R-Config (with Maintenance Mode disabled) was written but not applied yet. It will "
+                 "be applied on next TROPIC01 reboot/power-cycle.");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Verifying that Maintenance Mode is not accessible...");
+    ret = lt_reboot(lt_handle, TR01_MAINTENANCE_REBOOT);
+    if (ret == LT_L2_RESP_DISABLED) {
+        ESP_LOGI(TAG, "  OK");
+    }
+    else if (ret != LT_OK) {
+        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    else {
+        ESP_LOGE(TAG, "Maintenance reboot succeeded! ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
+}
+
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {
     uint8_t cpu_fw_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE] = {0};
@@ -136,6 +322,15 @@ void app_main(void)
     ESP_LOGI(TAG, "  - RISC-V FW version: %d.%d.%d", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
     ESP_LOGI(TAG, "  - SPECT FW version: %d.%d.%d", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
 
+#if LT_DISABLE_MAINTENANCE_MODE
+    // We need to make sure we can reboot into Maintenance Mode to perform the FW update.
+    if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return;
+    }
+#endif
+
     ESP_LOGI(TAG, "");
     ESP_LOGI(TAG, "Updating TROPIC01 firmware...");
     // This helper function implements the recommended FW update process.
@@ -143,6 +338,11 @@ void app_main(void)
     if (ret != LT_OK) {
         ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
         ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
+#if LT_DISABLE_MAINTENANCE_MODE
+        if (g_mtnc_mode_was_enabled) {
+            ESP_LOGW(TAG, "Due to the error, Maintenance Mode was kept enabled in R-Config!");
+        }
+#endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;
@@ -154,6 +354,23 @@ void app_main(void)
         mbedtls_psa_crypto_free();
         return;
     }
+
+#if LT_DISABLE_MAINTENANCE_MODE
+    // Warning: User shall disable Maintenance Mode only after both FW banks are updated with the
+    // latest FW. If only one bank is updated (while the second one contains invalid FW), and
+    // Maintenance Mode is disabled, the probability of bricking TROPIC01 increases. In this case, if
+    // lt_do_mutable_fw_update() succeeds, it is safe to disable Maintenance Mode.
+    if (LT_OK != disable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return;
+    }
+#else
+    ESP_LOGI(TAG, "");
+    ESP_LOGW(
+        TAG,
+        "We strongly recommend disabling Maintenance Mode in R-Config to reduce the attack surface.");
+#endif
 
     ESP_LOGI(TAG, "");
     ESP_LOGI(TAG, "Deinitializing handle...");

--- a/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-C3-DevKit-RUST-1/fw_update/main/main.c
@@ -33,7 +33,7 @@
 #endif
 
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
-bool g_mtnc_mode_was_enabled = false;
+bool g_maintenance_mode_was_enabled = false;
 
 lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
 {
@@ -114,7 +114,7 @@ lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
             return ret;
         }
         ESP_LOGI(TAG, "    OK");
-        g_mtnc_mode_was_enabled = true;
+        g_maintenance_mode_was_enabled = true;
 
         ESP_LOGI(TAG, "    - Rebooting TROPIC01 to apply R-Config changes...");
         ret = lt_reboot(lt_handle, TR01_REBOOT);
@@ -339,7 +339,7 @@ void app_main(void)
         ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
         ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
 #if LT_DISABLE_MAINTENANCE_MODE
-        if (g_mtnc_mode_was_enabled) {
+        if (g_maintenance_mode_was_enabled) {
             ESP_LOGW(TAG, "Due to the error, Maintenance Mode was kept enabled in R-Config!");
         }
 #endif

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/CMakeLists.txt
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/CMakeLists.txt
@@ -1,5 +1,32 @@
 cmake_minimum_required(VERSION 3.16)
 
+# Select pairing keys written during manufacturing into your TROPIC01.
+# Note for users: if you are writing your own application, the following logic
+# with LT_SH0_KEYS is not necessary - use specific key pair, e.g. your own or 
+# the ones from libtropic_common.h.
+set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
+set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
+
+# These are internal macros for selecting SH0 keys.
+set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
+set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
+
+if(LT_SH0_KEYS STREQUAL "eng_sample")
+	set(LT_USE_SH0_ENG_SAMPLE 1)
+	set(LT_USE_SH0_PROD0      0)
+elseif(LT_SH0_KEYS STREQUAL "prod0")
+	set(LT_USE_SH0_ENG_SAMPLE 0)
+	set(LT_USE_SH0_PROD0      1)
+else()
+	get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
+	message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
+endif()
+
+option(LT_DISABLE_MAINTENANCE_MODE "Disable Maintenance Mode in R-Config after successful FW update" ON)
+if (NOT LT_DISABLE_MAINTENANCE_MODE)
+    message(WARNING "Maintenance Mode will not be disabled in R-Config after successful FW update. This can increase the attack surface.")
+endif()
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 idf_build_set_property(MINIMAL_BUILD ON)
 project(fw_update)

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/CMakeLists.txt
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/CMakeLists.txt
@@ -1,3 +1,19 @@
 idf_component_register(SRCS "main.c"
                        INCLUDE_DIRS "."
                        REQUIRES mbedtls libtropic)
+
+# Propagate selected SH0 key macros into this component's compile definitions.
+# Note for users: if you are writing your own application, the following logic
+# with LT_SH0_KEYS is not necessary - use specific key pair, e.g. your own or 
+# the ones from libtropic_common.h.
+if(NOT DEFINED LT_USE_SH0_ENG_SAMPLE)
+    set(LT_USE_SH0_ENG_SAMPLE 0)
+endif()
+if(NOT DEFINED LT_USE_SH0_PROD0)
+    set(LT_USE_SH0_PROD0 0)
+endif()
+target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE}
+    LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0}
+    LT_DISABLE_MAINTENANCE_MODE=$<BOOL:${LT_DISABLE_MAINTENANCE_MODE}>
+)

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
@@ -32,6 +32,7 @@
 #define LT_EX_SH0_PUB lt_sh0pub_prod0
 #endif
 
+#if LT_DISABLE_MAINTENANCE_MODE
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
 bool g_maintenance_mode_was_enabled = false;
 
@@ -208,6 +209,7 @@ lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
 
     return LT_OK;
 }
+#endif
 
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
@@ -7,6 +7,7 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
@@ -23,6 +23,192 @@
 
 #define TAG "fw_update"
 
+// Choose pairing keypair for slot 0.
+#if LT_USE_SH0_ENG_SAMPLE
+#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
+#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
+#elif LT_USE_SH0_PROD0
+#define LT_EX_SH0_PRIV lt_sh0priv_prod0
+#define LT_EX_SH0_PUB lt_sh0pub_prod0
+#endif
+
+// Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
+bool g_mtnc_mode_was_enabled = false;
+
+lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "Checking if Maintenance Mode is enabled and enabling it in R-Config if needed:");
+
+    // Establish Secure Channel Session so we can read I-Config/R-Config.
+    ESP_LOGI(TAG, "  - Starting Secure Session with key slot %d...",
+             (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        ESP_LOGE(TAG, "Failed to start Secure Session with key %d, ret=%s",
+                 (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        ESP_LOGE(TAG,
+                 "Check if you use correct SH0 keys! Hint: if you use an engineering sample chip, "
+                 "compile with -DLT_SH0_KEYS=eng_sample");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    // Read I-Config and check if Maintenance Mode is enabled.
+    uint32_t i_config_cfg_startup;
+    ESP_LOGI(TAG, "  - Reading I-Config[CFG_START_UP]...");
+    ret = lt_i_config_read(lt_handle, TR01_CFG_START_UP_ADDR, &i_config_cfg_startup);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read I-Config[CFG_START_UP], ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Checking if Maintenance Mode is enabled in I-Config[CFG_START_UP]...");
+    if (!(i_config_cfg_startup & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        ESP_LOGE(TAG, "Maintenance Mode is not enabled in I-Config -> FW Update cannot be performed.");
+        return LT_FAIL;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    // Read R-Config and check if Maintenance Mode is enabled.
+    // The whole R-Config is read in case we need to modify it, as it has to be completely erased
+    // before writing again.
+    lt_config_t r_config;
+    ESP_LOGI(TAG, "  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Read R-Config (acts as a backup):");
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        ESP_LOGI(TAG, "    - %s= 0x%08" PRIx32, cfg_desc_table[i].desc, r_config.obj[i]);
+    }
+
+    ESP_LOGI(TAG, "  - Checking if Maintenance Mode is enabled in R-Config[CFG_START_UP]...");
+    if (!(r_config.obj[TR01_CFG_START_UP_IDX] & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        ESP_LOGI(TAG, "Disabled, will enable it");
+        ESP_LOGI(TAG, "    - Erasing R-Config...");
+        ret = lt_r_config_erase(lt_handle);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "Failed to erase R-Config, ret=%s", lt_ret_verbose(ret));
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+
+        r_config.obj[TR01_CFG_START_UP_IDX] |= BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+        ESP_LOGI(TAG, "    - Writing modified R-Config...");
+        ret = lt_write_whole_R_config(lt_handle, &r_config);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "Failed to write R-Config, ret=%s", lt_ret_verbose(ret));
+            ESP_LOGW(
+                TAG,
+                "R-Config is left in an erased state - the state before erasing is printed above.");
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+        g_mtnc_mode_was_enabled = true;
+
+        ESP_LOGI(TAG, "    - Rebooting TROPIC01 to apply R-Config changes...");
+        ret = lt_reboot(lt_handle, TR01_REBOOT);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+            ESP_LOGW(TAG,
+                     "R-Config (with Maintenance Mode enabled) was written but not applied yet. It "
+                     "will be applied on next TROPIC01 reboot/power-cycle.");
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+    }
+    else {
+        ESP_LOGI(TAG, "  OK");
+    }
+
+    return LT_OK;
+}
+
+lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "Disabling Maintenance Mode in R-Config (reduces the attack surface):");
+
+    ESP_LOGI(TAG, "  - Starting Secure Session with key slot %d...",
+             (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        ESP_LOGE(TAG, "Failed to start Secure Session with key %d, ret=%s",
+                 (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    lt_config_t r_config;
+    ESP_LOGI(TAG, "  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Erasing R-Config...");
+    ret = lt_r_config_erase(lt_handle);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to erase R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Disabling Maintenance Mode in R-Config...");
+    r_config.obj[TR01_CFG_START_UP_IDX] &= ~BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+    ret = lt_write_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to write R-Config, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGW(TAG,
+                 "R-Config is left in an erased state - the state before erasing is printed above.");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Rebooting TROPIC01 to apply R-Config changes...");
+    ret = lt_reboot(lt_handle, TR01_REBOOT);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGW(TAG,
+                 "R-Config (with Maintenance Mode disabled) was written but not applied yet. It will "
+                 "be applied on next TROPIC01 reboot/power-cycle.");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Verifying that Maintenance Mode is not accessible...");
+    ret = lt_reboot(lt_handle, TR01_MAINTENANCE_REBOOT);
+    if (ret == LT_L2_RESP_DISABLED) {
+        ESP_LOGI(TAG, "  OK");
+    }
+    else if (ret != LT_OK) {
+        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    else {
+        ESP_LOGE(TAG, "Maintenance reboot succeeded! ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
+}
+
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {
     uint8_t cpu_fw_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE] = {0};
@@ -136,6 +322,15 @@ void app_main(void)
     ESP_LOGI(TAG, "  - RISC-V FW version: %d.%d.%d", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
     ESP_LOGI(TAG, "  - SPECT FW version: %d.%d.%d", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
 
+#if LT_DISABLE_MAINTENANCE_MODE
+    // We need to make sure we can reboot into Maintenance Mode to perform the FW update.
+    if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return;
+    }
+#endif
+
     ESP_LOGI(TAG, "");
     ESP_LOGI(TAG, "Updating TROPIC01 firmware...");
     // This helper function implements the recommended FW update process.
@@ -143,6 +338,11 @@ void app_main(void)
     if (ret != LT_OK) {
         ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
         ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
+#if LT_DISABLE_MAINTENANCE_MODE
+        if (g_mtnc_mode_was_enabled) {
+            ESP_LOGW(TAG, "Due to the error, Maintenance Mode was kept enabled in R-Config!");
+        }
+#endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;
@@ -154,6 +354,23 @@ void app_main(void)
         mbedtls_psa_crypto_free();
         return;
     }
+
+#if LT_DISABLE_MAINTENANCE_MODE
+    // Warning: User shall disable Maintenance Mode only after both FW banks are updated with the
+    // latest FW. If only one bank is updated (while the second one contains invalid FW), and
+    // Maintenance Mode is disabled, the probability of bricking TROPIC01 increases. In this case, if
+    // lt_do_mutable_fw_update() succeeds, it is safe to disable Maintenance Mode.
+    if (LT_OK != disable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return;
+    }
+#else
+    ESP_LOGI(TAG, "");
+    ESP_LOGW(
+        TAG,
+        "We strongly recommend disabling Maintenance Mode in R-Config to reduce the attack surface.");
+#endif
 
     ESP_LOGI(TAG, "");
     ESP_LOGI(TAG, "Deinitializing handle...");

--- a/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
+++ b/examples/esp32/ESP32-DevKitC-V4/fw_update/main/main.c
@@ -33,7 +33,7 @@
 #endif
 
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
-bool g_mtnc_mode_was_enabled = false;
+bool g_maintenance_mode_was_enabled = false;
 
 lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
 {
@@ -114,7 +114,7 @@ lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
             return ret;
         }
         ESP_LOGI(TAG, "    OK");
-        g_mtnc_mode_was_enabled = true;
+        g_maintenance_mode_was_enabled = true;
 
         ESP_LOGI(TAG, "    - Rebooting TROPIC01 to apply R-Config changes...");
         ret = lt_reboot(lt_handle, TR01_REBOOT);
@@ -339,7 +339,7 @@ void app_main(void)
         ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
         ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
 #if LT_DISABLE_MAINTENANCE_MODE
-        if (g_mtnc_mode_was_enabled) {
+        if (g_maintenance_mode_was_enabled) {
             ESP_LOGW(TAG, "Due to the error, Maintenance Mode was kept enabled in R-Config!");
         }
 #endif

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/CMakeLists.txt
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/CMakeLists.txt
@@ -1,5 +1,32 @@
 cmake_minimum_required(VERSION 3.16)
 
+# Select pairing keys written during manufacturing into your TROPIC01.
+# Note for users: if you are writing your own application, the following logic
+# with LT_SH0_KEYS is not necessary - use specific key pair, e.g. your own or 
+# the ones from libtropic_common.h.
+set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
+set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
+
+# These are internal macros for selecting SH0 keys.
+set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
+set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
+
+if(LT_SH0_KEYS STREQUAL "eng_sample")
+	set(LT_USE_SH0_ENG_SAMPLE 1)
+	set(LT_USE_SH0_PROD0      0)
+elseif(LT_SH0_KEYS STREQUAL "prod0")
+	set(LT_USE_SH0_ENG_SAMPLE 0)
+	set(LT_USE_SH0_PROD0      1)
+else()
+	get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
+	message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
+endif()
+
+option(LT_DISABLE_MAINTENANCE_MODE "Disable Maintenance Mode in R-Config after successful FW update" ON)
+if (NOT LT_DISABLE_MAINTENANCE_MODE)
+    message(WARNING "Maintenance Mode will not be disabled in R-Config after successful FW update. This can increase the attack surface.")
+endif()
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 idf_build_set_property(MINIMAL_BUILD ON)
 project(fw_update)

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/CMakeLists.txt
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/CMakeLists.txt
@@ -1,3 +1,19 @@
 idf_component_register(SRCS "main.c"
                        INCLUDE_DIRS "."
                        REQUIRES mbedtls libtropic)
+
+# Propagate selected SH0 key macros into this component's compile definitions.
+# Note for users: if you are writing your own application, the following logic
+# with LT_SH0_KEYS is not necessary - use specific key pair, e.g. your own or 
+# the ones from libtropic_common.h.
+if(NOT DEFINED LT_USE_SH0_ENG_SAMPLE)
+    set(LT_USE_SH0_ENG_SAMPLE 0)
+endif()
+if(NOT DEFINED LT_USE_SH0_PROD0)
+    set(LT_USE_SH0_PROD0 0)
+endif()
+target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE}
+    LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0}
+    LT_DISABLE_MAINTENANCE_MODE=$<BOOL:${LT_DISABLE_MAINTENANCE_MODE}>
+)

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
@@ -32,6 +32,7 @@
 #define LT_EX_SH0_PUB lt_sh0pub_prod0
 #endif
 
+#if LT_DISABLE_MAINTENANCE_MODE
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
 bool g_maintenance_mode_was_enabled = false;
 
@@ -208,6 +209,7 @@ lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
 
     return LT_OK;
 }
+#endif
 
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
@@ -7,6 +7,7 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
@@ -23,6 +23,192 @@
 
 #define TAG "fw_update"
 
+// Choose pairing keypair for slot 0.
+#if LT_USE_SH0_ENG_SAMPLE
+#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
+#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
+#elif LT_USE_SH0_PROD0
+#define LT_EX_SH0_PRIV lt_sh0priv_prod0
+#define LT_EX_SH0_PUB lt_sh0pub_prod0
+#endif
+
+// Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
+bool g_mtnc_mode_was_enabled = false;
+
+lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "Checking if Maintenance Mode is enabled and enabling it in R-Config if needed:");
+
+    // Establish Secure Channel Session so we can read I-Config/R-Config.
+    ESP_LOGI(TAG, "  - Starting Secure Session with key slot %d...",
+             (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        ESP_LOGE(TAG, "Failed to start Secure Session with key %d, ret=%s",
+                 (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        ESP_LOGE(TAG,
+                 "Check if you use correct SH0 keys! Hint: if you use an engineering sample chip, "
+                 "compile with -DLT_SH0_KEYS=eng_sample");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    // Read I-Config and check if Maintenance Mode is enabled.
+    uint32_t i_config_cfg_startup;
+    ESP_LOGI(TAG, "  - Reading I-Config[CFG_START_UP]...");
+    ret = lt_i_config_read(lt_handle, TR01_CFG_START_UP_ADDR, &i_config_cfg_startup);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read I-Config[CFG_START_UP], ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Checking if Maintenance Mode is enabled in I-Config[CFG_START_UP]...");
+    if (!(i_config_cfg_startup & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        ESP_LOGE(TAG, "Maintenance Mode is not enabled in I-Config -> FW Update cannot be performed.");
+        return LT_FAIL;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    // Read R-Config and check if Maintenance Mode is enabled.
+    // The whole R-Config is read in case we need to modify it, as it has to be completely erased
+    // before writing again.
+    lt_config_t r_config;
+    ESP_LOGI(TAG, "  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Read R-Config (acts as a backup):");
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        ESP_LOGI(TAG, "    - %s= 0x%08" PRIx32, cfg_desc_table[i].desc, r_config.obj[i]);
+    }
+
+    ESP_LOGI(TAG, "  - Checking if Maintenance Mode is enabled in R-Config[CFG_START_UP]...");
+    if (!(r_config.obj[TR01_CFG_START_UP_IDX] & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        ESP_LOGI(TAG, "Disabled, will enable it");
+        ESP_LOGI(TAG, "    - Erasing R-Config...");
+        ret = lt_r_config_erase(lt_handle);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "Failed to erase R-Config, ret=%s", lt_ret_verbose(ret));
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+
+        r_config.obj[TR01_CFG_START_UP_IDX] |= BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+        ESP_LOGI(TAG, "    - Writing modified R-Config...");
+        ret = lt_write_whole_R_config(lt_handle, &r_config);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "Failed to write R-Config, ret=%s", lt_ret_verbose(ret));
+            ESP_LOGW(
+                TAG,
+                "R-Config is left in an erased state - the state before erasing is printed above.");
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+        g_mtnc_mode_was_enabled = true;
+
+        ESP_LOGI(TAG, "    - Rebooting TROPIC01 to apply R-Config changes...");
+        ret = lt_reboot(lt_handle, TR01_REBOOT);
+        if (ret != LT_OK) {
+            ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+            ESP_LOGW(TAG,
+                     "R-Config (with Maintenance Mode enabled) was written but not applied yet. It "
+                     "will be applied on next TROPIC01 reboot/power-cycle.");
+            return ret;
+        }
+        ESP_LOGI(TAG, "    OK");
+    }
+    else {
+        ESP_LOGI(TAG, "  OK");
+    }
+
+    return LT_OK;
+}
+
+lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "Disabling Maintenance Mode in R-Config (reduces the attack surface):");
+
+    ESP_LOGI(TAG, "  - Starting Secure Session with key slot %d...",
+             (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        ESP_LOGE(TAG, "Failed to start Secure Session with key %d, ret=%s",
+                 (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    lt_config_t r_config;
+    ESP_LOGI(TAG, "  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to read R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Erasing R-Config...");
+    ret = lt_r_config_erase(lt_handle);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to erase R-Config, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Disabling Maintenance Mode in R-Config...");
+    r_config.obj[TR01_CFG_START_UP_IDX] &= ~BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+    ret = lt_write_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "Failed to write R-Config, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGW(TAG,
+                 "R-Config is left in an erased state - the state before erasing is printed above.");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Rebooting TROPIC01 to apply R-Config changes...");
+    ret = lt_reboot(lt_handle, TR01_REBOOT);
+    if (ret != LT_OK) {
+        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+        ESP_LOGW(TAG,
+                 "R-Config (with Maintenance Mode disabled) was written but not applied yet. It will "
+                 "be applied on next TROPIC01 reboot/power-cycle.");
+        return ret;
+    }
+    ESP_LOGI(TAG, "  OK");
+
+    ESP_LOGI(TAG, "  - Verifying that Maintenance Mode is not accessible...");
+    ret = lt_reboot(lt_handle, TR01_MAINTENANCE_REBOOT);
+    if (ret == LT_L2_RESP_DISABLED) {
+        ESP_LOGI(TAG, "  OK");
+    }
+    else if (ret != LT_OK) {
+        ESP_LOGE(TAG, "lt_reboot() failed, ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+    else {
+        ESP_LOGE(TAG, "Maintenance reboot succeeded! ret=%s", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
+}
+
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {
     uint8_t cpu_fw_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE] = {0};
@@ -136,6 +322,15 @@ void app_main(void)
     ESP_LOGI(TAG, "  - RISC-V FW version: %d.%d.%d", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
     ESP_LOGI(TAG, "  - SPECT FW version: %d.%d.%d", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
 
+#if LT_DISABLE_MAINTENANCE_MODE
+    // We need to make sure we can reboot into Maintenance Mode to perform the FW update.
+    if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return;
+    }
+#endif
+
     ESP_LOGI(TAG, "");
     ESP_LOGI(TAG, "Updating TROPIC01 firmware...");
     // This helper function implements the recommended FW update process.
@@ -143,6 +338,11 @@ void app_main(void)
     if (ret != LT_OK) {
         ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
         ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
+#if LT_DISABLE_MAINTENANCE_MODE
+        if (g_mtnc_mode_was_enabled) {
+            ESP_LOGW(TAG, "Due to the error, Maintenance Mode was kept enabled in R-Config!");
+        }
+#endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return;
@@ -154,6 +354,23 @@ void app_main(void)
         mbedtls_psa_crypto_free();
         return;
     }
+
+#if LT_DISABLE_MAINTENANCE_MODE
+    // Warning: User shall disable Maintenance Mode only after both FW banks are updated with the
+    // latest FW. If only one bank is updated (while the second one contains invalid FW), and
+    // Maintenance Mode is disabled, the probability of bricking TROPIC01 increases. In this case, if
+    // lt_do_mutable_fw_update() succeeds, it is safe to disable Maintenance Mode.
+    if (LT_OK != disable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return;
+    }
+#else
+    ESP_LOGI(TAG, "");
+    ESP_LOGW(
+        TAG,
+        "We strongly recommend disabling Maintenance Mode in R-Config to reduce the attack surface.");
+#endif
 
     ESP_LOGI(TAG, "");
     ESP_LOGI(TAG, "Deinitializing handle...");

--- a/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
+++ b/examples/esp32/ESP32-S3-DevKitC-1/fw_update/main/main.c
@@ -33,7 +33,7 @@
 #endif
 
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
-bool g_mtnc_mode_was_enabled = false;
+bool g_maintenance_mode_was_enabled = false;
 
 lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
 {
@@ -114,7 +114,7 @@ lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
             return ret;
         }
         ESP_LOGI(TAG, "    OK");
-        g_mtnc_mode_was_enabled = true;
+        g_maintenance_mode_was_enabled = true;
 
         ESP_LOGI(TAG, "    - Rebooting TROPIC01 to apply R-Config changes...");
         ret = lt_reboot(lt_handle, TR01_REBOOT);
@@ -339,7 +339,7 @@ void app_main(void)
         ESP_LOGE(TAG, "lt_do_mutable_fw_update() failed, ret=%s", lt_ret_verbose(ret));
         ESP_LOGE(TAG, "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)");
 #if LT_DISABLE_MAINTENANCE_MODE
-        if (g_mtnc_mode_was_enabled) {
+        if (g_maintenance_mode_was_enabled) {
             ESP_LOGW(TAG, "Due to the error, Maintenance Mode was kept enabled in R-Config!");
         }
 #endif

--- a/examples/linux/spi/fw_update/CMakeLists.txt
+++ b/examples/linux/spi/fw_update/CMakeLists.txt
@@ -31,6 +31,33 @@ if (NOT DEFINED LT_GPIO_DEV_PATH)
 endif()
 message(STATUS "Using GPIO device: ${LT_GPIO_DEV_PATH}. You can change it by passing -DLT_GPIO_DEV_PATH=<path> to cmake.")
 
+# Select pairing keys written during manufacturing into your TROPIC01
+set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
+set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
+
+# These are internal macros for selecting SH0 keys (examples/tests)
+set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
+set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
+
+# Define SH0 macros based on selected string (examples/tests)
+if(LT_SH0_KEYS STREQUAL "eng_sample")
+    message(STATUS "Using Engineering sample keys in examples/tests")
+    set(LT_USE_SH0_ENG_SAMPLE 1)
+    set(LT_USE_SH0_PROD0      0)
+elseif(LT_SH0_KEYS STREQUAL "prod0")
+    message(STATUS "Using Production 0 keys in examples/tests")
+    set(LT_USE_SH0_ENG_SAMPLE 0)
+    set(LT_USE_SH0_PROD0      1)
+else()
+    get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
+    message(FATAL_ERROR "Incorrect SH0 keys for examples/tests specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
+endif()
+
+option(LT_DISABLE_MAINTENANCE_MODE "Disable Maintenance Mode in R-Config after successful FW update" ON)
+if (NOT LT_DISABLE_MAINTENANCE_MODE)
+    message(WARNING "Maintenance Mode will not be disabled in R-Config after successful FW update. This can increase the attack surface.")
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up dependencies                                                   #
@@ -85,4 +112,7 @@ set(SOURCES
 add_executable(${CMAKE_PROJECT_NAME} ${SOURCES})
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_SPI_DEV_PATH=\"${LT_SPI_DEV_PATH}\")
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_GPIO_DEV_PATH=\"${LT_GPIO_DEV_PATH}\")
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_DISABLE_MAINTENANCE_MODE=$<BOOL:${LT_DISABLE_MAINTENANCE_MODE}>)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE tropic)

--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -29,7 +29,7 @@
 #endif
 
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
-bool g_mtnc_mode_was_enabled = false;
+bool g_maintenance_mode_was_enabled = false;
 
 lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
 {
@@ -110,7 +110,7 @@ lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
             return ret;
         }
         printf("OK\n");
-        g_mtnc_mode_was_enabled = true;
+        g_maintenance_mode_was_enabled = true;
 
         printf("    - Rebooting TROPIC01 to apply R-Config changes...");
         ret = lt_reboot(lt_handle, TR01_REBOOT);
@@ -357,7 +357,7 @@ int main(void)
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
 #if LT_DISABLE_MAINTENANCE_MODE
-        if (g_mtnc_mode_was_enabled) {
+        if (g_maintenance_mode_was_enabled) {
             fprintf(stderr,
                     "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
         }

--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -7,6 +7,7 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>

--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -28,6 +28,7 @@
 #define LT_EX_SH0_PUB lt_sh0pub_prod0
 #endif
 
+#if LT_DISABLE_MAINTENANCE_MODE
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
 bool g_maintenance_mode_was_enabled = false;
 
@@ -203,6 +204,7 @@ lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
 
     return LT_OK;
 }
+#endif
 
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {

--- a/examples/linux/spi/fw_update/main.c
+++ b/examples/linux/spi/fw_update/main.c
@@ -19,6 +19,191 @@
 #include "libtropic_port_linux_spi.h"
 #include "psa/crypto.h"
 
+// Choose pairing keypair for slot 0 (used only if LT_DISABLE_MAINTENANCE_MODE CMake option is set).
+#if LT_USE_SH0_ENG_SAMPLE
+#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
+#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
+#elif LT_USE_SH0_PROD0
+#define LT_EX_SH0_PRIV lt_sh0priv_prod0
+#define LT_EX_SH0_PUB lt_sh0pub_prod0
+#endif
+
+// Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
+bool g_mtnc_mode_was_enabled = false;
+
+lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nChecking if Maintenance Mode is enabled and enabling it in R-Config if needed:\n");
+
+    // Establish Secure Channel Session so we can read I-Config/R-Config.
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Check if you use correct SH0 keys! Hint: if you use an engineering sample chip, "
+                "compile with "
+                "-DLT_SH0_KEYS=eng_sample\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    // Read I-Config and check if Maintenance Mode is enabled.
+    uint32_t i_config_cfg_startup;
+    printf("  - Reading I-Config[CFG_START_UP]...");
+    ret = lt_i_config_read(lt_handle, TR01_CFG_START_UP_ADDR, &i_config_cfg_startup);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read I-Config[CFG_START_UP], ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Checking if Maintenance Mode is enabled in I-Config[CFG_START_UP]...");
+    if (!(i_config_cfg_startup & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        fprintf(stderr,
+                "\nMaintenance Mode is not enabled in I-Config -> FW Update cannot be performed.\n");
+        return LT_FAIL;
+    }
+    printf("OK\n");
+
+    // Read R-Config and check if Maintenance Mode is enabled.
+    // The whole R-Config is read in case we need to modify it, as it has to be completely erased
+    // before writing again.
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Read R-Config (acts as a backup):\n");
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        printf("    - %s= 0x%08" PRIx32 "\n", cfg_desc_table[i].desc, r_config.obj[i]);
+    }
+
+    printf("  - Checking if Maintenance Mode is enabled in R-Config[CFG_START_UP]...");
+    if (!(r_config.obj[TR01_CFG_START_UP_IDX] & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        printf("Disabled, will enable it\n");
+        printf("    - Erasing R-Config...");
+        ret = lt_r_config_erase(lt_handle);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+            return ret;
+        }
+        printf("OK\n");
+
+        r_config.obj[TR01_CFG_START_UP_IDX] |= BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+        printf("    - Writing modified R-Config...");
+        ret = lt_write_whole_R_config(lt_handle, &r_config);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config is left in an erased state - the state before erasing is "
+                    "printed above.\n");
+            return ret;
+        }
+        printf("OK\n");
+        g_mtnc_mode_was_enabled = true;
+
+        printf("    - Rebooting TROPIC01 to apply R-Config changes...");
+        ret = lt_reboot(lt_handle, TR01_REBOOT);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config (with Maintenance Mode enabled) was written but not applied "
+                    "yet. It will be applied on next TROPIC01 reboot/power-cycle.\n");
+            return ret;
+        }
+        printf("OK\n");
+    }
+    else {
+        printf("OK\n");
+    }
+
+    return LT_OK;
+}
+
+lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nDisabling Maintenance Mode in R-Config (reduces the attack surface):\n");
+
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Erasing R-Config...");
+    ret = lt_r_config_erase(lt_handle);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Disabling Maintenance Mode in R-Config...");
+    r_config.obj[TR01_CFG_START_UP_IDX] &= ~BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+    ret = lt_write_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config is left in an erased state - the state before erasing is printed "
+                "above.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Rebooting TROPIC01 to apply R-Config changes...");
+    ret = lt_reboot(lt_handle, TR01_REBOOT);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config (with Maintenance Mode disabled) was written but not applied yet. "
+                "It will be applied on next TROPIC01 reboot/power-cycle.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Verifying that Maintenance Mode is not accessible...");
+    ret = lt_reboot(lt_handle, TR01_MAINTENANCE_REBOOT);
+    if (ret == LT_L2_RESP_DISABLED) {
+        printf("OK\n");
+    }
+    else if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    else {
+        fprintf(stderr, "\nMaintenance reboot succeeded! ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
+}
+
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {
     uint8_t cpu_fw_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE] = {0};
@@ -155,6 +340,15 @@ int main(void)
         return 0;
     }
 
+#if LT_DISABLE_MAINTENANCE_MODE
+    // We need to make sure we can reboot into Maintenance Mode to perform the FW update.
+    if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#endif
+
     printf("\nUpdating TROPIC01 firmware...");
     // This helper function implements the recommended FW update process.
     ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
@@ -162,6 +356,12 @@ int main(void)
         fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
+#if LT_DISABLE_MAINTENANCE_MODE
+        if (g_mtnc_mode_was_enabled) {
+            fprintf(stderr,
+                    "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
+        }
+#endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
@@ -174,7 +374,23 @@ int main(void)
         return -1;
     }
 
-    printf("Deinitializing handle...");
+#if LT_DISABLE_MAINTENANCE_MODE
+    // Warning: User shall disable Maintenance Mode only after both FW banks are updated with the
+    // latest FW. If only one bank is updated (while the second one contains invalid FW), and
+    // Maintenance Mode is disabled, the probability of bricking TROPIC01 increases. In this case, if
+    // lt_do_mutable_fw_update() succeeds, it is safe to disable Maintenance Mode.
+    if (LT_OK != disable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#else
+    printf(
+        "\nWARNING: We strongly recommend disabling Maintenance Mode in R-Config to reduce the attack "
+        "surface.\n");
+#endif
+
+    printf("\nDeinitializing handle...");
     ret = lt_deinit(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));

--- a/examples/linux/usb_devkit/fw_update/CMakeLists.txt
+++ b/examples/linux/usb_devkit/fw_update/CMakeLists.txt
@@ -26,6 +26,33 @@ if (NOT DEFINED LT_USB_DEVKIT_PATH)
 endif()
 message(STATUS "Using serial port: ${LT_USB_DEVKIT_PATH}. You can change it by passing -DLT_USB_DEVKIT_PATH=<path> to cmake.")
 
+# Select pairing keys written during manufacturing into your TROPIC01
+set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
+set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
+
+# These are internal macros for selecting SH0 keys (examples/tests)
+set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
+set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
+
+# Define SH0 macros based on selected string (examples/tests)
+if(LT_SH0_KEYS STREQUAL "eng_sample")
+    message(STATUS "Using Engineering sample keys in examples/tests")
+    set(LT_USE_SH0_ENG_SAMPLE 1)
+    set(LT_USE_SH0_PROD0      0)
+elseif(LT_SH0_KEYS STREQUAL "prod0")
+    message(STATUS "Using Production 0 keys in examples/tests")
+    set(LT_USE_SH0_ENG_SAMPLE 0)
+    set(LT_USE_SH0_PROD0      1)
+else()
+    get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
+    message(FATAL_ERROR "Incorrect SH0 keys for examples/tests specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
+endif()
+
+option(LT_DISABLE_MAINTENANCE_MODE "Disable Maintenance Mode in R-Config after successful FW update" ON)
+if (NOT LT_DISABLE_MAINTENANCE_MODE)
+    message(WARNING "Maintenance Mode will not be disabled in R-Config after successful FW update. This can increase the attack surface.")
+endif()
+
 ###########################################################################
 #                                                                         #
 #   Set up dependencies                                                   #
@@ -79,4 +106,7 @@ set(SOURCES
 # Define executable, pass defines, and link dependencies.
 add_executable(${CMAKE_PROJECT_NAME} ${SOURCES})
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_USB_DEVKIT_PATH=\"${LT_USB_DEVKIT_PATH}\")
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0})
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LT_DISABLE_MAINTENANCE_MODE=$<BOOL:${LT_DISABLE_MAINTENANCE_MODE}>)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE tropic)

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -29,7 +29,7 @@
 #endif
 
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
-bool g_mtnc_mode_was_enabled = false;
+bool g_maintenance_mode_was_enabled = false;
 
 lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
 {
@@ -110,7 +110,7 @@ lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
             return ret;
         }
         printf("OK\n");
-        g_mtnc_mode_was_enabled = true;
+        g_maintenance_mode_was_enabled = true;
 
         printf("    - Rebooting TROPIC01 to apply R-Config changes...");
         ret = lt_reboot(lt_handle, TR01_REBOOT);
@@ -342,7 +342,7 @@ int main(void)
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
 #if LT_DISABLE_MAINTENANCE_MODE
-        if (g_mtnc_mode_was_enabled) {
+        if (g_maintenance_mode_was_enabled) {
             fprintf(stderr,
                     "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
         }

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -7,6 +7,7 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -19,6 +19,191 @@
 #include "libtropic_port_posix_usb_devkit.h"
 #include "psa/crypto.h"
 
+// Choose pairing keypair for slot 0 (used only if LT_DISABLE_MAINTENANCE_MODE CMake option is set).
+#if LT_USE_SH0_ENG_SAMPLE
+#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
+#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
+#elif LT_USE_SH0_PROD0
+#define LT_EX_SH0_PRIV lt_sh0priv_prod0
+#define LT_EX_SH0_PUB lt_sh0pub_prod0
+#endif
+
+// Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
+bool g_mtnc_mode_was_enabled = false;
+
+lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nChecking if Maintenance Mode is enabled and enabling it in R-Config if needed:\n");
+
+    // Establish Secure Channel Session so we can read I-Config/R-Config.
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Check if you use correct SH0 keys! Hint: if you use an engineering sample chip, "
+                "compile with "
+                "-DLT_SH0_KEYS=eng_sample\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    // Read I-Config and check if Maintenance Mode is enabled.
+    uint32_t i_config_cfg_startup;
+    printf("  - Reading I-Config[CFG_START_UP]...");
+    ret = lt_i_config_read(lt_handle, TR01_CFG_START_UP_ADDR, &i_config_cfg_startup);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read I-Config[CFG_START_UP], ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Checking if Maintenance Mode is enabled in I-Config[CFG_START_UP]...");
+    if (!(i_config_cfg_startup & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        fprintf(stderr,
+                "\nMaintenance Mode is not enabled in I-Config -> FW Update cannot be performed.\n");
+        return LT_FAIL;
+    }
+    printf("OK\n");
+
+    // Read R-Config and check if Maintenance Mode is enabled.
+    // The whole R-Config is read in case we need to modify it, as it has to be completely erased
+    // before writing again.
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Read R-Config (acts as a backup):\n");
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        printf("    - %s= 0x%08" PRIx32 "\n", cfg_desc_table[i].desc, r_config.obj[i]);
+    }
+
+    printf("  - Checking if Maintenance Mode is enabled in R-Config[CFG_START_UP]...");
+    if (!(r_config.obj[TR01_CFG_START_UP_IDX] & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        printf("Disabled, will enable it\n");
+        printf("    - Erasing R-Config...");
+        ret = lt_r_config_erase(lt_handle);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+            return ret;
+        }
+        printf("OK\n");
+
+        r_config.obj[TR01_CFG_START_UP_IDX] |= BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+        printf("    - Writing modified R-Config...");
+        ret = lt_write_whole_R_config(lt_handle, &r_config);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config is left in an erased state - the state before erasing is "
+                    "printed above.\n");
+            return ret;
+        }
+        printf("OK\n");
+        g_mtnc_mode_was_enabled = true;
+
+        printf("    - Rebooting TROPIC01 to apply R-Config changes...");
+        ret = lt_reboot(lt_handle, TR01_REBOOT);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config (with Maintenance Mode enabled) was written but not applied "
+                    "yet. It will be applied on next TROPIC01 reboot/power-cycle.\n");
+            return ret;
+        }
+        printf("OK\n");
+    }
+    else {
+        printf("OK\n");
+    }
+
+    return LT_OK;
+}
+
+lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nDisabling Maintenance Mode in R-Config (reduces the attack surface):\n");
+
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Erasing R-Config...");
+    ret = lt_r_config_erase(lt_handle);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Disabling Maintenance Mode in R-Config...");
+    r_config.obj[TR01_CFG_START_UP_IDX] &= ~BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+    ret = lt_write_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config is left in an erased state - the state before erasing is printed "
+                "above.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Rebooting TROPIC01 to apply R-Config changes...");
+    ret = lt_reboot(lt_handle, TR01_REBOOT);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config (with Maintenance Mode disabled) was written but not applied yet. "
+                "It will be applied on next TROPIC01 reboot/power-cycle.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Verifying that Maintenance Mode is not accessible...");
+    ret = lt_reboot(lt_handle, TR01_MAINTENANCE_REBOOT);
+    if (ret == LT_L2_RESP_DISABLED) {
+        printf("OK\n");
+    }
+    else if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    else {
+        fprintf(stderr, "\nMaintenance reboot succeeded! ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
+}
+
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {
     uint8_t cpu_fw_ver[TR01_L2_GET_INFO_RISCV_FW_SIZE] = {0};
@@ -140,6 +325,15 @@ int main(void)
         return 0;
     }
 
+#if LT_DISABLE_MAINTENANCE_MODE
+    // We need to make sure we can reboot into Maintenance Mode to perform the FW update.
+    if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#endif
+
     printf("\nUpdating TROPIC01 firmware...");
     // This helper function implements the recommended FW update process.
     ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
@@ -147,6 +341,12 @@ int main(void)
         fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
+#if LT_DISABLE_MAINTENANCE_MODE
+        if (g_mtnc_mode_was_enabled) {
+            fprintf(stderr,
+                    "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
+        }
+#endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
@@ -159,7 +359,23 @@ int main(void)
         return -1;
     }
 
-    printf("Deinitializing handle...");
+#if LT_DISABLE_MAINTENANCE_MODE
+    // Warning: User shall disable Maintenance Mode only after both FW banks are updated with the
+    // latest FW. If only one bank is updated (while the second one contains invalid FW), and
+    // Maintenance Mode is disabled, the probability of bricking TROPIC01 increases. In this case, if
+    // lt_do_mutable_fw_update() succeeds, it is safe to disable Maintenance Mode.
+    if (LT_OK != disable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#else
+    printf(
+        "\nWARNING: We strongly recommend disabling Maintenance Mode in R-Config to reduce the attack "
+        "surface.\n");
+#endif
+
+    printf("\nDeinitializing handle...");
     ret = lt_deinit(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));

--- a/examples/linux/usb_devkit/fw_update/main.c
+++ b/examples/linux/usb_devkit/fw_update/main.c
@@ -28,6 +28,7 @@
 #define LT_EX_SH0_PUB lt_sh0pub_prod0
 #endif
 
+#if LT_DISABLE_MAINTENANCE_MODE
 // Tracks whether the Maintenance Mode had to be enabled before starting the FW update.
 bool g_maintenance_mode_was_enabled = false;
 
@@ -203,6 +204,7 @@ lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
 
     return LT_OK;
 }
+#endif
 
 lt_ret_t get_fw_versions(lt_handle_t *lt_handle)
 {

--- a/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/fw_update/CMakeLists.txt
@@ -68,6 +68,10 @@ else()
     message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
 endif()
 
+option(LT_DISABLE_MAINTENANCE_MODE "Disable Maintenance Mode in R-Config after successful FW update" ON)
+if (NOT LT_DISABLE_MAINTENANCE_MODE)
+    message(WARNING "Maintenance Mode will not be disabled in R-Config after successful FW update. This can increase the attack surface.")
+endif()
 
 ###########################################################################
 #                                                                         #
@@ -175,6 +179,7 @@ set(EXE_NAME ${CMAKE_PROJECT_NAME}.elf)
 add_executable(${EXE_NAME} ${SOURCES})
 target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE})
 target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0})
+target_compile_definitions(${EXE_NAME} PRIVATE LT_DISABLE_MAINTENANCE_MODE=$<BOOL:${LT_DISABLE_MAINTENANCE_MODE}>)
 target_compile_definitions(${EXE_NAME} PRIVATE -D${STM32_DEVICE}) # Configure target MCU (used by STM32 HAL)
 target_include_directories(${EXE_NAME} PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(${EXE_NAME} PRIVATE tropic)

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -69,7 +69,7 @@
 /* Private variables ---------------------------------------------------------*/
 
 /* Tracks whether the Maintenance Mode had to be enabled before starting the FW update. */
-bool g_mtnc_mode_was_enabled = false;
+bool g_maintenance_mode_was_enabled = false;
 
 /* Private function prototypes -----------------------------------------------*/
 #ifdef __GNUC__
@@ -225,7 +225,7 @@ lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
             return ret;
         }
         printf("OK\n");
-        g_mtnc_mode_was_enabled = true;
+        g_maintenance_mode_was_enabled = true;
 
         printf("    - Rebooting TROPIC01 to apply R-Config changes...");
         ret = lt_reboot(lt_handle, TR01_REBOOT);
@@ -502,7 +502,7 @@ int main(void)
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
 #if LT_DISABLE_MAINTENANCE_MODE
-        if (g_mtnc_mode_was_enabled) {
+        if (g_maintenance_mode_was_enabled) {
             fprintf(stderr,
                     "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
         }

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -68,6 +68,9 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 
+/* Tracks whether the Maintenance Mode had to be enabled before starting the FW update. */
+bool g_mtnc_mode_was_enabled = false;
+
 /* Private function prototypes -----------------------------------------------*/
 #ifdef __GNUC__
 /* With GCC, small printf (option LD Linker->Libraries->Small printf
@@ -136,6 +139,189 @@ PUTCHAR_PROTOTYPE
     }
 
     return ch;
+}
+
+/**
+ * @brief  Checks if Maintenance Mode is enabled and if not, enables it in R-Config.
+ * @param  lt_handle_t Device handle
+ * @retval LT_OK on success
+ */
+lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nChecking if Maintenance Mode is enabled and enabling it in R-Config if needed:\n");
+
+    // Establish Secure Channel Session so we can read I-Config/R-Config.
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Check if you use correct SH0 keys! Hint: if you use an engineering sample chip, "
+                "compile with "
+                "-DLT_SH0_KEYS=eng_sample\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    // Read I-Config and check if Maintenance Mode is enabled.
+    uint32_t i_config_cfg_startup;
+    printf("  - Reading I-Config[CFG_START_UP]...");
+    ret = lt_i_config_read(lt_handle, TR01_CFG_START_UP_ADDR, &i_config_cfg_startup);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read I-Config[CFG_START_UP], ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Checking if Maintenance Mode is enabled in I-Config[CFG_START_UP]...");
+    if (!(i_config_cfg_startup & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        fprintf(stderr,
+                "\nMaintenance Mode is not enabled in I-Config -> FW Update cannot be performed.\n");
+        return LT_FAIL;
+    }
+    printf("OK\n");
+
+    // Read R-Config and check if Maintenance Mode is enabled.
+    // The whole R-Config is read in case we need to modify it, as it has to be completely erased
+    // before writing again.
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Read R-Config (acts as a backup):\n");
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        printf("    - %s= 0x%08" PRIx32 "\n", cfg_desc_table[i].desc, r_config.obj[i]);
+    }
+
+    printf("  - Checking if Maintenance Mode is enabled in R-Config[CFG_START_UP]...");
+    if (!(r_config.obj[TR01_CFG_START_UP_IDX] & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        printf("Disabled, will enable it\n");
+        printf("    - Erasing R-Config...");
+        ret = lt_r_config_erase(lt_handle);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+            return ret;
+        }
+        printf("OK\n");
+
+        r_config.obj[TR01_CFG_START_UP_IDX] |= BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+        printf("    - Writing modified R-Config...");
+        ret = lt_write_whole_R_config(lt_handle, &r_config);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config is left in an erased state - the state before erasing is "
+                    "printed above.\n");
+            return ret;
+        }
+        printf("OK\n");
+        g_mtnc_mode_was_enabled = true;
+
+        printf("    - Rebooting TROPIC01 to apply R-Config changes...");
+        ret = lt_reboot(lt_handle, TR01_REBOOT);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config (with Maintenance Mode enabled) was written but not applied "
+                    "yet. It will be applied on next TROPIC01 reboot/power-cycle.\n");
+            return ret;
+        }
+        printf("OK\n");
+    }
+    else {
+        printf("OK\n");
+    }
+
+    return LT_OK;
+}
+
+/**
+ * @brief  Disables Maintenance Mode.
+ * @param  lt_handle_t Device handle
+ * @retval LT_OK on success
+ */
+lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nDisabling Maintenance Mode in R-Config (reduces the attack surface):\n");
+
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Erasing R-Config...");
+    ret = lt_r_config_erase(lt_handle);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Disabling Maintenance Mode in R-Config...");
+    r_config.obj[TR01_CFG_START_UP_IDX] &= ~BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+    ret = lt_write_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config is left in an erased state - the state before erasing is printed "
+                "above.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Rebooting TROPIC01 to apply R-Config changes...");
+    ret = lt_reboot(lt_handle, TR01_REBOOT);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config (with Maintenance Mode disabled) was written but not applied yet. "
+                "It will be applied on next TROPIC01 reboot/power-cycle.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Verifying that Maintenance Mode is not accessible...");
+    ret = lt_reboot(lt_handle, TR01_MAINTENANCE_REBOOT);
+    if (ret == LT_L2_RESP_DISABLED) {
+        printf("OK\n");
+    }
+    else if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    else {
+        fprintf(stderr, "\nMaintenance reboot succeeded! ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
 }
 
 /**
@@ -299,6 +485,15 @@ int main(void)
     printf("  - RISC-V FW version: %d.%d.%d\n", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
     printf("  - SPECT FW version: %d.%d.%d\n", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
 
+#if LT_DISABLE_MAINTENANCE_MODE
+    // We need to make sure we can reboot into Maintenance Mode to perform the FW update.
+    if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#endif
+
     printf("\nUpdating TROPIC01 firmware...");
     // This helper function implements the recommended FW update process.
     ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
@@ -306,6 +501,12 @@ int main(void)
         fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
+#if LT_DISABLE_MAINTENANCE_MODE
+        if (g_mtnc_mode_was_enabled) {
+            fprintf(stderr,
+                    "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
+        }
+#endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
@@ -318,7 +519,23 @@ int main(void)
         return -1;
     }
 
-    printf("Deinitializing handle...");
+#if LT_DISABLE_MAINTENANCE_MODE
+    // Warning: User shall disable Maintenance Mode only after both FW banks are updated with the
+    // latest FW. If only one bank is updated (while the second one contains invalid FW), and
+    // Maintenance Mode is disabled, the probability of bricking TROPIC01 increases. In this case, if
+    // lt_do_mutable_fw_update() succeeds, it is safe to disable Maintenance Mode.
+    if (LT_OK != disable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#else
+    printf(
+        "\nWARNING: We strongly recommend disabling Maintenance Mode in R-Config to reduce the attack "
+        "surface.\n");
+#endif
+
+    printf("\nDeinitializing handle...");
     ret = lt_deinit(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -68,8 +68,10 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 
+#if LT_DISABLE_MAINTENANCE_MODE
 /* Tracks whether the Maintenance Mode had to be enabled before starting the FW update. */
 bool g_maintenance_mode_was_enabled = false;
+#endif
 
 /* Private function prototypes -----------------------------------------------*/
 #ifdef __GNUC__
@@ -141,6 +143,7 @@ PUTCHAR_PROTOTYPE
     return ch;
 }
 
+#if LT_DISABLE_MAINTENANCE_MODE
 /**
  * @brief  Checks if Maintenance Mode is enabled and if not, enables it in R-Config.
  * @param  lt_handle_t Device handle
@@ -323,6 +326,7 @@ lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
 
     return LT_OK;
 }
+#endif
 
 /**
  * @brief  Retrieve and print versions of TROPIC01 firmware

--- a/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/fw_update/CMakeLists.txt
@@ -68,6 +68,10 @@ else()
     message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
 endif()
 
+option(LT_DISABLE_MAINTENANCE_MODE "Disable Maintenance Mode in R-Config after successful FW update" ON)
+if (NOT LT_DISABLE_MAINTENANCE_MODE)
+    message(WARNING "Maintenance Mode will not be disabled in R-Config after successful FW update. This can increase the attack surface.")
+endif()
 
 ###########################################################################
 #                                                                         #
@@ -176,6 +180,7 @@ set(EXE_NAME ${CMAKE_PROJECT_NAME}.elf)
 add_executable(${EXE_NAME} ${SOURCES})
 target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE})
 target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0})
+target_compile_definitions(${EXE_NAME} PRIVATE LT_DISABLE_MAINTENANCE_MODE=$<BOOL:${LT_DISABLE_MAINTENANCE_MODE}>)
 target_compile_definitions(${EXE_NAME} PRIVATE -D${STM32_DEVICE}) # Configure target MCU (used by STM32 HAL)
 target_include_directories(${EXE_NAME} PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(${EXE_NAME} PRIVATE tropic)

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -68,8 +68,10 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 
+#if LT_DISABLE_MAINTENANCE_MODE
 /* Tracks whether the Maintenance Mode had to be enabled before starting the FW update. */
 bool g_maintenance_mode_was_enabled = false;
+#endif
 
 /* Private function prototypes -----------------------------------------------*/
 #ifdef __GNUC__
@@ -174,6 +176,7 @@ PUTCHAR_PROTOTYPE
     return ch;
 }
 
+#if LT_DISABLE_MAINTENANCE_MODE
 /**
  * @brief  Checks if Maintenance Mode is enabled and if not, enables it in R-Config.
  * @param  lt_handle_t Device handle
@@ -356,6 +359,7 @@ lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
 
     return LT_OK;
 }
+#endif
 
 /**
  * @brief  Retrieve and print versions of TROPIC01 firmware

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -68,6 +68,9 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 
+/* Tracks whether the Maintenance Mode had to be enabled before starting the FW update. */
+bool g_mtnc_mode_was_enabled = false;
+
 /* Private function prototypes -----------------------------------------------*/
 #ifdef __GNUC__
 /* With GCC, small printf (option LD Linker->Libraries->Small printf
@@ -169,6 +172,189 @@ PUTCHAR_PROTOTYPE
     }
 
     return ch;
+}
+
+/**
+ * @brief  Checks if Maintenance Mode is enabled and if not, enables it in R-Config.
+ * @param  lt_handle_t Device handle
+ * @retval LT_OK on success
+ */
+lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nChecking if Maintenance Mode is enabled and enabling it in R-Config if needed:\n");
+
+    // Establish Secure Channel Session so we can read I-Config/R-Config.
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        fprintf(stderr,
+                "Check if you use correct SH0 keys! Hint: if you use an engineering sample chip, "
+                "compile with "
+                "-DLT_SH0_KEYS=eng_sample\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    // Read I-Config and check if Maintenance Mode is enabled.
+    uint32_t i_config_cfg_startup;
+    printf("  - Reading I-Config[CFG_START_UP]...");
+    ret = lt_i_config_read(lt_handle, TR01_CFG_START_UP_ADDR, &i_config_cfg_startup);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read I-Config[CFG_START_UP], ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Checking if Maintenance Mode is enabled in I-Config[CFG_START_UP]...");
+    if (!(i_config_cfg_startup & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        fprintf(stderr,
+                "\nMaintenance Mode is not enabled in I-Config -> FW Update cannot be performed.\n");
+        return LT_FAIL;
+    }
+    printf("OK\n");
+
+    // Read R-Config and check if Maintenance Mode is enabled.
+    // The whole R-Config is read in case we need to modify it, as it has to be completely erased
+    // before writing again.
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Read R-Config (acts as a backup):\n");
+    for (int i = 0; i < LT_CONFIG_OBJ_CNT; i++) {
+        printf("    - %s= 0x%08" PRIx32 "\n", cfg_desc_table[i].desc, r_config.obj[i]);
+    }
+
+    printf("  - Checking if Maintenance Mode is enabled in R-Config[CFG_START_UP]...");
+    if (!(r_config.obj[TR01_CFG_START_UP_IDX] & BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK)) {
+        printf("Disabled, will enable it\n");
+        printf("    - Erasing R-Config...");
+        ret = lt_r_config_erase(lt_handle);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+            return ret;
+        }
+        printf("OK\n");
+
+        r_config.obj[TR01_CFG_START_UP_IDX] |= BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+        printf("    - Writing modified R-Config...");
+        ret = lt_write_whole_R_config(lt_handle, &r_config);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config is left in an erased state - the state before erasing is "
+                    "printed above.\n");
+            return ret;
+        }
+        printf("OK\n");
+        g_mtnc_mode_was_enabled = true;
+
+        printf("    - Rebooting TROPIC01 to apply R-Config changes...");
+        ret = lt_reboot(lt_handle, TR01_REBOOT);
+        if (ret != LT_OK) {
+            fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+            fprintf(stderr,
+                    "WARNING: R-Config (with Maintenance Mode enabled) was written but not applied "
+                    "yet. It will be applied on next TROPIC01 reboot/power-cycle.\n");
+            return ret;
+        }
+        printf("OK\n");
+    }
+    else {
+        printf("OK\n");
+    }
+
+    return LT_OK;
+}
+
+/**
+ * @brief  Disables Maintenance Mode.
+ * @param  lt_handle_t Device handle
+ * @retval LT_OK on success
+ */
+lt_ret_t disable_maintenance_mode(lt_handle_t *lt_handle)
+{
+    lt_ret_t ret;
+
+    printf("\nDisabling Maintenance Mode in R-Config (reduces the attack surface):\n");
+
+    printf("  - Starting Secure Session with key slot %d...", (int)TR01_PAIRING_KEY_SLOT_INDEX_0);
+    // Keys are chosen based on the CMake option LT_SH0_KEYS.
+    ret = lt_verify_chip_and_start_secure_session(lt_handle, LT_EX_SH0_PRIV, LT_EX_SH0_PUB,
+                                                  TR01_PAIRING_KEY_SLOT_INDEX_0);
+    if (LT_OK != ret) {
+        fprintf(stderr, "\nFailed to start Secure Session with key %d, ret=%s\n",
+                (int)TR01_PAIRING_KEY_SLOT_INDEX_0, lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    lt_config_t r_config;
+    printf("  - Reading R-Config...");
+    ret = lt_read_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to read R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Erasing R-Config...");
+    ret = lt_r_config_erase(lt_handle);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to erase R-Config, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Disabling Maintenance Mode in R-Config...");
+    r_config.obj[TR01_CFG_START_UP_IDX] &= ~BOOTLOADER_CO_CFG_START_UP_MAINTENANCE_ENA_MASK;
+    ret = lt_write_whole_R_config(lt_handle, &r_config);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nFailed to write R-Config, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config is left in an erased state - the state before erasing is printed "
+                "above.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Rebooting TROPIC01 to apply R-Config changes...");
+    ret = lt_reboot(lt_handle, TR01_REBOOT);
+    if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        fprintf(stderr,
+                "WARNING: R-Config (with Maintenance Mode disabled) was written but not applied yet. "
+                "It will be applied on next TROPIC01 reboot/power-cycle.\n");
+        return ret;
+    }
+    printf("OK\n");
+
+    printf("  - Verifying that Maintenance Mode is not accessible...");
+    ret = lt_reboot(lt_handle, TR01_MAINTENANCE_REBOOT);
+    if (ret == LT_L2_RESP_DISABLED) {
+        printf("OK\n");
+    }
+    else if (ret != LT_OK) {
+        fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+    else {
+        fprintf(stderr, "\nMaintenance reboot succeeded! ret=%s\n", lt_ret_verbose(ret));
+        return ret;
+    }
+
+    return LT_OK;
 }
 
 /**
@@ -336,6 +522,15 @@ int main(void)
     printf("  - RISC-V FW version: %d.%d.%d\n", fw_CPU_ver[3], fw_CPU_ver[2], fw_CPU_ver[1]);
     printf("  - SPECT FW version: %d.%d.%d\n", fw_SPECT_ver[3], fw_SPECT_ver[2], fw_SPECT_ver[1]);
 
+#if LT_DISABLE_MAINTENANCE_MODE
+    // We need to make sure we can reboot into Maintenance Mode to perform the FW update.
+    if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#endif
+
     printf("\nUpdating TROPIC01 firmware...");
     // This helper function implements the recommended FW update process.
     ret = lt_do_mutable_fw_update(&lt_handle, fw_CPU, sizeof(fw_CPU), fw_SPECT, sizeof(fw_SPECT));
@@ -343,6 +538,12 @@ int main(void)
         fprintf(stderr, "\nlt_do_mutable_fw_update() failed, ret=%s\n", lt_ret_verbose(ret));
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
+#if LT_DISABLE_MAINTENANCE_MODE
+        if (g_mtnc_mode_was_enabled) {
+            fprintf(stderr,
+                    "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
+        }
+#endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
         return -1;
@@ -355,7 +556,23 @@ int main(void)
         return -1;
     }
 
-    printf("Deinitializing handle...");
+#if LT_DISABLE_MAINTENANCE_MODE
+    // Warning: User shall disable Maintenance Mode only after both FW banks are updated with the
+    // latest FW. If only one bank is updated (while the second one contains invalid FW), and
+    // Maintenance Mode is disabled, the probability of bricking TROPIC01 increases. In this case, if
+    // lt_do_mutable_fw_update() succeeds, it is safe to disable Maintenance Mode.
+    if (LT_OK != disable_maintenance_mode(&lt_handle)) {
+        lt_deinit(&lt_handle);
+        mbedtls_psa_crypto_free();
+        return -1;
+    }
+#else
+    printf(
+        "\nWARNING: We strongly recommend disabling Maintenance Mode in R-Config to reduce the attack "
+        "surface.\n");
+#endif
+
+    printf("\nDeinitializing handle...");
     ret = lt_deinit(&lt_handle);
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -69,7 +69,7 @@
 /* Private variables ---------------------------------------------------------*/
 
 /* Tracks whether the Maintenance Mode had to be enabled before starting the FW update. */
-bool g_mtnc_mode_was_enabled = false;
+bool g_maintenance_mode_was_enabled = false;
 
 /* Private function prototypes -----------------------------------------------*/
 #ifdef __GNUC__
@@ -258,7 +258,7 @@ lt_ret_t check_and_enable_maintenance_mode(lt_handle_t *lt_handle)
             return ret;
         }
         printf("OK\n");
-        g_mtnc_mode_was_enabled = true;
+        g_maintenance_mode_was_enabled = true;
 
         printf("    - Rebooting TROPIC01 to apply R-Config changes...");
         ret = lt_reboot(lt_handle, TR01_REBOOT);
@@ -539,7 +539,7 @@ int main(void)
         fprintf(stderr,
                 "Tip: turn logging on to see more information (compile with -DLT_LOG_LVL=Info)\n");
 #if LT_DISABLE_MAINTENANCE_MODE
-        if (g_mtnc_mode_was_enabled) {
+        if (g_maintenance_mode_was_enabled) {
             fprintf(stderr,
                     "WARNING: Due to the error, Maintenance Mode was kept enabled in R-Config!\n");
         }


### PR DESCRIPTION
## Description

This PR adds the recommended Maintenance Mode handling to FW update examples:
- Maintenance Mode is enabled before the FW update process and disabled after the FW is successfuly updated.
- Maintenance Mode handling can be disabled using the `LT_DISABLE_MAINTENANCE_MODE` CMake variable - during the CMake build process, warning is logged and in runtime, after the FW is updated, another warning is logged.
- Documentation was updated to mention Maintenance Mode handling.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [x] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---