### PR TITLE
ETR01SDK-626: Check length in `lt_l2_frame_check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Target version reporting in Firmware Update examples for Linux.
 - Compatibility table in main README.md: mention support of Bootloader FW 1.0.1-2.0.1 for all existing Libtropic releases.
 - `lt_print_chip_id()`: Silicon revision field in CHIP_ID v0.0.0.1 is not interpreted as ASCII chars, as this version does not include silicon revision.
+- Added a check of `RSP_LEN` field value to `lt_l2_frame_check`.
 
 ## [3.2.1]
 

--- a/src/lt_l2_frame_check.c
+++ b/src/lt_l2_frame_check.c
@@ -18,16 +18,24 @@ lt_ret_t lt_l2_frame_check(const uint8_t *frame)
         return LT_PARAM_ERR;
     }
 #endif
-    // Take status, len and crc values from incomming frame
-    uint8_t status = frame[1];
-    uint8_t len = frame[2];
-    uint16_t frame_crc = frame[len + 4] | frame[len + 3] << 8;
+
+    // Extract STATUS, RSP_LEN and RSP_CRC fields. Verify that RSP_LEN is in bounds.
+    uint8_t status = frame[TR01_L2_STATUS_OFFSET];
+    uint8_t len = frame[TR01_L2_RSP_LEN_OFFSET];
+
+    if (len > TR01_L2_CHUNK_MAX_DATA_SIZE) {
+        return LT_L2_RSP_LEN_ERROR;
+    }
+
+    uint16_t frame_crc = frame[len + TR01_L2_RSP_DATA_RSP_CRC_OFFSET + 1] |
+                         frame[len + TR01_L2_RSP_DATA_RSP_CRC_OFFSET] << 8;
 
     switch (status) {
-        // Valid frames, or crc errors in INCOMMING frames are handled here:
+        // Valid frames, or CRC errors in incoming frames are handled here:
         case TR01_L2_STATUS_REQUEST_OK:
         case TR01_L2_STATUS_RESULT_OK:
-            if (frame_crc != crc16(frame + 1, len + 2)) {
+            if (frame_crc != crc16(frame + TR01_L2_STATUS_OFFSET,
+                                   TR01_L2_STATUS_SIZE + TR01_L2_REQ_RSP_LEN_SIZE + len)) {
                 return LT_L2_IN_CRC_ERR;
             }
             return LT_OK;


### PR DESCRIPTION
## Description

In this PR, I add a missing length check of the L2 Response frame in `lt_l2_frame_check`. Additionally, I refactored the code to use constants from `libtropic_common.h`, instead of literals.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage