### PR TITLE
Fix: validate_fw_ver_in_bank is unused if ABAB is used

### DIFF
--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -2006,6 +2006,7 @@ static lt_ret_t update_mutable_fw_bank(lt_handle_t *h, const uint8_t *fw_data,
 #define _LT_DO_MUTABLE_FW_UPDATE_FW_VER_ARG(v) \
     (((v) >> 24) & 0xFF), (((v) >> 16) & 0xFF), (((v) >> 8) & 0xFF), ((v) & 0xFF)
 
+#if !defined(LT_SILICON_REV_ABAB)
 /**
  * @brief Reads out firmware header from the given firmware bank and validates the firmware version
  * against the expected one.
@@ -2051,6 +2052,7 @@ static lt_ret_t validate_fw_ver_in_bank(lt_handle_t *h, const uint32_t expected_
 
     return LT_OK;
 }
+#endif
 
 lt_ret_t lt_do_mutable_fw_update(lt_handle_t *h, const uint8_t *cpu_fw_data,
                                  const size_t cpu_fw_data_size, const uint8_t *spect_fw_data,


### PR DESCRIPTION
## Description

`validate_fw_ver_in_bank()` is used only with ACAB and newer revisions, so we now define this function only if `LT_SILICON_REV_ABAB` is not defined.

Ran FW update example with ABAB and ACAB and built tests for ABAB.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---