### PR TITLE
ETR01SDK-587: Document alarm mode behavior

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,18 @@ Normally, this means that the chip is busy processing an operation and is unable
 The reason is that we detect the status of the TROPIC01 using a single flag; if all data are zero, we cannot distinguish between the TROPIC01 being truly busy and the host receiving only zeroes.
 
 ### `LT_L1_CHIP_ALARM_MODE`
-Normally, this means the TROPIC01 entered Alarm Mode. However, it can also mean — similarly to `LT_L1_CHIP_BUSY` — that all ones are received on `MISO`. Check your connections.
+Normally, this means the TROPIC01 has entered the Alarm Mode. The alarm can be caused by a variety of factors:
+
+- sensors detected an attack,
+- TROPIC01 is operating outside of the standard range (voltage, temperature...),
+- incorrect or corrupted firmware update data used,
+- hardware failure,
+- and more.
+
+Refer to the TROPIC01 Datasheet for more information about the Alarm Mode.
+
+However, `LT_L1_CHIP_ALARM_MODE` can be also returned if all bits received on `MISO` are '1'. This happens due to how the Alarm Mode flag is defined, similarly to `LT_L1_CHIP_BUSY`. In that case,
+check connections between the host and TROPIC01.
 
 ### `LT_L2_HSK_ERR`
 This error is caused by a problem during Secure Session establishment. See [I cannot establish a Secure Session](#i-cannot-establish-a-secure-session).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,7 +29,7 @@ Normally, this means the TROPIC01 has entered the Alarm Mode. The alarm can be c
 
 - sensors detected an attack,
 - TROPIC01 is operating outside of the standard range (voltage, temperature...),
-- incorrect or corrupted firmware update data used,
+- incorrect or corrupted firmware update data was used,
 - hardware failure,
 - and more.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,7 +35,7 @@ Normally, this means the TROPIC01 has entered the Alarm Mode. The alarm can be c
 
 Refer to the TROPIC01 Datasheet for more information about the Alarm Mode.
 
-However, `LT_L1_CHIP_ALARM_MODE` can be also returned if all bits received on `MISO` are `1` (`0xFF`...). This happens due to how the Alarm Mode flag is defined, similarly to `LT_L1_CHIP_BUSY`. In that case, check connections between the host and TROPIC01.
+However, `LT_L1_CHIP_ALARM_MODE` can also be returned if all bits received on `MISO` are `1` (`0xFF`...). This happens due to how the Alarm Mode flag is defined, similarly to `LT_L1_CHIP_BUSY`. In that case, check connections between the host and TROPIC01.
 
 ### `LT_L2_HSK_ERR`
 This error is caused by a problem during Secure Session establishment. See [I cannot establish a Secure Session](#i-cannot-establish-a-secure-session).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,8 +35,7 @@ Normally, this means the TROPIC01 has entered the Alarm Mode. The alarm can be c
 
 Refer to the TROPIC01 Datasheet for more information about the Alarm Mode.
 
-However, `LT_L1_CHIP_ALARM_MODE` can be also returned if all bits received on `MISO` are '1'. This happens due to how the Alarm Mode flag is defined, similarly to `LT_L1_CHIP_BUSY`. In that case,
-check connections between the host and TROPIC01.
+However, `LT_L1_CHIP_ALARM_MODE` can be also returned if all bits received on `MISO` are `1` (`0xFF`...). This happens due to how the Alarm Mode flag is defined, similarly to `LT_L1_CHIP_BUSY`. In that case, check connections between the host and TROPIC01.
 
 ### `LT_L2_HSK_ERR`
 This error is caused by a problem during Secure Session establishment. See [I cannot establish a Secure Session](#i-cannot-establish-a-secure-session).


### PR DESCRIPTION
## Description

Based on the internal discussion, I extended the FAQ entry with more information about the alarm mode.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage