### PR TITLE
ETR01SDK-604: Model server not working with Python3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lt_do_mutable_fw_update()`: changed parameters, reworked to do the recommended FW update procedure.
 - Updated all FW update examples to use the reworked `lt_do_mutable_fw_update()` helper function.
 - `lt_get_info_cert_store()`: X.509 Certificate Store can be read only in Application Mode.
+- [TROPIC01 Model installation script](scripts/tropic01_model/install_linux.sh) now downloads ts-tvl version 2.4, which fixes compatibility with Python 3.14.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/scripts/tropic01_model/install_linux.sh
+++ b/scripts/tropic01_model/install_linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-URL="https://github.com/tropicsquare/ts-tvl/releases/download/2.3/tvl-2.3-py3-none-any.whl"
+URL="https://github.com/tropicsquare/ts-tvl/releases/download/2.4/tvl-2.4-py3-none-any.whl"
 
 # Resolve script directory and venv path
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/tropic01_model/install_linux.sh
+++ b/scripts/tropic01_model/install_linux.sh
@@ -24,6 +24,11 @@ if ! command -v sha256sum >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! command -v awk >/dev/null 2>&1; then
+    echo "Error: awk is not installed. Please install and retry." >&2
+    exit 1
+fi
+
 echo "Selecting Python interpreter (prefer python3.8)..."
 if command -v python3.8 >/dev/null 2>&1; then
     PYTHON=python3.8

--- a/scripts/tropic01_model/install_linux.sh
+++ b/scripts/tropic01_model/install_linux.sh
@@ -19,6 +19,11 @@ else
     exit 1
 fi
 
+if ! command -v sha256sum >/dev/null 2>&1; then
+    echo "Error: sha256sum is not installed. Please install and retry." >&2
+    exit 1
+fi
+
 echo "Selecting Python interpreter (prefer python3.8)..."
 if command -v python3.8 >/dev/null 2>&1; then
     PYTHON=python3.8

--- a/scripts/tropic01_model/install_linux.sh
+++ b/scripts/tropic01_model/install_linux.sh
@@ -65,6 +65,14 @@ else
     wget -O "$TMP_WHEEL" "$URL"
 fi
 
+echo "Verifying wheel checksum..."
+EXPECTED_CHECKSUM="aaceecc3cdf408b94784ae6b5229bedda974d74530267ad25e0e0a61ad2e526c"
+ACTUAL_CHECKSUM=$(sha256sum "$TMP_WHEEL" | awk '{print $1}')
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
+  echo "Checksum mismatch: expected $EXPECTED_CHECKSUM, got $ACTUAL_CHECKSUM" >&2
+  exit 1
+fi
+
 echo "Installing wheel into virtualenv..."
 pip install "$TMP_WHEEL"
 


### PR DESCRIPTION
## Description

I just changed the URL to point to the new ts-tvl release 2.4, which fixed the incompatibility with Python 3.14. It's up to a discussion if this fix is enough or we, for example, want to emit a warning in the script if Python >=3.15 is used (future-proofing)?

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage
