### PR TITLE
Fix failing tests due to lt_get_info_cert_store behavior change

### DIFF
--- a/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
+++ b/tests/functional/src/lt_test_rev_get_info_req_bootloader.c
@@ -167,7 +167,7 @@ void lt_test_rev_get_info_req_bootloader(lt_handle_t *h)
     lt_test_cleanup_function = &lt_test_rev_get_info_req_bootloader_cleanup;
 
     LT_LOG_INFO("Reading X509 Certificate Store (should fail)...");
-    LT_TEST_ASSERT(LT_FAIL, lt_get_info_cert_store(h, &store));
+    LT_TEST_ASSERT(LT_L1_CHIP_STARTUP_MODE, lt_get_info_cert_store(h, &store));
 
     LT_LOG_INFO("Reading Chip ID...");
     LT_TEST_ASSERT(LT_OK, lt_get_info_chip_id(h, &chip_id));

--- a/tests/functional/src/lt_test_rev_startup_req.c
+++ b/tests/functional/src/lt_test_rev_startup_req.c
@@ -114,15 +114,20 @@ void lt_test_rev_startup_req(lt_handle_t *h)
         LT_LOG_INFO("Checking the chip is in the maintenance mode...");
         LT_TEST_ASSERT(MAINTENANCE_MODE, check_current_state());
         LT_LOG_INFO("Checking that the handshake does not work...");
+        // We don't call lt_verify_chip_and_start_secure_session(), because it calls
+        // lt_get_info_cert_store() to get STpub from the X.509 certificate. But the X.509 certificate
+        // cannot be read in Maintenance Mode. So, to really test Handshake_Req L2 command does not
+        // work, we will call lt_session_start() directly with dummy STpub - TROPIC01 should indicate
+        // that the command is unknown before we even process the STpub.
+        uint8_t dummy_stpub[TR01_STPUB_LEN] = {0};
 #if defined(LT_SILICON_REV_ABAB)
-        LT_TEST_ASSERT(LT_L2_GEN_ERR,
-                       lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
-                                                               TR01_PAIRING_KEY_SLOT_INDEX_0));
+        LT_TEST_ASSERT(LT_L2_GEN_ERR, lt_session_start(h, dummy_stpub, TR01_PAIRING_KEY_SLOT_INDEX_0,
+                                                       LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB));
 
 #elif defined(LT_SILICON_REV_ACAB)
         LT_TEST_ASSERT(LT_L2_UNKNOWN_REQ,
-                       lt_verify_chip_and_start_secure_session(h, LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB,
-                                                               TR01_PAIRING_KEY_SLOT_INDEX_0));
+                       lt_session_start(h, dummy_stpub, TR01_PAIRING_KEY_SLOT_INDEX_0,
+                                        LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB));
 #else
 #error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
 #endif


### PR DESCRIPTION
## Description

This PR fixes tests that call `lt_get_info_cert_store()` in Maintenance Mode - there was a change in the behavior of the function.

Tested with both silicon revisions.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---