### PR TITLE
ETR01SDK-632: Incorrect type of ret in some functions

### DIFF
--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -153,7 +153,7 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
         return LT_PARAM_ERR;
     }
 
-    int ret = LT_FAIL;
+    lt_ret_t ret = LT_FAIL;
 
     // There is L3 payload in provided buffer (buff).
     // First check how much data are to be send and if it actually fits into that buffer,
@@ -283,7 +283,7 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
         return LT_PARAM_ERR;
     }
 
-    int ret = LT_FAIL;
+    lt_ret_t ret = LT_FAIL;
     // Setup a response pointer to L2 buffer, which is placed in handle
     struct lt_l2_encrypted_cmd_rsp_t *resp = (struct lt_l2_encrypted_cmd_rsp_t *)s2->buff;
 

--- a/src/lt_l3_process.c
+++ b/src/lt_l3_process.c
@@ -75,9 +75,9 @@ lt_ret_t lt_l3_encrypt_request(lt_l3_state_t *s3)
 
     // p_frame->data is both input plaintext and output ciphertext buffer,
     // it is large enough to hold both plaintext and ciphertext + tag.
-    int ret = lt_aesgcm_encrypt(s3->crypto_ctx, s3->encryption_IV, TR01_L3_IV_SIZE, (uint8_t *)"", 0,
-                                p_frame->data, p_frame->cmd_size, p_frame->data,
-                                p_frame->cmd_size + TR01_L3_TAG_SIZE);
+    lt_ret_t ret = lt_aesgcm_encrypt(s3->crypto_ctx, s3->encryption_IV, TR01_L3_IV_SIZE, (uint8_t *)"",
+                                     0, p_frame->data, p_frame->cmd_size, p_frame->data,
+                                     p_frame->cmd_size + TR01_L3_TAG_SIZE);
     if (ret != LT_OK) {
         lt_l3_invalidate_host_session_data(s3);
         return ret;


### PR DESCRIPTION
## Description


`int` was used for storing "Libtropic return values" (from `lt_ret_t` enum) in these functions: `lt_l2_recv_encrypted_res`, `lt_l2_send_encrypted_cmd`, `lt_l3_encrypt_request`. In this PR, I change it to `lt_ret_t`.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage