### PR TITLE
ETR01SDK-343: Make L1 retry count/delay configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Count of retries can be configured using `LT_CRC_ERR_RETRY_ATTEMPTS` parameter/macro. Default value is 3 retries.
   - See [`LT_CRC_ERR_RETRY_ATTEMPTS` section](https://tropicsquare.github.io/libtropic/latest/reference/integrating_libtropic/how_to_configure/#lt_crc_err_retry_attempts) in "How to Configure" page of the documentation to learn how the retry mechanism works.
 - FAQ section covering `LT_L2_CRC_ERR` and `LT_L2_IN_CRC_ERR`.
+- Possibility to configure `LT_L1_READ_MAX_TRIES` and `LT_L1_READ_RETRY_DELAY`.
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,14 +108,14 @@ if(NOT LT_CRC_ERR_RETRY_ATTEMPTS MATCHES "^(0|[1-9][0-9]*)$")
 endif()
 
 # Must be positive without leading zero.
-set(LT_L1_READ_MAX_TRIES "50" CACHE STRING "Max number of GET_INFO requests when chip is not answerin.")
+set(LT_L1_READ_MAX_TRIES "50" CACHE STRING "Max number of Get_Response requests when chip is not answering.")
 
 if(NOT LT_L1_READ_MAX_TRIES MATCHES "^([1-9][0-9]*)$")
     message(FATAL_ERROR "LT_L1_READ_MAX_TRIES must be a positive integer without leading zeros, got '${LT_L1_READ_MAX_TRIES}'")
 endif()
 
 # Must be positive without leading zero.
-set(LT_L1_READ_RETRY_DELAY "25" CACHE STRING "Number of ms to wait between each GET_RESP request.")
+set(LT_L1_READ_RETRY_DELAY "25" CACHE STRING "Time to wait in ms between each Get_Response request.")
 
 if(NOT LT_L1_READ_RETRY_DELAY MATCHES "^([1-9][0-9]*)$")
     message(FATAL_ERROR "LT_L1_READ_RETRY_DELAY must be a positive integer without leading zeros, got '${LT_L1_READ_RETRY_DELAY}'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,20 @@ if(NOT LT_CRC_ERR_RETRY_ATTEMPTS MATCHES "^(0|[1-9][0-9]*)$")
     message(FATAL_ERROR "LT_CRC_ERR_RETRY_ATTEMPTS must be a non-negative integer without leading zeros unless the value is exactly '0', got '${LT_CRC_ERR_RETRY_ATTEMPTS}'")
 endif()
 
+# Must be positive without leading zero.
+set(LT_L1_READ_MAX_TRIES "50" CACHE STRING "Max number of GET_INFO requests when chip is not answerin.")
+
+if(NOT LT_L1_READ_MAX_TRIES MATCHES "^([1-9][0-9]*)$")
+    message(FATAL_ERROR "LT_L1_READ_MAX_TRIES must be a positive integer without leading zeros, got '${LT_L1_READ_MAX_TRIES}'")
+endif()
+
+# Must be positive without leading zero.
+set(LT_L1_READ_RETRY_DELAY "25" CACHE STRING "Number of ms to wait between each GET_RESP request.")
+
+if(NOT LT_L1_READ_RETRY_DELAY MATCHES "^([1-9][0-9]*)$")
+    message(FATAL_ERROR "LT_L1_READ_RETRY_DELAY must be a positive integer without leading zeros, got '${LT_L1_READ_RETRY_DELAY}'")
+endif()
+
 # Check whether compiling standalone (e.g. as a library) or as a child project (= has parent scope)
 # and save result to HAS_PARENT_SCOPE.
 get_directory_property(HAS_PARENT_SCOPE PARENT_DIRECTORY)
@@ -295,3 +309,5 @@ if(LT_RETRIEVE_ALARM_LOG)
 endif()
 
 target_compile_definitions(tropic PUBLIC LT_CRC_ERR_RETRY_ATTEMPTS=${LT_CRC_ERR_RETRY_ATTEMPTS})
+target_compile_definitions(tropic PUBLIC LT_L1_READ_MAX_TRIES=${LT_L1_READ_MAX_TRIES})
+target_compile_definitions(tropic PUBLIC LT_L1_READ_RETRY_DELAY=${LT_L1_READ_RETRY_DELAY})

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -118,3 +118,25 @@ The counter scope is always one L2 frame operation:
         Even if two errors occur while transmitting the first chunk, the second chunk starts with a fresh retry counter.
 
 Set this parameter to zero to disable retries.
+
+### `LT_L1_READ_MAX_TRIES`
+- integer (positive)
+- default value: 50
+
+Sets how many times to try L1 transfer (if the chip is busy) before failing.
+
+See also [`LT_L1_READ_RETRY_DELAY`](#lt_l1_read_retry_delay).
+
+!!! tip "Tip: Use interrupt pin"
+    It is better to use interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.
+
+### `LT_L1_READ_RETRY_DELAY`
+- integer (positive)
+- default value: 25 (ms)
+
+Sets how long to wait in milliseconds before retrying L1 transfer (if the chip is busy).
+
+See also [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries).
+
+!!! tip "Tip: Use interrupt pin"
+    It is better to use interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -128,7 +128,7 @@ Sets how many times to try L1 transfer (if the chip is busy) before failing.
 See also [`LT_L1_READ_RETRY_DELAY`](#lt_l1_read_retry_delay).
 
 !!! tip "Tip: Use interrupt pin"
-    It is better to use interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.
+    It is better to use the interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.
 
 ### `LT_L1_READ_RETRY_DELAY`
 - integer (positive)
@@ -139,4 +139,4 @@ Sets how long to wait in milliseconds before retrying L1 transfer (if the chip i
 See also [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries).
 
 !!! tip "Tip: Use interrupt pin"
-    It is better to use interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.
+    It is better to use the interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.

--- a/src/lt_l1.h
+++ b/src/lt_l1.h
@@ -30,7 +30,7 @@ extern "C" {
 #define TR01_L1_CHIP_MODE_STARTUP_bit 0x04
 
 #ifndef LT_L1_READ_MAX_TRIES
-/** @brief Max number of GET_INFO requests when chip is not answering
+/** @brief Max number of Get_Response requests when chip is not answering.
  *
  * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
  * parameters.
@@ -39,7 +39,7 @@ extern "C" {
 #endif
 
 #ifndef LT_L1_READ_RETRY_DELAY
-/** @brief Number of ms to wait between each GET_RESP request
+/** @brief Time to wait in ms between each Get_Response request.
  *
  * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
  * parameters.

--- a/src/lt_l1.h
+++ b/src/lt_l1.h
@@ -29,10 +29,23 @@ extern "C" {
 /** This bit in CHIP_STATUS byte signalizes that chip is in STARTUP mode */
 #define TR01_L1_CHIP_MODE_STARTUP_bit 0x04
 
-/** Max number of GET_INFO requests when chip is not answering */
+#ifndef LT_L1_READ_MAX_TRIES
+/** @brief Max number of GET_INFO requests when chip is not answering
+ *
+ * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
+ * parameters.
+ */
 #define LT_L1_READ_MAX_TRIES 50
-/** Number of ms to wait between each GET_INFO request */
+#endif
+
+#ifndef LT_L1_READ_RETRY_DELAY
+/** @brief Number of ms to wait between each GET_RESP request
+ *
+ * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
+ * parameters.
+ */
 #define LT_L1_READ_RETRY_DELAY 25
+#endif
 
 /** Minimal timeout when waiting for activity on SPI bus */
 #define LT_L1_TIMEOUT_MS_MIN 5


### PR DESCRIPTION
## Description

In this PR, I made `LT_L1_READ_MAX_TRIES` and `LT_L1_READ_RETRY_DELAY` user-configurable.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage