### PR TITLE
ETR01SDK-633: Remove `SDK_INCS` if not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lt_print_chip_id()`: Silicon revision field in CHIP_ID v0.0.0.1 is not interpreted as ASCII chars, as this version does not include silicon revision.
 - Added a check of `RSP_LEN` field value to `lt_l2_frame_check`.
 
+### Removed
+- `SDK_INCS` variable from the main `CMakeLists.txt`.
+
 ## [3.2.1]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,6 @@ get_directory_property(HAS_PARENT_SCOPE PARENT_DIRECTORY)
 #   Collect files:                                                        #
 #                                                                         #
 #   SDK_SRCS:       source files                                          #
-#   SDK_INCS:       header files                                          #
 #   SDK_DIRS_PRIV:  private directories                                   #
 #   SDK_DIRS_PUB:   public directories                                    #
 #                                                                         #
@@ -147,21 +146,6 @@ set(SDK_SRCS ${SDK_SRCS}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/libtropic_secure_memzero.c
 )
 
-set(SDK_INCS ${SDK_INCS}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/libtropic_common.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/libtropic.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/libtropic_port.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/libtropic_l2.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/libtropic_l3.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/libtropic_secure_memzero.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lt_crc16.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lt_port_wrap.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lt_l1.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lt_l2_frame_check.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lt_l3_process.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lt_hkdf.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/lt_asn1_der.h
-)
 set(SDK_DIRS_PRIV ${SDK_DIRS_PRIV}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/
 )
@@ -183,16 +167,11 @@ else()
     message(FATAL_ERROR "Invalid silicon revision: '${LT_SILICON_REV}'\nAvailable silicon revisions: ${lt_silicon_rev_choices}")
 endif()
 
-set(SDK_INCS ${SDK_INCS}
-    ${CMAKE_CURRENT_SOURCE_DIR}/TROPIC01_fw_update_files/${BL_FOLDER}/fw_v_${LT_CPU_FW_UPDATE_DATA_VER}/fw_CPU.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/TROPIC01_fw_update_files/${BL_FOLDER}/fw_v_${LT_CPU_FW_UPDATE_DATA_VER}/fw_SPECT.h
-)
-
 set(SDK_DIRS_PUB ${SDK_DIRS_PUB}
     ${CMAKE_CURRENT_SOURCE_DIR}/TROPIC01_fw_update_files/${BL_FOLDER}/fw_v_${LT_CPU_FW_UPDATE_DATA_VER}/
 )
 
-add_library(tropic ${SDK_SRCS} ${SDK_INCS})
+add_library(tropic ${SDK_SRCS})
 
 target_include_directories(tropic PRIVATE ${SDK_DIRS_PRIV})
 target_include_directories(tropic PUBLIC ${SDK_DIRS_PUB})


### PR DESCRIPTION
## Description

This PR removes `SDK_INCS` variable from the root `CMakeLists.txt`, as it is redundant.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage