### PR TITLE
fix(lt_test_rev_startup_req): assert correct retval of lt_session_start

### DIFF
--- a/tests/functional/src/lt_test_rev_startup_req.c
+++ b/tests/functional/src/lt_test_rev_startup_req.c
@@ -120,17 +120,9 @@ void lt_test_rev_startup_req(lt_handle_t *h)
         // work, we will call lt_session_start() directly with dummy STpub - TROPIC01 should indicate
         // that the command is unknown before we even process the STpub.
         uint8_t dummy_stpub[TR01_STPUB_LEN] = {0};
-#if defined(LT_SILICON_REV_ABAB)
-        LT_TEST_ASSERT(LT_L2_GEN_ERR, lt_session_start(h, dummy_stpub, TR01_PAIRING_KEY_SLOT_INDEX_0,
-                                                       LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB));
-
-#elif defined(LT_SILICON_REV_ACAB)
         LT_TEST_ASSERT(LT_L2_UNKNOWN_REQ,
                        lt_session_start(h, dummy_stpub, TR01_PAIRING_KEY_SLOT_INDEX_0,
                                         LT_TEST_SH0_PRIV, LT_TEST_SH0_PUB));
-#else
-#error "Undefined silicon revision! One of the LT_SILICON_REV_* macros must be defined."
-#endif
     }
 
     // Part 3: Try to reboot from maintenance mode to app mode.


### PR DESCRIPTION
## Description

Return value of `Encrypted_Cmd_Req` L2 command (issued by `lt_session_start`) is the same for all silicon revisions.

Tested with ABAB and ACAB.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---