### PR TITLE
ETR01SDK-637: Docs: mention RPi Pico HAL is by community

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - See [`LT_CRC_ERR_RETRY_ATTEMPTS` section](https://tropicsquare.github.io/libtropic/latest/reference/integrating_libtropic/how_to_configure/#lt_crc_err_retry_attempts) in "How to Configure" page of the documentation to learn how the retry mechanism works.
 - FAQ section covering `LT_L2_CRC_ERR` and `LT_L2_IN_CRC_ERR`.
 - Possibility to configure `LT_L1_READ_MAX_TRIES` and `LT_L1_READ_RETRY_DELAY`.
+- Community HAL for Raspberry Pi Pico boards created by [Wuard](https://github.com/wuard) (see the documentation for more information).
 
 ### Fixed
 - Change the type of `slot` parameter from `uint8_t` to `lt_pkey_index_t` in `lt_pairing_key_write()`, `lt_pairing_key_read()`, `lt_pairing_key_invalidate()`, `lt_out__pairing_key_write()`, `lt_out__pairing_key_read()`, `lt_out__pairing_key_invalidate()`.

--- a/docs/compatibility/host_platforms/index.md
+++ b/docs/compatibility/host_platforms/index.md
@@ -6,6 +6,7 @@ These are the currently supported host platforms:
 - [Linux](linux.md)
 - [POSIX](posix.md)
 - [Arduino](arduino.md)
+- [Raspberry Pi Pico](rpi_pico.md)
 
 All HAL files can be found in the `libtropic/hal/` directory.
 

--- a/docs/compatibility/host_platforms/rpi_pico.md
+++ b/docs/compatibility/host_platforms/rpi_pico.md
@@ -1,0 +1,10 @@
+# Raspberry Pi Pico
+We provide a community HAL created by [Wuard](https://github.com/wuard), which utilizes the [Pico SDK](https://github.com/raspberrypi/pico-sdk). The currently supported boards are:
+
+- [Raspberry Pi Pico (RP2040 MCU)](https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html#pico1)
+- [Raspberry Pi Pico 2 (RP2350 MCU)](https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html#pico2)
+
+The HAL is available in the `libtropic/hal/rpi-pico/` directory.
+
+!!! warning "Disclaimer"
+    This is a community HAL, meaning that official support by Tropic Square for this HAL is not available at the moment. In other words, Tropic Square is not responsible for the proper functionality of the HAL and the process of fixing potentional issues may take longer compared to the officially supported HALs.

--- a/docs/compatibility/host_platforms/rpi_pico.md
+++ b/docs/compatibility/host_platforms/rpi_pico.md
@@ -7,4 +7,4 @@ We provide a community HAL created by [Wuard](https://github.com/wuard), which u
 The HAL is available in the `libtropic/hal/rpi-pico/` directory.
 
 !!! warning "Disclaimer"
-    This is a community HAL, meaning that official support by Tropic Square for this HAL is not available at the moment. In other words, Tropic Square is not responsible for the proper functionality of the HAL and the process of fixing potentional issues may take longer compared to the officially supported HALs.
+    This is a community HAL, meaning that official support by Tropic Square for this HAL is not available at the moment. In other words, Tropic Square is not responsible for the proper functionality of the HAL, and fixing potential issues may take longer than for officially supported HALs.

--- a/hal/rpi-pico/CMakeLists.txt
+++ b/hal/rpi-pico/CMakeLists.txt
@@ -12,4 +12,4 @@ set(LT_HAL_INC_DIRS
 set(LT_HAL_SRCS ${LT_HAL_SRCS} PARENT_SCOPE)
 set(LT_HAL_INC_DIRS ${LT_HAL_INC_DIRS} PARENT_SCOPE)
 
-message(STATUS "HAL for Raspberry Pi Pico added: ${LT_HAL_SRCS}")
+message(WARNING "This is a community HAL created by Wuard. Official support by Tropic Square for this HAL is not available at the moment.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
       - Linux: compatibility/host_platforms/linux.md
       - POSIX: compatibility/host_platforms/posix.md
       - Arduino: compatibility/host_platforms/arduino.md
+      - Raspberry Pi Pico: compatibility/host_platforms/rpi_pico.md
     - Cryptographic Functionality Providers:
       - compatibility/cfps/index.md
       - Trezor Crypto: compatibility/cfps/trezor_crypto.md


### PR DESCRIPTION

## Description

This PR adds a new documentation section for the RPi Pico HAL and mentions limited support by Tropic Square.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---