### PR TITLE
ETR01SDK-636: make `LT_L1_TIMEOUT_MS_DEFAULT` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `LT_FAIL` in HALs with `LT_HAL_ERROR`.
 - Enhanced logging: include errno (if set) in Linux/POSIX HALs, log error on invalid curve type in `lt_in__ecc_key_read`.
 - Return `LT_PARAM_ERR` in `lt_print_fw_header` on invalid firmware header size.
-- Replaced `LT_L1_TIMEOUT_MS_MIN`, `LT_L1_TIMEOUT_MS_DEFAULT`, `LT_L1_TIMEOUT_MS_MAX` with `LT_L1_SPI_TIMEOUT_MS` (timeout on SPI transfers) and `LT_L1_INT_TIMEOUT_MS` (timeout on waiting on interrupt from TROPIC01).
+- Replaced `LT_L1_TIMEOUT_MS_MIN`, `LT_L1_TIMEOUT_MS_DEFAULT`, `LT_L1_TIMEOUT_MS_MAX` with `LT_L1_SPI_TIMEOUT_MS` (timeout on SPI transfers) and `LT_L1_INT_TIMEOUT_MS` (timeout while waiting for an interrupt from TROPIC01).
   - Both constants are user-configurable. Provided values were tested on supported HALs.
   - Some HALs do not support timeouts, so they ignore those constants. Refer to the HAL source.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `LT_FAIL` in HALs with `LT_HAL_ERROR`.
 - Enhanced logging: include errno (if set) in Linux/POSIX HALs, log error on invalid curve type in `lt_in__ecc_key_read`.
 - Return `LT_PARAM_ERR` in `lt_print_fw_header` on invalid firmware header size.
-- Replaced `LT_L1_TIMEOUT_MS_MIN`, `LT_L1_TIMEOUT_MS_DEFAULT`, `LT_L1_TIMEOUT_MS_MAX` with `LT_L1_SPI_TIMEOUT_MS` (timeout of SPI operations) and `LT_L1_INT_TIMEOUT_MS` (timeout of waiting on interrupt from TROPIC01).
+- Replaced `LT_L1_TIMEOUT_MS_MIN`, `LT_L1_TIMEOUT_MS_DEFAULT`, `LT_L1_TIMEOUT_MS_MAX` with `LT_L1_SPI_TIMEOUT_MS` (timeout on SPI transfers) and `LT_L1_INT_TIMEOUT_MS` (timeout on waiting on interrupt from TROPIC01).
   - Both constants are user-configurable. Provided values were tested on supported HALs.
   - Some HALs do not support timeouts, so they ignore those constants. Refer to the HAL source.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `LT_FAIL` in HALs with `LT_HAL_ERROR`.
 - Enhanced logging: include errno (if set) in Linux/POSIX HALs, log error on invalid curve type in `lt_in__ecc_key_read`.
 - Return `LT_PARAM_ERR` in `lt_print_fw_header` on invalid firmware header size.
+- Replaced `LT_L1_TIMEOUT_MS_MIN`, `LT_L1_TIMEOUT_MS_DEFAULT`, `LT_L1_TIMEOUT_MS_MAX` with `LT_L1_SPI_TIMEOUT_MS` (timeout of SPI operations) and `LT_L1_INT_TIMEOUT_MS` (timeout of waiting on interrupt from TROPIC01).
+  - Both constants are user-configurable. Provided values were tested on supported HALs.
+  - Some HALs do not support timeouts, so they ignore those constants. Refer to the HAL source.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,12 +129,12 @@ if(NOT LT_L1_SPI_TIMEOUT_MS MATCHES "^(0|[1-9][0-9]*)$")
     message(FATAL_ERROR "LT_L1_SPI_TIMEOUT_MS must be a non-negative integer without leading zeros unless the value is exactly '0', got '${LT_L1_SPI_TIMEOUT_MS}'")
 endif()
 
-# Must be non-negative without leading zero.
+# Must be positive without leading zero.
 # Check HAL of your platform for supported range and behavior.
-set(LT_L1_INT_TIMEOUT_MS "150" CACHE STRING "Timeout when waiting for interrupt from TROPIC01's GPO pin.")
+set(LT_L1_INT_TIMEOUT_MS "200" CACHE STRING "Timeout when waiting for interrupt from TROPIC01's GPO pin.")
 
-if(NOT LT_L1_INT_TIMEOUT_MS MATCHES "^(0|[1-9][0-9]*)$")
-    message(FATAL_ERROR "LT_L1_INT_TIMEOUT_MS must be a non-negative integer without leading zeros unless the value is exactly '0', got '${LT_L1_INT_TIMEOUT_MS}'")
+if(NOT LT_L1_INT_TIMEOUT_MS MATCHES "^([1-9][0-9]*)$")
+    message(FATAL_ERROR "LT_L1_INT_TIMEOUT_MS must be a positive integer without leading zeros, got '${LT_L1_INT_TIMEOUT_MS}'")
 endif()
 
 # Check whether compiling standalone (e.g. as a library) or as a child project (= has parent scope)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if(NOT LT_L1_READ_RETRY_DELAY MATCHES "^([1-9][0-9]*)$")
 endif()
 
 # Must be non-negative without leading zero.
-# Check HAL of your platform for supported range.
+# Check HAL of your platform for supported range and behavior.
 set(LT_L1_SPI_TIMEOUT_MS "70" CACHE STRING "Timeout when waiting for activity on SPI bus.")
 
 if(NOT LT_L1_SPI_TIMEOUT_MS MATCHES "^(0|[1-9][0-9]*)$")
@@ -130,7 +130,7 @@ if(NOT LT_L1_SPI_TIMEOUT_MS MATCHES "^(0|[1-9][0-9]*)$")
 endif()
 
 # Must be non-negative without leading zero.
-# Check HAL of your platform for supported range.
+# Check HAL of your platform for supported range and behavior.
 set(LT_L1_INT_TIMEOUT_MS "150" CACHE STRING "Timeout when waiting for interrupt from TROPIC01's GPO pin.")
 
 if(NOT LT_L1_INT_TIMEOUT_MS MATCHES "^(0|[1-9][0-9]*)$")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,22 @@ if(NOT LT_L1_READ_RETRY_DELAY MATCHES "^([1-9][0-9]*)$")
     message(FATAL_ERROR "LT_L1_READ_RETRY_DELAY must be a positive integer without leading zeros, got '${LT_L1_READ_RETRY_DELAY}'")
 endif()
 
+# Must be non-negative without leading zero.
+# Check HAL of your platform for supported range.
+set(LT_L1_SPI_TIMEOUT_MS "70" CACHE STRING "Timeout when waiting for activity on SPI bus.")
+
+if(NOT LT_L1_SPI_TIMEOUT_MS MATCHES "^(0|[1-9][0-9]*)$")
+    message(FATAL_ERROR "LT_L1_SPI_TIMEOUT_MS must be a non-negative integer without leading zeros unless the value is exactly '0', got '${LT_L1_SPI_TIMEOUT_MS}'")
+endif()
+
+# Must be non-negative without leading zero.
+# Check HAL of your platform for supported range.
+set(LT_L1_INT_TIMEOUT_MS "150" CACHE STRING "Timeout when waiting for interrupt from TROPIC01's GPO pin.")
+
+if(NOT LT_L1_INT_TIMEOUT_MS MATCHES "^(0|[1-9][0-9]*)$")
+    message(FATAL_ERROR "LT_L1_INT_TIMEOUT_MS must be a non-negative integer without leading zeros unless the value is exactly '0', got '${LT_L1_INT_TIMEOUT_MS}'")
+endif()
+
 # Check whether compiling standalone (e.g. as a library) or as a child project (= has parent scope)
 # and save result to HAS_PARENT_SCOPE.
 get_directory_property(HAS_PARENT_SCOPE PARENT_DIRECTORY)
@@ -290,3 +306,5 @@ endif()
 target_compile_definitions(tropic PUBLIC LT_CRC_ERR_RETRY_ATTEMPTS=${LT_CRC_ERR_RETRY_ATTEMPTS})
 target_compile_definitions(tropic PUBLIC LT_L1_READ_MAX_TRIES=${LT_L1_READ_MAX_TRIES})
 target_compile_definitions(tropic PUBLIC LT_L1_READ_RETRY_DELAY=${LT_L1_READ_RETRY_DELAY})
+target_compile_definitions(tropic PUBLIC LT_L1_SPI_TIMEOUT_MS=${LT_L1_SPI_TIMEOUT_MS})
+target_compile_definitions(tropic PUBLIC LT_L1_INT_TIMEOUT_MS=${LT_L1_INT_TIMEOUT_MS})

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -140,3 +140,19 @@ See also [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries).
 
 !!! tip "Tip: Use interrupt pin"
     It is better to use the interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.
+
+### `LT_L1_SPI_TIMEOUT_MS`
+- integer (non-negative)
+- default value: 70 (ms)
+
+Sets timeout on SPI operations. Used only by certain HALs, refer to the source code of the HAL you use.
+
+The default value was tested with supported HALs. Lowering the value may lower response delays but could also increase a risk of communication errors.
+
+### `LT_L1_INT_TIMEOUT_MS`
+- integer (non-negative)
+- default value: 150 (ms)
+
+Sets maximum waiting time for interrupt from TROPIC01's GPO pin before retrying. Used only by certain HALs when [`LT_USE_INT_PIN`](#lt_use_int_pin) is enabled. Refer to the source code of the HAL you use.
+
+The default value was tested with supported HALs. Lowering the value may lower response delays but could also increase a risk of communication errors.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -145,12 +145,12 @@ See also [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries).
 - integer (non-negative)
 - default value: 70 (ms)
 
-Sets timeout on SPI operations. If the operation times out, it is retried up to [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries) times.
+Sets timeout on SPI transfer. If the transfer operation times out, `LT_L1_INT_TIMEOUT` is returned by Libtropic API functions.
 
 !!! info
     Used only by certain HALs, refer to the source code of the HAL you use.
 
-The default value was tested with supported HALs. Lowering the value may lower response delays but could also increase a risk of communication errors.
+The default value was tested with supported HALs and normally does not have to be changed. Lowering the value increases a risk of communication errors.
 
 !!! warning "Warning: value '0'"
     This parameter also accepts the value of zero, however, behavior is HAL-dependent. For example, in STM32 HAL the value of '0' disables polling and the function returns immediately. Check behavior of HAL you use carefully.
@@ -159,9 +159,9 @@ The default value was tested with supported HALs. Lowering the value may lower r
 - integer (positive)
 - default value: 200 (ms)
 
-Sets maximum waiting time for interrupt from TROPIC01's GPO pin. If the operation times out, `LT_L1_INT_TIMEOUT` is returned immediately (this is a **different** behavior than in the case of [`LT_L1_SPI_TIMEOUT_MS`](#lt_l1_spi_timeout_ms)).
+Sets maximum waiting time for interrupt from TROPIC01's GPO pin. If the operation times out, `LT_L1_INT_TIMEOUT` is returned by Libtropic API functions.
 
 !!! info
     Used only by certain HALs when [`LT_USE_INT_PIN`](#lt_use_int_pin) is enabled. Refer to the source code of the HAL you use.
 
-The default value was tested with supported HALs. It is recommended to keep this value equal or higher than the longest time a TROPIC01 operation can take. Refer to the [TROPIC01 Datasheet](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#documentation).
+The default value was tested with supported HALs and normally does not have to be changed. It is recommended to keep this value equal or higher than the longest time a TROPIC01 operation can take. Refer to the [TROPIC01 Datasheet](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#documentation).

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -145,7 +145,10 @@ See also [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries).
 - integer (non-negative)
 - default value: 70 (ms)
 
-Sets timeout on SPI operations. Used only by certain HALs, refer to the source code of the HAL you use.
+Sets timeout on SPI operations. If the operation times out, it is retried up to [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries) times.
+
+!!! info
+    Used only by certain HALs, refer to the source code of the HAL you use.
 
 The default value was tested with supported HALs. Lowering the value may lower response delays but could also increase a risk of communication errors.
 
@@ -153,12 +156,12 @@ The default value was tested with supported HALs. Lowering the value may lower r
     This parameter also accepts the value of zero, however, behavior is HAL-dependent. For example, in STM32 HAL the value of '0' disables polling and the function returns immediately. Check behavior of HAL you use carefully.
 
 ### `LT_L1_INT_TIMEOUT_MS`
-- integer (non-negative)
-- default value: 150 (ms)
+- integer (positive)
+- default value: 200 (ms)
 
-Sets maximum waiting time for interrupt from TROPIC01's GPO pin before retrying. Used only by certain HALs when [`LT_USE_INT_PIN`](#lt_use_int_pin) is enabled. Refer to the source code of the HAL you use.
+Sets maximum waiting time for interrupt from TROPIC01's GPO pin. If the operation times out, `LT_L1_INT_TIMEOUT` is returned immediately (this is a **different** behavior than in the case of [`LT_L1_SPI_TIMEOUT_MS`](#lt_l1_spi_timeout_ms)).
 
-The default value was tested with supported HALs.
+!!! info
+    Used only by certain HALs when [`LT_USE_INT_PIN`](#lt_use_int_pin) is enabled. Refer to the source code of the HAL you use.
 
-!!! warning "Warning: value '0'"
-    This parameter also accepts the value of zero, however, behavior is HAL-dependent. Check behavior of HAL you use carefully.
+The default value was tested with supported HALs. It is recommended to keep this value equal or higher than the longest time a TROPIC01 operation can take. Refer to the [TROPIC01 Datasheet](https://github.com/tropicsquare/tropic01?tab=readme-ov-file#documentation).

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -149,6 +149,9 @@ Sets timeout on SPI operations. Used only by certain HALs, refer to the source c
 
 The default value was tested with supported HALs. Lowering the value may lower response delays but could also increase a risk of communication errors.
 
+!!! warning "Warning: value '0'"
+    This parameter also accepts the value of zero, however, behavior is HAL-dependent. For example, in STM32 HAL the value of '0' disables polling and the function returns immediately. Check behavior of HAL you use carefully.
+
 ### `LT_L1_INT_TIMEOUT_MS`
 - integer (non-negative)
 - default value: 150 (ms)
@@ -156,3 +159,6 @@ The default value was tested with supported HALs. Lowering the value may lower r
 Sets maximum waiting time for interrupt from TROPIC01's GPO pin before retrying. Used only by certain HALs when [`LT_USE_INT_PIN`](#lt_use_int_pin) is enabled. Refer to the source code of the HAL you use.
 
 The default value was tested with supported HALs.
+
+!!! warning "Warning: value '0'"
+    This parameter also accepts the value of zero, however, behavior is HAL-dependent. Check behavior of HAL you use carefully.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -145,7 +145,7 @@ See also [`LT_L1_READ_MAX_TRIES`](#lt_l1_read_max_tries).
 - integer (non-negative)
 - default value: 70 (ms)
 
-Sets timeout on SPI transfer. If the transfer operation times out, `LT_L1_INT_TIMEOUT` is returned by Libtropic API functions.
+Sets timeout on SPI transfer. If the transfer operation times out, `LT_HAL_ERROR` is returned by Libtropic API functions.
 
 !!! info
     Used only by certain HALs, refer to the source code of the HAL you use.

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -155,4 +155,4 @@ The default value was tested with supported HALs. Lowering the value may lower r
 
 Sets maximum waiting time for interrupt from TROPIC01's GPO pin before retrying. Used only by certain HALs when [`LT_USE_INT_PIN`](#lt_use_int_pin) is enabled. Refer to the source code of the HAL you use.
 
-The default value was tested with supported HALs. Lowering the value may lower response delays but could also increase a risk of communication errors.
+The default value was tested with supported HALs.

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -145,14 +145,14 @@ lt_ret_t lt_get_tr01_mode(lt_handle_t *h, lt_tr01_mode_t *mode)
     do {
         h->l2.buff[0] = TR01_L1_GET_RESPONSE_REQ_ID;
 
-        ret = lt_l1_write(&h->l2, 1, LT_L1_TIMEOUT_MS_DEFAULT);
+        ret = lt_l1_write(&h->l2, 1, LT_L1_SPI_TIMEOUT_MS);
         if (ret != LT_OK) {
             return ret;
         }
 
         if (h->l2.buff[0] & TR01_L1_CHIP_MODE_ALARM_bit) {
 #ifdef LT_RETRIEVE_ALARM_LOG
-            lt_ret_t ret_unused = lt_l1_retrieve_alarm_log(&h->l2, LT_L1_TIMEOUT_MS_DEFAULT);
+            lt_ret_t ret_unused = lt_l1_retrieve_alarm_log(&h->l2, LT_L1_SPI_TIMEOUT_MS);
             LT_UNUSED(ret_unused);
 #endif
 

--- a/src/libtropic_l2.c
+++ b/src/libtropic_l2.c
@@ -35,7 +35,7 @@ lt_ret_t lt_l2_send(lt_l2_state_t *s2)
 
     uint8_t len = s2->buff[1];
 
-    return lt_l1_write(s2, len + 4, LT_L1_TIMEOUT_MS_DEFAULT);
+    return lt_l1_write(s2, len + 4, LT_L1_SPI_TIMEOUT_MS);
 }
 
 lt_ret_t lt_l2_resend_response(lt_l2_state_t *s2)
@@ -50,7 +50,7 @@ lt_ret_t lt_l2_resend_response(lt_l2_state_t *s2)
         return ret;
     }
 
-    ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_TIMEOUT_MS_DEFAULT);
+    ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_SPI_TIMEOUT_MS);
     if (ret != LT_OK) {
         return ret;
     }
@@ -64,7 +64,7 @@ lt_ret_t lt_l2_receive(lt_l2_state_t *s2)
         return LT_PARAM_ERR;
     }
 
-    lt_ret_t ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_TIMEOUT_MS_DEFAULT);
+    lt_ret_t ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_SPI_TIMEOUT_MS);
     if (ret != LT_OK) {
         return ret;
     }
@@ -212,13 +212,13 @@ lt_ret_t lt_l2_send_encrypted_cmd(lt_l2_state_t *s2, uint8_t *buff, uint16_t buf
         add_crc(req);
 
         // Send L2 request containing a chunk from L3 buff
-        ret = lt_l1_write(s2, 2 + req_len + 2, LT_L1_TIMEOUT_MS_DEFAULT);
+        ret = lt_l1_write(s2, 2 + req_len + 2, LT_L1_SPI_TIMEOUT_MS);
         if (ret != LT_OK) {
             return ret;
         }
 
         // Read a response on this L2 request
-        ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_TIMEOUT_MS_DEFAULT);
+        ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_SPI_TIMEOUT_MS);
         if (ret != LT_OK) {
             return ret;
         }
@@ -306,7 +306,7 @@ lt_ret_t lt_l2_recv_encrypted_res(lt_l2_state_t *s2, uint8_t *buff, uint16_t max
         // If previous frame was received OK, read a next frame. Otherwise, ask to resend
         // the previous frame.
         if (!resend_response) {
-            ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_TIMEOUT_MS_DEFAULT);
+            ret = lt_l1_read(s2, TR01_L1_LEN_MAX, LT_L1_SPI_TIMEOUT_MS);
             if (ret != LT_OK) {
                 return ret;
             }

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -46,9 +46,6 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
     if (!s2) {
         return LT_PARAM_ERR;
     }
-    if ((timeout_ms < LT_L1_TIMEOUT_MS_MIN) | (timeout_ms > LT_L1_TIMEOUT_MS_MAX)) {
-        return LT_PARAM_ERR;
-    }
     if ((max_len < TR01_L1_LEN_MIN) | (max_len > TR01_L1_LEN_MAX)) {
         return LT_PARAM_ERR;
     }
@@ -160,7 +157,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
 #if LT_USE_INT_PIN
                 // Wait for rising edge on the INT pin, which signalizes that L2 Response frame is
                 // ready to be received
-                ret = lt_l1_delay_on_int(s2, LT_L1_TIMEOUT_MS_MAX);
+                ret = lt_l1_delay_on_int(s2, LT_L1_INT_TIMEOUT_MS);
                 if (ret != LT_OK) {
                     return ret;
                 }
@@ -182,9 +179,6 @@ lt_ret_t lt_l1_write(lt_l2_state_t *s2, const uint16_t len, const uint32_t timeo
 {
 #ifdef LT_REDUNDANT_ARG_CHECK
     if (!s2) {
-        return LT_PARAM_ERR;
-    }
-    if ((timeout_ms < LT_L1_TIMEOUT_MS_MIN) | (timeout_ms > LT_L1_TIMEOUT_MS_MAX)) {
         return LT_PARAM_ERR;
     }
     if ((len < TR01_L1_LEN_MIN) | (len > TR01_L1_LEN_MAX)) {

--- a/src/lt_l1.h
+++ b/src/lt_l1.h
@@ -47,12 +47,23 @@ extern "C" {
 #define LT_L1_READ_RETRY_DELAY 25
 #endif
 
-/** Minimal timeout when waiting for activity on SPI bus */
-#define LT_L1_TIMEOUT_MS_MIN 5
-/** Default timeout when waiting for activity on SPI bus */
-#define LT_L1_TIMEOUT_MS_DEFAULT 70
-/** Maximal timeout when waiting for activity on SPI bus */
-#define LT_L1_TIMEOUT_MS_MAX 150
+#ifndef LT_L1_SPI_TIMEOUT_MS
+/** @brief Timeout when waiting for activity on SPI bus.
+ *
+ * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
+ * parameters.
+ */
+#define LT_L1_SPI_TIMEOUT_MS 70
+#endif
+
+#ifndef LT_L1_INT_TIMEOUT_MS
+/** @brief Timeout when waiting for interrupt from TROPIC01's GPO pin.
+ *
+ * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
+ * parameters.
+ */
+#define LT_L1_INT_TIMEOUT_MS 150
+#endif
 
 /** Get response request's ID */
 #define TR01_L1_GET_RESPONSE_REQ_ID 0xAA

--- a/src/lt_l1.h
+++ b/src/lt_l1.h
@@ -62,7 +62,7 @@ extern "C" {
  * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
  * parameters.
  */
-#define LT_L1_INT_TIMEOUT_MS 150
+#define LT_L1_INT_TIMEOUT_MS 200
 #endif
 
 /** Get response request's ID */


### PR DESCRIPTION
## Description

In this PR, I remove `LT_L1_TIMEOUT_MS_*` constants and add more specific ones:

- `LT_L1_SPI_TIMEOUT_MS`: timeout on SPI transfer operation
- `LT_L1_INT_TIMEOUT_MS`: timeout when waiting on interrupt from TROPIC01

Both are configurable from CMake and both are set to sane defaults. I also added mention of the new config options in the documentation.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage