### PR TITLE
ETR01SDK-630: Docs: refactor CMake options mentions in tutorials

### DIFF
--- a/docs/tutorials/esp32/fw_update.md
+++ b/docs/tutorials/esp32/fw_update.md
@@ -29,7 +29,7 @@
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 
 ## Configuration
-Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
 
@@ -46,7 +46,7 @@ Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_t
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/esp32/fw_update.md
+++ b/docs/tutorials/esp32/fw_update.md
@@ -14,7 +14,7 @@
         ```bash { .copy }
         idf.py build flash monitor
         ```
-        After this, you should see a colored output in your terminal.
+        After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
         !!! tip "Closing the ESP-IDF serial monitor"
             To close the ESP-IDF serial monitor, press <kbd>Ctrl</kbd> + <kbd>]</kbd>. Refer to the [ESP-IDF monitor documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-monitor.html) for a full list of available keyboard shortcuts.
@@ -24,41 +24,43 @@
 
     === ":fontawesome-brands-windows: Windows"
         TBA
-
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass any CMake option to `idf.py` as follows:
-        ```bash { .copy }
-        idf.py -DLT_SH0_KEYS="eng_sample" build flash monitor
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
-
-If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
-!!! example "Keeping Maintenance Mode enabled after FW update"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass any CMake option to `idf.py` as follows:
-        ```bash { .copy }
-        idf.py -DLT_DISABLE_MAINTENANCE_MODE=0 build flash monitor
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-    !!! warning "Not recommended"
-        This step is not recommended because it can increase the attack surface.
-
-!!! failure "FW update failed"
+    
+!!! question "What if firmware update failed?"
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
+
+## Configuration
+Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            idf.py -DLT_SH0_KEYS="eng_sample" build flash monitor
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+
+    ??? example "Keeping Maintenance Mode enabled after FW update"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            idf.py -DLT_DISABLE_MAINTENANCE_MODE=0 build flash monitor
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+        !!! warning "Not recommended"
+            This step is not recommended because it can increase the attack surface.
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/esp32/fw_update.md
+++ b/docs/tutorials/esp32/fw_update.md
@@ -29,9 +29,9 @@
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 
 ## Configuration
-Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"
@@ -46,7 +46,7 @@ Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) controls whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if Maintenance Mode is enabled in your TROPIC01 and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/esp32/hello_world.md
+++ b/docs/tutorials/esp32/hello_world.md
@@ -26,9 +26,9 @@
         TBA
 
 ## Configuration
-Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
+In addition to the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake option:
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/esp32/hello_world.md
+++ b/docs/tutorials/esp32/hello_world.md
@@ -26,7 +26,7 @@
         TBA
 
 ## Configuration
-Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
 
 - `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
 

--- a/docs/tutorials/esp32/hello_world.md
+++ b/docs/tutorials/esp32/hello_world.md
@@ -25,18 +25,20 @@
     === ":fontawesome-brands-windows: Windows"
         TBA
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass any CMake option to `idf.py` as follows:
-        ```bash { .copy }
-        idf.py -DLT_SH0_KEYS="eng_sample" build flash monitor
-        ```
+## Configuration
+Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
-    === ":fontawesome-brands-apple: macOS"
-        TBA
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
 
-    === ":fontawesome-brands-windows: Windows"
-        TBA
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            idf.py -DLT_SH0_KEYS="eng_sample" build flash monitor
+            ```
 
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.

--- a/docs/tutorials/linux/spi/full_chain_verification.md
+++ b/docs/tutorials/linux/spi/full_chain_verification.md
@@ -85,3 +85,38 @@ The script contains comments about each step, so refer to the code of the script
 
 !!! note "Alternative implementation of the verification"
     The script verifies the TROPIC01 certificates against certificate authority certificates downloaded from the Tropic Square PKI website. As the same certificates are present also in the TROPIC01 itself, those can be used instead. The importance of verifying the root certificate independently remains the key part of the process.
+
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
+
+    ??? example "Configuring SPI device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SPI_DEV_PATH=<spi_dev_path> ..
+            make
+            ./libtropic_dump_certificates
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+
+    ??? example "Configuring GPIO device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_GPIO_DEV_PATH=<gpio_dev_path> ..
+            make
+            ./libtropic_dump_certificates
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA

--- a/docs/tutorials/linux/spi/full_chain_verification.md
+++ b/docs/tutorials/linux/spi/full_chain_verification.md
@@ -87,7 +87,7 @@ The script contains comments about each step, so refer to the code of the script
     The script verifies the TROPIC01 certificates against certificate authority certificates downloaded from the Tropic Square PKI website. As the same certificates are present also in the TROPIC01 itself, those can be used instead. The importance of verifying the root certificate independently remains the key part of the process.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
 

--- a/docs/tutorials/linux/spi/full_chain_verification.md
+++ b/docs/tutorials/linux/spi/full_chain_verification.md
@@ -87,9 +87,9 @@ The script contains comments about each step, so refer to the code of the script
     The script verifies the TROPIC01 certificates against certificate authority certificates downloaded from the Tropic Square PKI website. As the same certificates are present also in the TROPIC01 itself, those can be used instead. The importance of verifying the root certificate independently remains the key part of the process.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) specifies the path to the SPI device to which the TROPIC01 is connected:
 
     ??? example "Configuring SPI device path"
         === ":fontawesome-brands-linux: Linux"
@@ -105,7 +105,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) specifies the path to the GPIO device to which TROPIC01's interrupt (INT) and Chip Select (CS) lines are connected:
 
     ??? example "Configuring GPIO device path"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/spi/fw_update.md
+++ b/docs/tutorials/linux/spi/fw_update.md
@@ -37,7 +37,7 @@
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
 
@@ -88,7 +88,7 @@ Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/ho
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/spi/fw_update.md
+++ b/docs/tutorials/linux/spi/fw_update.md
@@ -37,9 +37,9 @@
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) specifies the path to the SPI device to which the TROPIC01 is connected:
 
     ??? example "Configuring SPI device path"
         === ":fontawesome-brands-linux: Linux"
@@ -55,7 +55,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) specifies the path to the GPIO device to which TROPIC01's interrupt (INT) and Chip Select (CS) lines are connected:
 
     ??? example "Configuring GPIO device path"
         === ":fontawesome-brands-linux: Linux"
@@ -71,7 +71,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"
@@ -88,7 +88,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) controls whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if Maintenance Mode is enabled in your TROPIC01 and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/spi/fw_update.md
+++ b/docs/tutorials/linux/spi/fw_update.md
@@ -33,42 +33,78 @@
     
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_SH0_KEYS` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_SH0_KEYS="eng_sample" ..
-        make
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
-
-If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
-!!! example "Keeping Maintenance Mode enabled after FW update"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_DISABLE_MAINTENANCE_MODE` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
-        make
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-    !!! warning "Not recommended"
-        This step is not recommended because it can increase the attack surface.
-
-!!! failure "FW update failed"
+!!! question "What if firmware update failed?"
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
+
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
+
+    ??? example "Configuring SPI device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SPI_DEV_PATH=<spi_dev_path> ..
+            make
+            ./libtropic_fw_update
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+
+    ??? example "Configuring GPIO device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_GPIO_DEV_PATH=<gpio_dev_path> ..
+            make
+            ./libtropic_fw_update
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SH0_KEYS="eng_sample" ..
+            make
+            ./libtropic_fw_update
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+
+    ??? example "Keeping Maintenance Mode enabled after FW update"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
+            make
+            ./libtropic_fw_update
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+        !!! warning "Not recommended"
+            This step is not recommended because it can increase the attack surface.
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/linux/spi/hello_world.md
+++ b/docs/tutorials/linux/spi/hello_world.md
@@ -32,9 +32,9 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) specifies the path to the SPI device to which the TROPIC01 is connected:
 
     ??? example "Configuring SPI device path"
         === ":fontawesome-brands-linux: Linux"
@@ -50,7 +50,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) specifies the path to the GPIO device to which TROPIC01's interrupt (INT) and Chip Select (CS) lines are connected:
 
     ??? example "Configuring GPIO device path"
         === ":fontawesome-brands-linux: Linux"
@@ -66,7 +66,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/spi/hello_world.md
+++ b/docs/tutorials/linux/spi/hello_world.md
@@ -31,19 +31,56 @@
 
     After this, you should see an output in your terminal.
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_SH0_KEYS` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_SH0_KEYS="eng_sample" ..
-        make
-        ```
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
-    === ":fontawesome-brands-apple: macOS"
-        TBA
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
 
-    === ":fontawesome-brands-windows: Windows"
-        TBA
+    ??? example "Configuring SPI device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SPI_DEV_PATH=<spi_dev_path> ..
+            make
+            ./libtropic_hello_world
+            ```
 
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+
+    ??? example "Configuring GPIO device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_GPIO_DEV_PATH=<gpio_dev_path> ..
+            make
+            ./libtropic_hello_world
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SH0_KEYS="eng_sample" ..
+            make
+            ./libtropic_hello_world
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+
+[Next example :material-arrow-right:](full_chain_verification.md){ .md-button }

--- a/docs/tutorials/linux/spi/hello_world.md
+++ b/docs/tutorials/linux/spi/hello_world.md
@@ -32,7 +32,7 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
 

--- a/docs/tutorials/linux/spi/identify_chip.md
+++ b/docs/tutorials/linux/spi/identify_chip.md
@@ -32,9 +32,9 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) specifies the path to the SPI device to which the TROPIC01 is connected:
 
     ??? example "Configuring SPI device path"
         === ":fontawesome-brands-linux: Linux"
@@ -50,7 +50,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) specifies the path to the GPIO device to which TROPIC01's interrupt (INT) and Chip Select (CS) lines are connected:
 
     ??? example "Configuring GPIO device path"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/spi/identify_chip.md
+++ b/docs/tutorials/linux/spi/identify_chip.md
@@ -31,4 +31,39 @@
 
     After this, you should see an output in your terminal.
 
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
+
+    ??? example "Configuring SPI device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SPI_DEV_PATH=<spi_dev_path> ..
+            make
+            ./libtropic_identify_chip
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_GPIO_DEV_PATH` (default: `"/dev/gpiochip0"`) to set the path to the GPIO device where TROPIC01's interrupt (INT) and Chip Select (CS) line is connected:
+
+    ??? example "Configuring GPIO device path"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_GPIO_DEV_PATH=<gpio_dev_path> ..
+            make
+            ./libtropic_identify_chip
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
 [Next example :material-arrow-right:](fw_update.md){ .md-button }

--- a/docs/tutorials/linux/spi/identify_chip.md
+++ b/docs/tutorials/linux/spi/identify_chip.md
@@ -32,7 +32,7 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_SPI_DEV_PATH` (default: `"/dev/spidev0.0"`) to set the path to the SPI device where TROPIC01 is connected:
 

--- a/docs/tutorials/linux/usb_devkit/ecc_eddsa.md
+++ b/docs/tutorials/linux/usb_devkit/ecc_eddsa.md
@@ -1,4 +1,4 @@
-# 5. ECC Key Generation and EdDSA Signing Example Tutorial
+# 4. ECC Key Generation and EdDSA Signing Example Tutorial
 
 --8<-- "docs/common/examples_descriptions/ecc_eddsa.md"
 
@@ -34,19 +34,40 @@
 
     After this, you should see an output in your terminal.
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_SH0_KEYS` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_SH0_KEYS="eng_sample" ..
-        make
-        ```
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
-    === ":fontawesome-brands-apple: macOS"
-        TBA
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
 
-    === ":fontawesome-brands-windows: Windows"
-        TBA
+    ??? example "Configuring USB DevKit serial port"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_USB_DEVKIT_PATH=<serial_port_path> ..
+            make
+            ./libtropic_ecc_eddsa
+            ```
 
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SH0_KEYS="eng_sample" ..
+            make
+            ./libtropic_ecc_eddsa
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+
+[Next example :material-arrow-right:](full_chain_verification.md){ .md-button }

--- a/docs/tutorials/linux/usb_devkit/ecc_eddsa.md
+++ b/docs/tutorials/linux/usb_devkit/ecc_eddsa.md
@@ -35,7 +35,7 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
 

--- a/docs/tutorials/linux/usb_devkit/ecc_eddsa.md
+++ b/docs/tutorials/linux/usb_devkit/ecc_eddsa.md
@@ -35,9 +35,9 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) sets the path to the USB device representing the USB DevKit serial port:
 
     ??? example "Configuring USB DevKit serial port"
         === ":fontawesome-brands-linux: Linux"
@@ -53,7 +53,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/usb_devkit/full_chain_verification.md
+++ b/docs/tutorials/linux/usb_devkit/full_chain_verification.md
@@ -87,9 +87,9 @@ The script contains comments about each step, so refer to the code of the script
     The script verifies the TROPIC01 certificates against certificate authority certificates downloaded from the Tropic Square PKI website. As the same certificates are present also in the TROPIC01 itself, those can be used instead. The importance of verifying the root certificate independently remains the key part of the process.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake option:
 
-- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) sets the path to the USB device representing the USB DevKit serial port:
 
     ??? example "Configuring USB DevKit serial port"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/usb_devkit/full_chain_verification.md
+++ b/docs/tutorials/linux/usb_devkit/full_chain_verification.md
@@ -87,7 +87,7 @@ The script contains comments about each step, so refer to the code of the script
     The script verifies the TROPIC01 certificates against certificate authority certificates downloaded from the Tropic Square PKI website. As the same certificates are present also in the TROPIC01 itself, those can be used instead. The importance of verifying the root certificate independently remains the key part of the process.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
 
 - `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
 

--- a/docs/tutorials/linux/usb_devkit/full_chain_verification.md
+++ b/docs/tutorials/linux/usb_devkit/full_chain_verification.md
@@ -1,4 +1,4 @@
-# 4. Full Chain Verification Example Tutorial
+# 5. Full Chain Verification Example Tutorial
 
 In this tutorial, you will learn about one of the steps required to verify the authenticity of the TROPIC01 certificate chain — a process that should be done by Tropic Square customers during provisioning of their device which integrates TROPIC01.
 
@@ -85,3 +85,22 @@ The script contains comments about each step, so refer to the code of the script
 
 !!! note "Alternative implementation of the verification"
     The script verifies the TROPIC01 certificates against certificate authority certificates downloaded from the Tropic Square PKI website. As the same certificates are present also in the TROPIC01 itself, those can be used instead. The importance of verifying the root certificate independently remains the key part of the process.
+
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+
+    ??? example "Configuring USB DevKit serial port"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_USB_DEVKIT_PATH=<serial_port_path> ..
+            make
+            ./libtropic_dump_certificates
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA

--- a/docs/tutorials/linux/usb_devkit/fw_update.md
+++ b/docs/tutorials/linux/usb_devkit/fw_update.md
@@ -33,42 +33,62 @@
     
     After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_SH0_KEYS` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_SH0_KEYS="eng_sample" ..
-        make
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
-
-If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
-!!! example "Keeping Maintenance Mode enabled after FW update"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_DISABLE_MAINTENANCE_MODE` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
-        make
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-    !!! warning "Not recommended"
-        This step is not recommended because it can increase the attack surface.
-
-!!! failure "FW update failed"
+!!! question "What if firmware update failed?"
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
+
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+
+    ??? example "Configuring USB DevKit serial port"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_USB_DEVKIT_PATH=<serial_port_path> ..
+            make
+            ./libtropic_fw_update
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SH0_KEYS="eng_sample" ..
+            make
+            ./libtropic_fw_update
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+
+    ??? example "Keeping Maintenance Mode enabled after FW update"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
+            make
+            ./libtropic_fw_update
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+        !!! warning "Not recommended"
+            This step is not recommended because it can increase the attack surface.
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/linux/usb_devkit/fw_update.md
+++ b/docs/tutorials/linux/usb_devkit/fw_update.md
@@ -37,7 +37,7 @@
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
 
@@ -72,7 +72,7 @@ Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/ho
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/usb_devkit/fw_update.md
+++ b/docs/tutorials/linux/usb_devkit/fw_update.md
@@ -37,9 +37,9 @@
     Check out the dedicated section in [FAQ](../../../faq.md#fw-update-failed).
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) sets the path to the USB device representing the USB DevKit serial port:
 
     ??? example "Configuring USB DevKit serial port"
         === ":fontawesome-brands-linux: Linux"
@@ -55,7 +55,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"
@@ -72,7 +72,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) controls whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if Maintenance Mode is enabled in your TROPIC01 and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/usb_devkit/hello_world.md
+++ b/docs/tutorials/linux/usb_devkit/hello_world.md
@@ -32,7 +32,7 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
 

--- a/docs/tutorials/linux/usb_devkit/hello_world.md
+++ b/docs/tutorials/linux/usb_devkit/hello_world.md
@@ -32,9 +32,9 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) sets the path to the USB device representing the USB DevKit serial port:
 
     ??? example "Configuring USB DevKit serial port"
         === ":fontawesome-brands-linux: Linux"
@@ -50,7 +50,7 @@ Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/h
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/usb_devkit/hello_world.md
+++ b/docs/tutorials/linux/usb_devkit/hello_world.md
@@ -31,19 +31,40 @@
 
     After this, you should see an output in your terminal.
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_SH0_KEYS` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_SH0_KEYS="eng_sample" ..
-        make
-        ```
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
-    === ":fontawesome-brands-apple: macOS"
-        TBA
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
 
-    === ":fontawesome-brands-windows: Windows"
-        TBA
+    ??? example "Configuring USB DevKit serial port"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_USB_DEVKIT_PATH=<serial_port_path> ..
+            make
+            ./libtropic_hello_world
+            ```
 
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SH0_KEYS="eng_sample" ..
+            make
+            ./libtropic_hello_world
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../../reference/default_pairing_keys.md) for more information.
+
+[Next example :material-arrow-right:](ecc_eddsa.md){ .md-button }

--- a/docs/tutorials/linux/usb_devkit/identify_chip.md
+++ b/docs/tutorials/linux/usb_devkit/identify_chip.md
@@ -32,9 +32,9 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
+In addition to the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake option:
 
-- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) sets the path to the USB device representing the USB DevKit serial port:
 
     ??? example "Configuring USB DevKit serial port"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/linux/usb_devkit/identify_chip.md
+++ b/docs/tutorials/linux/usb_devkit/identify_chip.md
@@ -31,4 +31,23 @@
 
     After this, you should see an output in your terminal.
 
+## Configuration
+Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
+
+    ??? example "Configuring USB DevKit serial port"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_USB_DEVKIT_PATH=<serial_port_path> ..
+            make
+            ./libtropic_identify_chip
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
 [Next example :material-arrow-right:](fw_update.md){ .md-button }

--- a/docs/tutorials/linux/usb_devkit/identify_chip.md
+++ b/docs/tutorials/linux/usb_devkit/identify_chip.md
@@ -32,7 +32,7 @@
     After this, you should see an output in your terminal.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
 
 - `LT_USB_DEVKIT_PATH` (default: `"/dev/ttyACM0"`) to set the path to the USB device representing the USB DevKit serial port:
 

--- a/docs/tutorials/linux/usb_devkit/index.md
+++ b/docs/tutorials/linux/usb_devkit/index.md
@@ -42,8 +42,8 @@ After that, setup your system:
 1. [Chip Identification](identify_chip.md)
 2. [FW Update](fw_update.md)
 3. [Hello, World!](hello_world.md)
-4. [Full Chain Verification](full_chain_verification.md)
-5. [ECC Key Generation and EdDSA Signing](ecc_eddsa.md)
+4. [ECC Key Generation and EdDSA Signing](ecc_eddsa.md)
+5. [Full Chain Verification](full_chain_verification.md)
 
 ## FAQ
 If you encounter any issues, please check the [FAQ](../../../faq.md) before filing an issue or reaching out to our [support](https://support.tropicsquare.com/).

--- a/docs/tutorials/stm32/fw_update.md
+++ b/docs/tutorials/stm32/fw_update.md
@@ -43,9 +43,9 @@
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 
 ## Configuration
-Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
+- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) specifies the serial number of the STLink device used for flashing. This is needed only when you have multiple STM32s connected via built-in STLink or when OpenOCD autodetection does not work:
 
     ??? example "Configuring STLink serial number"
         === ":fontawesome-brands-linux: Linux"
@@ -61,7 +61,7 @@ Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"
@@ -78,7 +78,7 @@ Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) controls whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if Maintenance Mode is enabled in your TROPIC01 and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/stm32/fw_update.md
+++ b/docs/tutorials/stm32/fw_update.md
@@ -43,7 +43,7 @@
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
 
 ## Configuration
-Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
 
@@ -78,7 +78,7 @@ Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_t
             TBA
     Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
 
-- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to control whether the FW update example disables Maintenance Mode in R-Config after a successful FW update. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
 
     ??? example "Keeping Maintenance Mode enabled after FW update"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/stm32/fw_update.md
+++ b/docs/tutorials/stm32/fw_update.md
@@ -37,44 +37,64 @@
     === ":fontawesome-brands-windows: Windows"
         TBA
 
-    After this, you should see a colored output in your serial monitor.
+    After successful execution, your chip will contain the latest firmware and will be compatible with the current Libtropic API.
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_SH0_KEYS` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_SH0_KEYS="eng_sample" ..
-        make
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
-
-If your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it, use the `LT_DISABLE_MAINTENANCE_MODE` CMake option:
-!!! example "Keeping Maintenance Mode enabled after FW update"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_DISABLE_MAINTENANCE_MODE` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
-        make
-        ```
-
-    === ":fontawesome-brands-apple: macOS"
-        TBA
-
-    === ":fontawesome-brands-windows: Windows"
-        TBA
-
-    !!! warning "Not recommended"
-        This step is not recommended because it can increase the attack surface.
-
-!!! failure "FW update failed"
+!!! question "What if firmware update failed?"
     Check out the dedicated section in [FAQ](../../faq.md#fw-update-failed).
+
+## Configuration
+Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
+
+    ??? example "Configuring STLink serial number"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DSTLINK_SERIAL_NUMBER=<stlink_serial_number> ..
+            make
+            make flash
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SH0_KEYS="eng_sample" ..
+            make
+            make flash
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+
+- `LT_DISABLE_MAINTENANCE_MODE` (default: `"ON"`) to configure whether Maintenance Mode will be enabled/disabled. Set to `"OFF"` or `0` if your TROPIC01 has Maintenance Mode enabled and you don't want the FW update example to disable it:
+
+    ??? example "Keeping Maintenance Mode enabled after FW update"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_DISABLE_MAINTENANCE_MODE=0 ..
+            make
+            make flash
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+        !!! warning "Not recommended"
+            This step is not recommended because it can increase the attack surface.
 
 [Next example :material-arrow-right:](hello_world.md){ .md-button }

--- a/docs/tutorials/stm32/hello_world.md
+++ b/docs/tutorials/stm32/hello_world.md
@@ -39,19 +39,38 @@
 
     After this, you should see an output in your serial monitor.
 
-If your TROPIC01 has engineering sample pairing keys, you can switch to them using the `LT_SH0_KEYS` CMake option:
-!!! example "Switching to engineering sample pairing keys"
-    === ":fontawesome-brands-linux: Linux"
-        You can pass `LT_SH0_KEYS` to `cmake` as follows:
-        ```bash { .copy }
-        cmake -DLT_SH0_KEYS="eng_sample" ..
-        make
-        ```
+## Configuration
+Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
-    === ":fontawesome-brands-apple: macOS"
-        TBA
+- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
 
-    === ":fontawesome-brands-windows: Windows"
-        TBA
+    ??? example "Configuring STLink serial number"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DSTLINK_SERIAL_NUMBER=<stlink_serial_number> ..
+            make
+            make flash
+            ```
 
-Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
+- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+
+    ??? example "Switching to engineering sample pairing keys"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DLT_SH0_KEYS="eng_sample" ..
+            make
+            make flash
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+    Additionally, see [Default Pairing Keys for a Secure Channel Handshake](../../reference/default_pairing_keys.md) for more information.

--- a/docs/tutorials/stm32/hello_world.md
+++ b/docs/tutorials/stm32/hello_world.md
@@ -40,7 +40,7 @@
     After this, you should see an output in your serial monitor.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
 
 - `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
 

--- a/docs/tutorials/stm32/hello_world.md
+++ b/docs/tutorials/stm32/hello_world.md
@@ -40,9 +40,9 @@
     After this, you should see an output in your serial monitor.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+In addition to the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake options:
 
-- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
+- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) specifies the serial number of the STLink device used for flashing. This is needed only when you have multiple STM32s connected via built-in STLink or when OpenOCD autodetection does not work:
 
     ??? example "Configuring STLink serial number"
         === ":fontawesome-brands-linux: Linux"
@@ -58,7 +58,7 @@ Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_
         === ":fontawesome-brands-windows: Windows"
             TBA
 
-- `LT_SH0_KEYS` (default: `"prod0"`) to choose which pairing keys in slot 0 will be used. Switch to engineering sample pairing keys if your TROPIC01 has them:
+- `LT_SH0_KEYS` (default: `"prod0"`) selects which pairing keys in slot 0 are used. Switch to engineering-sample pairing keys if your TROPIC01 is provisioned with them:
 
     ??? example "Switching to engineering sample pairing keys"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/stm32/identify_chip.md
+++ b/docs/tutorials/stm32/identify_chip.md
@@ -39,4 +39,23 @@
 
     After this, you should see a colored output in your serial monitor.
 
+## Configuration
+Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+
+- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
+
+    ??? example "Configuring STLink serial number"
+        === ":fontawesome-brands-linux: Linux"
+            ```bash { .copy }
+            cmake -DSTLINK_SERIAL_NUMBER=<stlink_serial_number> ..
+            make
+            make flash
+            ```
+
+        === ":fontawesome-brands-apple: macOS"
+            TBA
+
+        === ":fontawesome-brands-windows: Windows"
+            TBA
+
 [Next example :material-arrow-right:](fw_update.md){ .md-button }

--- a/docs/tutorials/stm32/identify_chip.md
+++ b/docs/tutorials/stm32/identify_chip.md
@@ -40,9 +40,9 @@
     After this, you should see a colored output in your serial monitor.
 
 ## Configuration
-Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
+In addition to the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, this example provides the following CMake option:
 
-- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
+- `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) specifies the serial number of the STLink device used for flashing. This is needed only when you have multiple STM32s connected via built-in STLink or when OpenOCD autodetection does not work:
 
     ??? example "Configuring STLink serial number"
         === ":fontawesome-brands-linux: Linux"

--- a/docs/tutorials/stm32/identify_chip.md
+++ b/docs/tutorials/stm32/identify_chip.md
@@ -40,7 +40,7 @@
     After this, you should see a colored output in your serial monitor.
 
 ## Configuration
-Beside the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there are multiple CMake options specific to this example:
+Besides the [Libtropic CMake options](../../reference/integrating_libtropic/how_to_configure/index.md) used to configure Libtropic, there is the following CMake option specific to this example:
 
 - `STLINK_SERIAL_NUMBER` (default: none, OpenOCD looks for any STLink programming interface) to set the serial number of the STLink device which will be used for flashing. This is needed only when you have multiple STM32s connected using built-in STLink or problems with OpenOCD's autodetection:
 

--- a/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_f439zi/identify_chip/CMakeLists.txt
@@ -46,28 +46,6 @@ if (NOT DEFINED STLINK_SERIAL_NUMBER)
     set(STLINK_SERIAL_NUMBER "")
 endif()
 
-# Select pairing keys written during manufacturing into your TROPIC01
-set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
-set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
-
-# These are internal macros for selecting SH0 keys
-set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
-set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
-
-# Define SH0 macros based on selected string
-if(LT_SH0_KEYS STREQUAL "eng_sample")
-    message(STATUS "Using Engineering sample keys")
-    set(LT_USE_SH0_ENG_SAMPLE 1)
-    set(LT_USE_SH0_PROD0      0)
-elseif(LT_SH0_KEYS STREQUAL "prod0")
-    message(STATUS "Using Production 0 keys")
-    set(LT_USE_SH0_ENG_SAMPLE 0)
-    set(LT_USE_SH0_PROD0      1)
-else()
-    get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
-    message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
-endif()
-
 ###########################################################################
 #                                                                         #
 #   Set up dependencies                                                   #
@@ -172,8 +150,6 @@ set(INCLUDE_DIRS
 # Define executable and configure (pass defines, includes and link dependencies).
 set(EXE_NAME ${CMAKE_PROJECT_NAME}.elf)
 add_executable(${EXE_NAME} ${SOURCES})
-target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE})
-target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0})
 target_compile_definitions(${EXE_NAME} PRIVATE -D${STM32_DEVICE}) # Configure target MCU (used by STM32 HAL)
 target_include_directories(${EXE_NAME} PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(${EXE_NAME} PRIVATE tropic)

--- a/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
@@ -51,18 +51,7 @@
  */
 
 /* Private typedef -----------------------------------------------------------*/
-
 /* Private define ------------------------------------------------------------*/
-
-/* Choose pairing keypair for slot 0. */
-#if LT_USE_SH0_ENG_SAMPLE
-#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
-#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
-#elif LT_USE_SH0_PROD0
-#define LT_EX_SH0_PRIV lt_sh0priv_prod0
-#define LT_EX_SH0_PUB lt_sh0pub_prod0
-#endif
-
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 

--- a/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_l432kc/identify_chip/CMakeLists.txt
@@ -46,29 +46,6 @@ if (NOT DEFINED STLINK_SERIAL_NUMBER)
     set(STLINK_SERIAL_NUMBER "")
 endif()
 
-# Select pairing keys written during manufacturing into your TROPIC01
-set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
-set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
-
-# These are internal macros for selecting SH0 keys
-set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
-set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
-
-# Define SH0 macros based on selected string
-if(LT_SH0_KEYS STREQUAL "eng_sample")
-    message(STATUS "Using Engineering sample keys")
-    set(LT_USE_SH0_ENG_SAMPLE 1)
-    set(LT_USE_SH0_PROD0      0)
-elseif(LT_SH0_KEYS STREQUAL "prod0")
-    message(STATUS "Using Production 0 keys")
-    set(LT_USE_SH0_ENG_SAMPLE 0)
-    set(LT_USE_SH0_PROD0      1)
-else()
-    get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
-    message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
-endif()
-
-
 ###########################################################################
 #                                                                         #
 #   Set up dependencies                                                   #
@@ -174,8 +151,6 @@ set(INCLUDE_DIRS
 # Define executable and configure (pass defines, includes and link dependencies).
 set(EXE_NAME ${CMAKE_PROJECT_NAME}.elf)
 add_executable(${EXE_NAME} ${SOURCES})
-target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE})
-target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0})
 target_compile_definitions(${EXE_NAME} PRIVATE -D${STM32_DEVICE}) # Configure target MCU (used by STM32 HAL)
 target_include_directories(${EXE_NAME} PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(${EXE_NAME} PRIVATE tropic)

--- a/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
@@ -53,16 +53,6 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-
-/* Choose pairing keypair for slot 0. */
-#if LT_USE_SH0_ENG_SAMPLE
-#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
-#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
-#elif LT_USE_SH0_PROD0
-#define LT_EX_SH0_PRIV lt_sh0priv_prod0
-#define LT_EX_SH0_PUB lt_sh0pub_prod0
-#endif
-
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 

--- a/examples/stm32/nucleo_u545re_q/identify_chip/CMakeLists.txt
+++ b/examples/stm32/nucleo_u545re_q/identify_chip/CMakeLists.txt
@@ -50,28 +50,6 @@ if (NOT DEFINED STLINK_SERIAL_NUMBER)
     set(STLINK_SERIAL_NUMBER "")
 endif()
 
-# Select pairing keys written during manufacturing into your TROPIC01
-set(LT_SH0_KEYS "prod0" CACHE STRING "Choose which pairing keys in slot 0 will be used in this example")
-set_property(CACHE LT_SH0_KEYS PROPERTY STRINGS "eng_sample" "prod0")
-
-# These are internal macros for selecting SH0 keys
-set(LT_USE_SH0_ENG_SAMPLE 0 CACHE INTERNAL "")
-set(LT_USE_SH0_PROD0      0 CACHE INTERNAL "")
-
-# Define SH0 macros based on selected string
-if(LT_SH0_KEYS STREQUAL "eng_sample")
-    message(STATUS "Using Engineering sample keys")
-    set(LT_USE_SH0_ENG_SAMPLE 1)
-    set(LT_USE_SH0_PROD0      0)
-elseif(LT_SH0_KEYS STREQUAL "prod0")
-    message(STATUS "Using Production 0 keys")
-    set(LT_USE_SH0_ENG_SAMPLE 0)
-    set(LT_USE_SH0_PROD0      1)
-else()
-    get_property(lt_sh0_keys_choices CACHE LT_SH0_KEYS PROPERTY STRINGS)
-    message(FATAL_ERROR "Incorrect SH0 keys specified: '${LT_SH0_KEYS}'\nAvailable SH0 keys: ${lt_sh0_keys_choices}")
-endif()
-
 ###########################################################################
 #                                                                         #
 #   Set up dependencies                                                   #
@@ -192,8 +170,6 @@ set(INCLUDE_DIRS
 # Define executable and configure (pass defines, includes and link dependencies).
 set(EXE_NAME ${CMAKE_PROJECT_NAME}.elf)
 add_executable(${EXE_NAME} ${SOURCES})
-target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_ENG_SAMPLE=${LT_USE_SH0_ENG_SAMPLE})
-target_compile_definitions(${EXE_NAME} PRIVATE LT_USE_SH0_PROD0=${LT_USE_SH0_PROD0})
 target_compile_definitions(${EXE_NAME} PRIVATE -D${STM32_DEVICE}) # Configure target MCU (used by STM32 HAL)
 target_include_directories(${EXE_NAME} PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(${EXE_NAME} PRIVATE tropic)

--- a/examples/stm32/nucleo_u545re_q/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_u545re_q/identify_chip/Src/main.c
@@ -32,16 +32,6 @@
 #include "psa/crypto.h"
 
 /* Private define ------------------------------------------------------------*/
-
-/* Choose pairing keypair for slot 0. */
-#if LT_USE_SH0_ENG_SAMPLE
-#define LT_EX_SH0_PRIV lt_sh0priv_eng_sample
-#define LT_EX_SH0_PUB lt_sh0pub_eng_sample
-#elif LT_USE_SH0_PROD0
-#define LT_EX_SH0_PRIV lt_sh0priv_prod0
-#define LT_EX_SH0_PUB lt_sh0pub_prod0
-#endif
-
 /* Private variables ---------------------------------------------------------*/
 /* RNG handle declaration */
 RNG_HandleTypeDef hrng;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,8 +74,8 @@ nav:
           - 1. Chip Identification: tutorials/linux/usb_devkit/identify_chip.md
           - 2. FW Update: tutorials/linux/usb_devkit/fw_update.md
           - 3. Hello, World!: tutorials/linux/usb_devkit/hello_world.md
-          - 4. Full Chain Verification: tutorials/linux/usb_devkit/full_chain_verification.md
-          - 5. ECC EdDSA: tutorials/linux/usb_devkit/ecc_eddsa.md
+          - 4. ECC EdDSA: tutorials/linux/usb_devkit/ecc_eddsa.md
+          - 5. Full Chain Verification: tutorials/linux/usb_devkit/full_chain_verification.md
       - ESP32:
         - tutorials/esp32/index.md
         - 1. Chip Identification: tutorials/esp32/identify_chip.md


### PR DESCRIPTION
## Description

This PR:
- adds a new Configuration section to all tutorials,
- reorders USB DevKit tutorials,
- removes SH0 keys related CMake options from STM32 Identify Chip example (not needed).

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---