### PR TITLE
refactor: rename LT_L1_READ_RETRY_DELAY to LT_L1_READ_RETRY_DELAY_MS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `LT_L1_TIMEOUT_MS_MIN`, `LT_L1_TIMEOUT_MS_DEFAULT`, `LT_L1_TIMEOUT_MS_MAX` with `LT_L1_SPI_TIMEOUT_MS` (timeout on SPI transfers) and `LT_L1_INT_TIMEOUT_MS` (timeout while waiting for an interrupt from TROPIC01).
   - Both constants are user-configurable. Provided values were tested on supported HALs.
   - Some HALs do not support timeouts, so they ignore those constants. Refer to the HAL source.
+- Renamed `LT_L1_READ_RETRY_DELAY` to `LT_L1_READ_RETRY_DELAY_MS`.
 
 ### Added
 - ECC + EdDSA example for USB DevKit.
@@ -54,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Count of retries can be configured using `LT_CRC_ERR_RETRY_ATTEMPTS` parameter/macro. Default value is 3 retries.
   - See [`LT_CRC_ERR_RETRY_ATTEMPTS` section](https://tropicsquare.github.io/libtropic/latest/reference/integrating_libtropic/how_to_configure/#lt_crc_err_retry_attempts) in "How to Configure" page of the documentation to learn how the retry mechanism works.
 - FAQ section covering `LT_L2_CRC_ERR` and `LT_L2_IN_CRC_ERR`.
-- Possibility to configure `LT_L1_READ_MAX_TRIES` and `LT_L1_READ_RETRY_DELAY`.
+- Possibility to configure `LT_L1_READ_MAX_TRIES` and `LT_L1_READ_RETRY_DELAY_MS`.
 - Community HAL for Raspberry Pi Pico boards created by [Wuard](https://github.com/wuard) (see the documentation for more information).
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,10 +115,10 @@ if(NOT LT_L1_READ_MAX_TRIES MATCHES "^([1-9][0-9]*)$")
 endif()
 
 # Must be positive without leading zero.
-set(LT_L1_READ_RETRY_DELAY "25" CACHE STRING "Time to wait in ms between each Get_Response request.")
+set(LT_L1_READ_RETRY_DELAY_MS "25" CACHE STRING "Time to wait in ms between each Get_Response request.")
 
-if(NOT LT_L1_READ_RETRY_DELAY MATCHES "^([1-9][0-9]*)$")
-    message(FATAL_ERROR "LT_L1_READ_RETRY_DELAY must be a positive integer without leading zeros, got '${LT_L1_READ_RETRY_DELAY}'")
+if(NOT LT_L1_READ_RETRY_DELAY_MS MATCHES "^([1-9][0-9]*)$")
+    message(FATAL_ERROR "LT_L1_READ_RETRY_DELAY_MS must be a positive integer without leading zeros, got '${LT_L1_READ_RETRY_DELAY_MS}'")
 endif()
 
 # Must be non-negative without leading zero.
@@ -305,6 +305,6 @@ endif()
 
 target_compile_definitions(tropic PUBLIC LT_CRC_ERR_RETRY_ATTEMPTS=${LT_CRC_ERR_RETRY_ATTEMPTS})
 target_compile_definitions(tropic PUBLIC LT_L1_READ_MAX_TRIES=${LT_L1_READ_MAX_TRIES})
-target_compile_definitions(tropic PUBLIC LT_L1_READ_RETRY_DELAY=${LT_L1_READ_RETRY_DELAY})
+target_compile_definitions(tropic PUBLIC LT_L1_READ_RETRY_DELAY_MS=${LT_L1_READ_RETRY_DELAY_MS})
 target_compile_definitions(tropic PUBLIC LT_L1_SPI_TIMEOUT_MS=${LT_L1_SPI_TIMEOUT_MS})
 target_compile_definitions(tropic PUBLIC LT_L1_INT_TIMEOUT_MS=${LT_L1_INT_TIMEOUT_MS})

--- a/docs/reference/integrating_libtropic/how_to_configure/index.md
+++ b/docs/reference/integrating_libtropic/how_to_configure/index.md
@@ -125,12 +125,12 @@ Set this parameter to zero to disable retries.
 
 Sets how many times to try L1 transfer (if the chip is busy) before failing.
 
-See also [`LT_L1_READ_RETRY_DELAY`](#lt_l1_read_retry_delay).
+See also [`LT_L1_READ_RETRY_DELAY_MS`](#lt_l1_read_retry_delay_ms).
 
 !!! tip "Tip: Use interrupt pin"
     It is better to use the interrupt pin functionality of TROPIC01 if you need to shorten reaction time. See [`LT_USE_INT_PIN`](#lt_use_int_pin) parameter.
 
-### `LT_L1_READ_RETRY_DELAY`
+### `LT_L1_READ_RETRY_DELAY_MS`
 - integer (positive)
 - default value: 25 (ms)
 

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -170,7 +170,7 @@ lt_ret_t lt_get_tr01_mode(lt_handle_t *h, lt_tr01_mode_t *mode)
         }
 
         // Chip is not ready, let's wait and try again in a while.
-        ret = lt_l1_delay(&h->l2, LT_L1_READ_RETRY_DELAY);
+        ret = lt_l1_delay(&h->l2, LT_L1_READ_RETRY_DELAY_MS);
         if (ret != LT_OK) {
             return ret;
         }

--- a/src/lt_l1.c
+++ b/src/lt_l1.c
@@ -105,7 +105,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
                 if (ret != LT_OK) {
                     return ret;
                 }
-                ret = lt_l1_delay(s2, LT_L1_READ_RETRY_DELAY);
+                ret = lt_l1_delay(s2, LT_L1_READ_RETRY_DELAY_MS);
                 if (ret != LT_OK) {
                     return ret;
                 }
@@ -148,7 +148,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
             if (s2->buff[0] & TR01_L1_CHIP_MODE_STARTUP_bit) {
                 // INT pin is not implemented in Start-up Mode
                 // So we wait a bit before we poll again for CHIP_STATUS
-                ret = lt_l1_delay(s2, LT_L1_READ_RETRY_DELAY);
+                ret = lt_l1_delay(s2, LT_L1_READ_RETRY_DELAY_MS);
                 if (ret != LT_OK) {
                     return ret;
                 }
@@ -163,7 +163,7 @@ lt_ret_t lt_l1_read(lt_l2_state_t *s2, const uint32_t max_len, const uint32_t ti
                 }
 #else
                 // INT pin not used, delay for some time
-                ret = lt_l1_delay(s2, LT_L1_READ_RETRY_DELAY);
+                ret = lt_l1_delay(s2, LT_L1_READ_RETRY_DELAY_MS);
                 if (ret != LT_OK) {
                     return ret;
                 }

--- a/src/lt_l1.h
+++ b/src/lt_l1.h
@@ -38,13 +38,13 @@ extern "C" {
 #define LT_L1_READ_MAX_TRIES 50
 #endif
 
-#ifndef LT_L1_READ_RETRY_DELAY
+#ifndef LT_L1_READ_RETRY_DELAY_MS
 /** @brief Time to wait in ms between each Get_Response request.
  *
  * @note In CMake-based builds it is set in CMakeLists.txt and can be configured using CMake
  * parameters.
  */
-#define LT_L1_READ_RETRY_DELAY 25
+#define LT_L1_READ_RETRY_DELAY_MS 25
 #endif
 
 #ifndef LT_L1_SPI_TIMEOUT_MS


### PR DESCRIPTION
## Description

Based on issue https://github.com/tropicsquare/libtropic/issues/67.

Although it was meant to be a good first issue for newcomers, it's a change suitable for a major release and we have already done some related changes to the timeout logic in PRs https://github.com/tropicsquare/libtropic/pull/528 and https://github.com/tropicsquare/libtropic/pull/536 .

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [x] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---