### PR TITLE
ETR01SDK-643: fix variable initialization in functions using goto

### DIFF
--- a/cal/openssl/lt_openssl_hmac_sha256.c
+++ b/cal/openssl/lt_openssl_hmac_sha256.c
@@ -20,6 +20,7 @@ lt_ret_t lt_hmac_sha256(const uint8_t *key, const uint32_t key_len, const uint8_
     EVP_MD_CTX *ctx = NULL;
     EVP_PKEY *pkey = NULL;
     unsigned long err_code;
+    size_t out_len = LT_HMAC_SHA256_HASH_LEN;
     lt_ret_t ret = LT_OK;
 
     // Convert `key` raw bytes into an OpenSSL Key object.
@@ -61,7 +62,6 @@ lt_ret_t lt_hmac_sha256(const uint8_t *key, const uint32_t key_len, const uint8_
     }
 
     // Finalize the HMAC-SHA256 computation.
-    size_t out_len = LT_HMAC_SHA256_HASH_LEN;
     if (!EVP_DigestSignFinal(ctx, output, &out_len)) {
         err_code = ERR_get_error();
         LT_LOG_ERROR("Failed to finalize HMAC-SHA256 hash, err_code=%lu (%s)", err_code,

--- a/cal/openssl/lt_openssl_x25519.c
+++ b/cal/openssl/lt_openssl_x25519.c
@@ -20,6 +20,7 @@ lt_ret_t lt_X25519(const uint8_t *privkey, const uint8_t *pubkey, uint8_t *secre
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *priv = NULL;
     EVP_PKEY *pub = NULL;
+    size_t secret_len = TR01_X25519_KEY_LEN;
     lt_ret_t lt_ret = LT_OK;
     unsigned long err_code;
 
@@ -72,7 +73,6 @@ lt_ret_t lt_X25519(const uint8_t *privkey, const uint8_t *pubkey, uint8_t *secre
     }
 
     // Derive the shared secret.
-    size_t secret_len = TR01_X25519_KEY_LEN;
     if (EVP_PKEY_derive(ctx, secret, &secret_len) <= 0) {
         err_code = ERR_get_error();
         LT_LOG_ERROR("Failed to derive X25519 shared secret, err_code=%lu (%s)", err_code,
@@ -98,6 +98,7 @@ lt_X25519_cleanup:
 lt_ret_t lt_X25519_scalarmult(const uint8_t *sk, uint8_t *pk)
 {
     EVP_PKEY *priv = NULL;
+    size_t pk_len = TR01_X25519_KEY_LEN;
     lt_ret_t lt_ret = LT_OK;
     unsigned long err_code;
 
@@ -112,7 +113,6 @@ lt_ret_t lt_X25519_scalarmult(const uint8_t *sk, uint8_t *pk)
     }
 
     // Extract the public key.
-    size_t pk_len = TR01_X25519_KEY_LEN;
     if (!EVP_PKEY_get_raw_public_key(priv, pk, &pk_len)) {
         err_code = ERR_get_error();
         LT_LOG_ERROR("Failed to extract X25519 public key from private key, err_code=%lu (%s)",

--- a/cal/wolfcrypt/lt_wolfcrypt_x25519.c
+++ b/cal/wolfcrypt/lt_wolfcrypt_x25519.c
@@ -20,6 +20,7 @@
 lt_ret_t lt_X25519(const uint8_t *privkey, const uint8_t *pubkey, uint8_t *secret)
 {
     int ret;
+    word32 secret_out_len = TR01_X25519_KEY_LEN;
     lt_ret_t lt_ret = LT_OK;
     curve25519_key wc_priv, wc_pub;
 #ifdef WOLFSSL_CURVE25519_BLINDING
@@ -76,7 +77,6 @@ lt_ret_t lt_X25519(const uint8_t *privkey, const uint8_t *pubkey, uint8_t *secre
         goto lt_X25519_cleanup;
     }
 
-    word32 secret_out_len = TR01_X25519_KEY_LEN;
     ret = wc_curve25519_shared_secret_ex(&wc_priv, &wc_pub, secret, &secret_out_len,
                                          EC25519_LITTLE_ENDIAN);
     if (ret != 0) {
@@ -110,6 +110,7 @@ lt_X25519_cleanup:
 lt_ret_t lt_X25519_scalarmult(const uint8_t *sk, uint8_t *pk)
 {
     int ret;
+    word32 pk_out_len = TR01_X25519_KEY_LEN;
     lt_ret_t lt_ret = LT_OK;
     curve25519_key wc_secret;
 #ifdef WOLFSSL_CURVE25519_BLINDING
@@ -150,7 +151,6 @@ lt_ret_t lt_X25519_scalarmult(const uint8_t *sk, uint8_t *pk)
     }
 #endif
 
-    word32 pk_out_len = TR01_X25519_KEY_LEN;
     ret = wc_curve25519_export_public_ex(&wc_secret, pk, &pk_out_len, EC25519_LITTLE_ENDIAN);
     if (ret != 0) {
         LT_LOG_ERROR("Failed to compute X25519 public key, ret=%d (%s)", ret, wc_GetErrorString(ret));

--- a/cmake/strict_compile_flags.cmake
+++ b/cmake/strict_compile_flags.cmake
@@ -16,6 +16,7 @@ set(LT_STRICT_COMPILATION_FLAGS
     "-Wstrict-prototypes"
     "-Wunused-result"
     "-Wmissing-prototypes"
+    "-Wjump-misses-init"
     "-fstack-protector-strong"
     CACHE STRING "Strict compile flags")
 

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -450,6 +450,8 @@ lt_ret_t lt_session_start(lt_handle_t *h, const uint8_t *stpub, const lt_pkey_in
     }
 
     lt_host_eph_keys_t host_eph_keys = {0};
+    // Setup a pointer to a response in the L2 buffer.
+    struct lt_l2_handshake_rsp_t *p_l2_resp = (struct lt_l2_handshake_rsp_t *)h->l2.buff;
 
     lt_ret_t ret = lt_out__session_start(h, pkey_index, &host_eph_keys);
     if (ret != LT_OK) {
@@ -460,9 +462,6 @@ lt_ret_t lt_session_start(lt_handle_t *h, const uint8_t *stpub, const lt_pkey_in
     if (ret != LT_OK) {
         goto cleanup;
     }
-
-    // Setup a pointer to a response in the L2 buffer.
-    struct lt_l2_handshake_rsp_t *p_l2_resp = (struct lt_l2_handshake_rsp_t *)h->l2.buff;
 
     if (TR01_L2_HANDSHAKE_RSP_LEN != (p_l2_resp->rsp_len)) {
         ret = LT_L2_RSP_LEN_ERROR;

--- a/src/libtropic_l3.c
+++ b/src/libtropic_l3.c
@@ -88,6 +88,17 @@ lt_ret_t lt_in__session_start(lt_handle_t *h, const uint8_t *stpub, const lt_pke
                                  '5', '5', '1', '9', '_', 'A', 'E', 'S',  'G',  'C', 'M',
                                  '_', 'S', 'H', 'A', '2', '5', '6', 0x00, 0x00, 0x00};
     uint8_t hash[LT_SHA256_DIGEST_LENGTH] = {0};
+
+    // Variables used during key derivation (ECDH)
+    uint8_t output_1[33] = {0};  // Temp storage for ck, kcmd.
+    uint8_t output_2[32] = {0};  // Temp storage for kauth.
+    uint8_t shared_secret[TR01_X25519_KEY_LEN] = {0};
+    uint8_t kcmd[TR01_AES256_KEY_LEN] = {
+        0};  // AES256 key used for L3 command packet encryption/decryption.
+    uint8_t kres[TR01_AES256_KEY_LEN] = {
+        0};  // AES256 key used for L3 result packet encryption/decryption.
+    uint8_t kauth[TR01_AES256_KEY_LEN] = {0};  // AES256 key used for handshake authentication.
+
     lt_ret_t ret;
     lt_ret_t ret_unused;
 
@@ -202,15 +213,6 @@ lt_ret_t lt_in__session_start(lt_handle_t *h, const uint8_t *stpub, const lt_pke
     }
 
     // Derivate the keys (ECDH)
-    uint8_t output_1[33] = {0};  // Temp storage for ck, kcmd.
-    uint8_t output_2[32] = {0};  // Temp storage for kauth.
-    uint8_t shared_secret[TR01_X25519_KEY_LEN] = {0};
-    uint8_t kcmd[TR01_AES256_KEY_LEN] = {
-        0};  // AES256 key used for L3 command packet encryption/decryption.
-    uint8_t kres[TR01_AES256_KEY_LEN] = {
-        0};  // AES256 key used for L3 result packet encryption/decryption.
-    uint8_t kauth[TR01_AES256_KEY_LEN] = {0};  // AES256 key used for handshake authentication.
-
     // ck = protocol_name
     // ck = HKDF (ck, X25519(EHPRIV, ETPUB), 1)
     ret = lt_X25519(host_eph_keys->ehpriv, p_rsp->e_tpub, shared_secret);

--- a/tests/functional/linux/spi/main.c
+++ b/tests/functional/linux/spi/main.c
@@ -5,6 +5,7 @@
  * @license For the license see LICENSE.md in the root directory of this source tree.
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 


### PR DESCRIPTION
## Description

This PR adds `-Wjump-misses-init` compilation flags when building tests and fixes the errors.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [x] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---