### PR TITLE
ETR01SDK-644: Code Checker check return values

### DIFF
--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
@@ -639,6 +639,9 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
             return LT_HAL_ERROR;
         }
 
+        // Ensure the buffer is null-terminated (for sscanf).
+        buffered_chars[LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX - 1] = '\0';
+
         for (size_t count = 0; count < tx_data_length; count++) {
             int ret = sscanf((char *)&buffered_chars[count * 2], "%02" SCNx8,
                              &s2->buff[count + offset]);

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
@@ -609,7 +609,15 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
         // buffered_chars.
         uint8_t buffered_chars[LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX] = {0};
         for (int i = 0; i < tx_data_length; i++) {
-            sprintf((char *)(buffered_chars + i * 2), "%02" PRIX8, s2->buff[i + offset]);
+            int written = sprintf((char *)(buffered_chars + i * 2), "%02" PRIX8, s2->buff[i + offset]);
+            if (written < 0) {
+                LT_LOG_ERROR("sprintf failed: errno=%d (%s)", errno, strerror(errno));
+                return LT_HAL_ERROR;
+            }
+            else if (written != 2) {
+                LT_LOG_ERROR("sprintf wrote incorrect number of chars, expected 2, got %d", written);
+                return LT_HAL_ERROR;
+            }
         }
 
         // Control characters to keep CS LOW (they are expected by USB DevKit, see the top of this file
@@ -630,7 +638,12 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
         }
 
         for (size_t count = 0; count < tx_data_length; count++) {
-            sscanf((char *)&buffered_chars[count * 2], "%02" SCNx8, &s2->buff[count + offset]);
+            int ret = sscanf((char *)&buffered_chars[count * 2], "%02" SCNx8,
+                             &s2->buff[count + offset]);
+            if (ret != 1) {
+                LT_LOG_ERROR("sscanf failed to convert hex value at offset %zu, ret=%d", count, ret);
+                return LT_HAL_ERROR;
+            }
         }
     }
     else {

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
@@ -613,11 +613,11 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
             int written = snprintf((char *)(buffered_chars + i * 2), remaining, "%02" PRIX8,
                                    s2->buff[i + offset]);
             if (written < 0) {
-                LT_LOG_ERROR("sprintf failed: errno=%d (%s)", errno, strerror(errno));
+                LT_LOG_ERROR("snprintf failed: errno=%d (%s)", errno, strerror(errno));
                 return LT_HAL_ERROR;
             }
             else if (written != 2) {
-                LT_LOG_ERROR("sprintf wrote incorrect number of chars, expected 2, got %d", written);
+                LT_LOG_ERROR("snprintf wrote incorrect number of chars, expected 2, got %d", written);
                 return LT_HAL_ERROR;
             }
         }

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
@@ -609,11 +609,17 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
         // buffered_chars.
         uint8_t buffered_chars[LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX] = {0};
         for (int i = 0; i < tx_data_length; i++) {
-            int remaining = sizeof(buffered_chars) - i * 2;
+            size_t remaining = sizeof(buffered_chars) - i * 2;
             int written = snprintf((char *)(buffered_chars + i * 2), remaining, "%02" PRIX8,
                                    s2->buff[i + offset]);
             if (written < 0) {
                 LT_LOG_ERROR("snprintf failed: errno=%d (%s)", errno, strerror(errno));
+                return LT_HAL_ERROR;
+            }
+            // Considering one additional byte for null terminator.
+            else if (written >= remaining) {
+                LT_LOG_ERROR("snprintf output was truncated, written=%d, remaining=%zu", written,
+                             remaining);
                 return LT_HAL_ERROR;
             }
             else if (written != 2) {

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
@@ -617,7 +617,7 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
                 return LT_HAL_ERROR;
             }
             // Considering one additional byte for null terminator.
-            else if (written >= remaining) {
+            else if ((size_t)written >= remaining) {
                 LT_LOG_ERROR("snprintf output was truncated, written=%d, remaining=%zu", written,
                              remaining);
                 return LT_HAL_ERROR;

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.c
@@ -609,7 +609,9 @@ lt_ret_t lt_port_spi_transfer(lt_l2_state_t *s2, uint8_t offset, uint16_t tx_dat
         // buffered_chars.
         uint8_t buffered_chars[LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX] = {0};
         for (int i = 0; i < tx_data_length; i++) {
-            int written = sprintf((char *)(buffered_chars + i * 2), "%02" PRIX8, s2->buff[i + offset]);
+            int remaining = sizeof(buffered_chars) - i * 2;
+            int written = snprintf((char *)(buffered_chars + i * 2), remaining, "%02" PRIX8,
+                                   s2->buff[i + offset]);
             if (written < 0) {
                 LT_LOG_ERROR("sprintf failed: errno=%d (%s)", errno, strerror(errno));
                 return LT_HAL_ERROR;

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.h
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.h
@@ -22,10 +22,10 @@ extern "C" {
 /**
  * @brief Size of the buffer used for encoded data prepared for transfer.
  *
- * Each byte is translated to hex number (len * 2 bytes) and two-character terminator is appended (+ 2
- * bytes).
+ * Each byte is translated to hex number (len * 2 bytes), two-character terminator is appended (+ 2
+ * bytes) and null-terminator for sscanf is appended (+ 1 byte).
  */
-#define LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX ((TR01_L1_LEN_MAX * 2) + 2)
+#define LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX ((TR01_L1_LEN_MAX * 2) + 3)
 
 /**
  * @brief Device structure for TROPIC01 USB DevKit POSIX port.

--- a/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.h
+++ b/hal/posix/usb_devkit/libtropic_port_posix_usb_devkit.h
@@ -18,7 +18,14 @@ extern "C" {
 #endif
 
 #define LT_USB_DEVKIT_READ_WRITE_DELAY 10
-#define LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX ((TR01_L1_LEN_MAX * 2) + 1)
+
+/**
+ * @brief Size of the buffer used for encoded data prepared for transfer.
+ *
+ * Each byte is translated to hex number (len * 2 bytes) and two-character terminator is appended (+ 2
+ * bytes).
+ */
+#define LT_USB_DEVKIT_SPI_TRANSFER_BUFF_SIZE_MAX ((TR01_L1_LEN_MAX * 2) + 2)
 
 /**
  * @brief Device structure for TROPIC01 USB DevKit POSIX port.

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -2215,12 +2215,8 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id,
         print_func("      Git hash:           %08" PRIX32 "\n", p_h->git_hash);
         // Hash str has 32B
         char hash_str[32 * 2 + 1] = {0};
-        for (int i = 0; i < 32; i++) {
-            int written = snprintf(hash_str + i * 2, sizeof(hash_str) - i * 2, "%02" PRIX8,
-                                   p_h->hash[i]);
-            if (written != 2) {
-                return LT_FAIL;
-            }
+        if (LT_OK != lt_print_bytes(p_h->hash, sizeof(p_h->hash), hash_str, sizeof(hash_str))) {
+            return LT_FAIL;
         }
         print_func("      Hash:          %s\n", hash_str);
         print_func("      Pair version:  %08" PRIX32 "\n", p_h->pair_version);

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1703,8 +1703,7 @@ lt_ret_t lt_print_bytes(const uint8_t *bytes, const size_t bytes_cnt, char *out_
     for (size_t i = 0; i < bytes_cnt; i++) {
         size_t remaining = out_buf_size - (i * 2);
         int written = snprintf(&out_buf[i * 2], remaining, "%02" PRIX8, bytes[i]);
-        // Verify snprintf succeeded and didn't truncate
-        // (should never happen given precondition check, but defensive)
+        // '"%02" PRIX8' should always result in 2 characters written.
         if (written != 2) {
             return LT_FAIL;
         }

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1709,7 +1709,7 @@ lt_ret_t lt_print_bytes(const uint8_t *bytes, const size_t bytes_cnt, char *out_
             return LT_HAL_ERROR;
         }
         // Considering one additional byte for null terminator.
-        else if (written >= remaining) {
+        else if ((size_t)written >= remaining) {
             LT_LOG_ERROR("snprintf output was truncated, written=%d, remaining=%zu", written,
                          remaining);
             return LT_HAL_ERROR;

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1705,7 +1705,7 @@ lt_ret_t lt_print_bytes(const uint8_t *bytes, const size_t bytes_cnt, char *out_
         int written = snprintf(&out_buf[i * 2], remaining, "%02" PRIX8, bytes[i]);
         // Verify snprintf succeeded and didn't truncate
         // (should never happen given precondition check, but defensive)
-        if (written < 0 || (size_t)written >= remaining) {
+        if (written != 2) {
             return LT_FAIL;
         }
     }
@@ -2217,7 +2217,11 @@ lt_ret_t lt_print_fw_header(lt_handle_t *h, const lt_bank_id_t bank_id,
         // Hash str has 32B
         char hash_str[32 * 2 + 1] = {0};
         for (int i = 0; i < 32; i++) {
-            snprintf(hash_str + i * 2, sizeof(hash_str) - i * 2, "%02" PRIX8, p_h->hash[i]);
+            int written = snprintf(hash_str + i * 2, sizeof(hash_str) - i * 2, "%02" PRIX8,
+                                   p_h->hash[i]);
+            if (written != 2) {
+                return LT_FAIL;
+            }
         }
         print_func("      Hash:          %s\n", hash_str);
         print_func("      Pair version:  %08" PRIX32 "\n", p_h->pair_version);

--- a/src/libtropic.c
+++ b/src/libtropic.c
@@ -1703,9 +1703,20 @@ lt_ret_t lt_print_bytes(const uint8_t *bytes, const size_t bytes_cnt, char *out_
     for (size_t i = 0; i < bytes_cnt; i++) {
         size_t remaining = out_buf_size - (i * 2);
         int written = snprintf(&out_buf[i * 2], remaining, "%02" PRIX8, bytes[i]);
-        // '"%02" PRIX8' should always result in 2 characters written.
-        if (written != 2) {
-            return LT_FAIL;
+        if (written < 0) {
+            // Not using errno here, as it is required only by POSIX.
+            LT_LOG_ERROR("snprintf failed, written=%d", written);
+            return LT_HAL_ERROR;
+        }
+        // Considering one additional byte for null terminator.
+        else if (written >= remaining) {
+            LT_LOG_ERROR("snprintf output was truncated, written=%d, remaining=%zu", written,
+                         remaining);
+            return LT_HAL_ERROR;
+        }
+        else if (written != 2) {
+            LT_LOG_ERROR("snprintf wrote incorrect number of chars, expected 2, got %d", written);
+            return LT_HAL_ERROR;
         }
     }
     out_buf[bytes_cnt * 2] = '\0';


### PR DESCRIPTION
## Description

This PR adds checks according to cert-err33-c with the exception of `fflush`.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage
