### PR TITLE
ETR01SDK-647: Fix `main.c` code of STM32s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+### Added
+
+### Fixed
+- STM32 examples and tests: replace `return` in the `main()` function with `Error_Handler()`, enhanced error logging.
+
+### Removed
+
 ## [4.0.0]
 
 ### Changed

--- a/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/fw_update/Src/main.c
@@ -383,7 +383,9 @@ int main(void)
     /* Initialize BSP Led for LED2 */
     BSP_LED_Init(LED2);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "DBG_UART_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -391,7 +393,9 @@ int main(void)
         Do not forget to do this in your application, as the
         Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -414,7 +418,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -462,7 +466,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -475,14 +479,14 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     printf("Versions to update to:\n");
@@ -494,7 +498,7 @@ int main(void)
     if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 #endif
 
@@ -513,14 +517,14 @@ int main(void)
 #endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
 #if LT_DISABLE_MAINTENANCE_MODE
@@ -531,7 +535,7 @@ int main(void)
     if (LT_OK != disable_maintenance_mode(&lt_handle)) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 #else
     printf(
@@ -544,7 +548,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -562,7 +566,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
         demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -647,6 +653,8 @@ static void SystemClock_Config(void)
  */
 static void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     /* Turn LED2 on */
     BSP_LED_On(LED2);
     while (1) {

--- a/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
@@ -164,7 +164,9 @@ int main(void)
     /* Initialize BSP Led for LED2 */
     BSP_LED_Init(LED2);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "DBG_UART_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -172,7 +174,9 @@ int main(void)
         Do not forget to do this in your application, as the
         Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -195,7 +199,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -243,7 +247,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -256,7 +260,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -273,7 +277,7 @@ int main(void)
                 "-DLT_SH0_KEYS=eng_sample\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+            Error_Handler();
     }
     printf("OK\n");
 
@@ -286,7 +290,7 @@ int main(void)
         lt_session_abort(&lt_handle);
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("\t<-- Message received from TROPIC01: '%s'\n", recv_buf);
 
@@ -296,7 +300,7 @@ int main(void)
         fprintf(stderr, "\nFailed to abort Secure Session, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -305,7 +309,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -323,7 +327,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
         demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -408,6 +414,8 @@ static void SystemClock_Config(void)
  */
 static void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     /* Turn LED2 on */
     BSP_LED_On(LED2);
     while (1) {

--- a/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/hello_world/Src/main.c
@@ -277,7 +277,7 @@ int main(void)
                 "-DLT_SH0_KEYS=eng_sample\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-            Error_Handler();
+        Error_Handler();
     }
     printf("OK\n");
 

--- a/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_f439zi/identify_chip/Src/main.c
@@ -150,7 +150,9 @@ int main(void)
     /* Initialize BSP Led for LED2 */
     BSP_LED_Init(LED2);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "DBG_UART_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -158,7 +160,9 @@ int main(void)
         Do not forget to do this in your application, as the
         Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -181,7 +185,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -229,7 +233,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -242,7 +246,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -254,7 +258,7 @@ int main(void)
         fprintf(stderr, "Failed to get RISC-V FW version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  RISC-V FW version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n", fw_ver[3],
            fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -264,7 +268,7 @@ int main(void)
         fprintf(stderr, "Failed to get SPECT FW version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  SPECT FW version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n", fw_ver[3],
            fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -277,7 +281,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -291,7 +295,7 @@ int main(void)
         fprintf(stderr, "Failed to get RISC-V bootloader version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  RISC-V bootloader version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n",
            fw_ver[3] & 0x7f, fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -302,28 +306,28 @@ int main(void)
         fprintf(stderr, "Failed to print TR01_FW_BANK_FW1 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_FW2, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_FW2 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_SPECT1, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_SPECT1 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_SPECT2, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_SPECT2 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     struct lt_chip_id_t chip_id = {0};
@@ -334,7 +338,7 @@ int main(void)
         fprintf(stderr, "Failed to get chip ID, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     printf("---------------------------------------------------------\n");
@@ -343,7 +347,7 @@ int main(void)
         fprintf(stderr, "Failed to print chip ID, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("---------------------------------------------------------\n");
 
@@ -353,7 +357,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK!\n");
 
@@ -362,7 +366,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -380,7 +384,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
         demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -465,6 +471,8 @@ static void SystemClock_Config(void)
  */
 static void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     /* Turn LED2 on */
     BSP_LED_On(LED2);
     while (1) {

--- a/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/fw_update/Src/main.c
@@ -420,7 +420,9 @@ int main(void)
     /* Configure LED3 */
     BSP_LED_Init(LED3);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "DBG_UART_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -428,7 +430,9 @@ int main(void)
        Do not forget to do this in your application, as the
        Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -451,7 +455,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -499,7 +503,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -512,14 +516,14 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     printf("Versions to update to:\n");
@@ -531,7 +535,7 @@ int main(void)
     if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 #endif
 
@@ -550,14 +554,14 @@ int main(void)
 #endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
 #if LT_DISABLE_MAINTENANCE_MODE
@@ -568,7 +572,7 @@ int main(void)
     if (LT_OK != disable_maintenance_mode(&lt_handle)) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 #else
     printf(
@@ -581,7 +585,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -599,7 +603,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
        demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -617,6 +623,8 @@ int main(void)
  */
 static void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     while (1) {
         /* Toggle LED3 for error */
         BSP_LED_Toggle(LED3);

--- a/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
@@ -314,7 +314,7 @@ int main(void)
                 "-DLT_SH0_KEYS=eng_sample\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-            Error_Handler();
+        Error_Handler();
     }
     printf("OK\n");
 

--- a/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/hello_world/Src/main.c
@@ -201,7 +201,9 @@ int main(void)
     /* Configure LED3 */
     BSP_LED_Init(LED3);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "DBG_UART_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -209,7 +211,9 @@ int main(void)
        Do not forget to do this in your application, as the
        Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -232,7 +236,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -280,7 +284,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -293,7 +297,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -310,7 +314,7 @@ int main(void)
                 "-DLT_SH0_KEYS=eng_sample\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+            Error_Handler();
     }
     printf("OK\n");
 
@@ -323,7 +327,7 @@ int main(void)
         lt_session_abort(&lt_handle);
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("\t<-- Message received from TROPIC01: '%s'\n", recv_buf);
 
@@ -333,7 +337,7 @@ int main(void)
         fprintf(stderr, "\nFailed to abort Secure Session, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -342,7 +346,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -360,7 +364,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
        demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -378,6 +384,8 @@ int main(void)
  */
 static void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     while (1) {
         /* Toggle LED3 for error */
         BSP_LED_Toggle(LED3);

--- a/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_l432kc/identify_chip/Src/main.c
@@ -188,7 +188,9 @@ int main(void)
     /* Configure LED3 */
     BSP_LED_Init(LED3);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "DBG_UART_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -196,7 +198,9 @@ int main(void)
        Do not forget to do this in your application, as the
        Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_Init() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -219,7 +223,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -267,7 +271,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -280,7 +284,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -292,7 +296,7 @@ int main(void)
         fprintf(stderr, "Failed to get RISC-V FW version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  RISC-V FW version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n", fw_ver[3],
            fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -302,7 +306,7 @@ int main(void)
         fprintf(stderr, "Failed to get SPECT FW version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  SPECT FW version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n", fw_ver[3],
            fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -315,7 +319,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -329,7 +333,7 @@ int main(void)
         fprintf(stderr, "Failed to get RISC-V bootloader version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  RISC-V bootloader version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n",
            fw_ver[3] & 0x7f, fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -340,28 +344,28 @@ int main(void)
         fprintf(stderr, "Failed to print TR01_FW_BANK_FW1 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_FW2, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_FW2 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_SPECT1, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_SPECT1 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_SPECT2, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_SPECT2 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     struct lt_chip_id_t chip_id = {0};
@@ -372,7 +376,7 @@ int main(void)
         fprintf(stderr, "Failed to get chip ID, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     printf("---------------------------------------------------------\n");
@@ -381,7 +385,7 @@ int main(void)
         fprintf(stderr, "Failed to print chip ID, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("---------------------------------------------------------\n");
 
@@ -391,7 +395,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK!\n");
 
@@ -400,7 +404,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -418,7 +422,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
        demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -436,6 +442,8 @@ int main(void)
  */
 static void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     while (1) {
         /* Toggle LED3 for error */
         BSP_LED_Toggle(LED3);

--- a/examples/stm32/nucleo_u545re_q/fw_update/Src/main.c
+++ b/examples/stm32/nucleo_u545re_q/fw_update/Src/main.c
@@ -336,7 +336,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -376,7 +376,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -389,14 +389,14 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     printf("Versions to update to:\n");
@@ -408,7 +408,7 @@ int main(void)
     if (LT_OK != check_and_enable_maintenance_mode(&lt_handle)) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 #endif
 
@@ -427,14 +427,14 @@ int main(void)
 #endif
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
     if (get_fw_versions(&lt_handle) != LT_OK) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
 #if LT_DISABLE_MAINTENANCE_MODE
@@ -445,7 +445,7 @@ int main(void)
     if (LT_OK != disable_maintenance_mode(&lt_handle)) {
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 #else
     printf(
@@ -458,7 +458,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -475,7 +475,9 @@ int main(void)
     /* libtropic related code END */
 
     /* Not strictly necessary, but we deinitialize RNG here to demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&hrng) != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = HAL_RNG_DeInit(&hrng);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -648,6 +650,8 @@ PUTCHAR_PROTOTYPE
  */
 void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     __disable_irq();
     while (1) {
     }

--- a/examples/stm32/nucleo_u545re_q/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_u545re_q/hello_world/Src/main.c
@@ -413,6 +413,7 @@ PUTCHAR_PROTOTYPE
 void Error_Handler(void)
 {
     fprintf(stderr, "Error_Handler() was called!\n");
+
     __disable_irq();
     while (1) {
     }

--- a/examples/stm32/nucleo_u545re_q/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_u545re_q/hello_world/Src/main.c
@@ -118,7 +118,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -158,7 +158,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -171,7 +171,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -188,7 +188,7 @@ int main(void)
                 "-DLT_SH0_KEYS=eng_sample\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+            Error_Handler();
     }
     printf("OK\n");
 
@@ -201,7 +201,7 @@ int main(void)
         lt_session_abort(&lt_handle);
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("\t<-- Message received from TROPIC01: '%s'\n", recv_buf);
 
@@ -211,7 +211,7 @@ int main(void)
         fprintf(stderr, "\nFailed to abort Secure Session, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -220,7 +220,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -237,7 +237,9 @@ int main(void)
     /* libtropic related code END */
 
     /* Not strictly necessary, but we deinitialize RNG here to demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&hrng) != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = HAL_RNG_DeInit(&hrng);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -410,6 +412,7 @@ PUTCHAR_PROTOTYPE
  */
 void Error_Handler(void)
 {
+    fprintf(stderr, "Error_Handler() was called!\n");
     __disable_irq();
     while (1) {
     }

--- a/examples/stm32/nucleo_u545re_q/hello_world/Src/main.c
+++ b/examples/stm32/nucleo_u545re_q/hello_world/Src/main.c
@@ -188,7 +188,7 @@ int main(void)
                 "-DLT_SH0_KEYS=eng_sample\n");
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-            Error_Handler();
+        Error_Handler();
     }
     printf("OK\n");
 

--- a/examples/stm32/nucleo_u545re_q/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_u545re_q/identify_chip/Src/main.c
@@ -470,9 +470,9 @@ PUTCHAR_PROTOTYPE
  */
 void Error_Handler(void)
 {
-    __disable_irq();
     fprintf(stderr, "Error_Handler() was called!\n");
 
+    __disable_irq();
     while (1) {
     }
 }

--- a/examples/stm32/nucleo_u545re_q/identify_chip/Src/main.c
+++ b/examples/stm32/nucleo_u545re_q/identify_chip/Src/main.c
@@ -105,7 +105,7 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         fprintf(stderr, "PSA Crypto initialization failed, status=%ld (psa_status_t)\n", status);
-        return -1;
+        Error_Handler();
     }
 
     /* Libtropic handle.
@@ -145,7 +145,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to initialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -158,7 +158,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -170,7 +170,7 @@ int main(void)
         fprintf(stderr, "Failed to get RISC-V FW version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  RISC-V FW version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n", fw_ver[3],
            fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -180,7 +180,7 @@ int main(void)
         fprintf(stderr, "Failed to get SPECT FW version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  SPECT FW version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n", fw_ver[3],
            fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -193,7 +193,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -207,7 +207,7 @@ int main(void)
         fprintf(stderr, "Failed to get RISC-V bootloader version, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("  RISC-V bootloader version: %" PRIX8 ".%" PRIX8 ".%" PRIX8 " (.%" PRIX8 ")\n",
            fw_ver[3] & 0x7f, fw_ver[2], fw_ver[1], fw_ver[0]);
@@ -218,28 +218,28 @@ int main(void)
         fprintf(stderr, "Failed to print TR01_FW_BANK_FW1 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_FW2, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_FW2 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_SPECT1, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_SPECT1 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     ret = lt_print_fw_header(&lt_handle, TR01_FW_BANK_SPECT2, printf);
     if (ret != LT_OK) {
         fprintf(stderr, "Failed to print TR01_FW_BANK_SPECT2 header, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     struct lt_chip_id_t chip_id = {0};
@@ -250,7 +250,7 @@ int main(void)
         fprintf(stderr, "Failed to get chip ID, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
 
     printf("---------------------------------------------------------\n");
@@ -259,7 +259,7 @@ int main(void)
         fprintf(stderr, "Failed to print chip ID, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("---------------------------------------------------------\n");
 
@@ -269,7 +269,7 @@ int main(void)
         fprintf(stderr, "\nlt_reboot() failed, ret=%s\n", lt_ret_verbose(ret));
         lt_deinit(&lt_handle);
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK!\n");
 
@@ -278,7 +278,7 @@ int main(void)
     if (LT_OK != ret) {
         fprintf(stderr, "\nFailed to deinitialize handle, ret=%s\n", lt_ret_verbose(ret));
         mbedtls_psa_crypto_free();
-        return -1;
+        Error_Handler();
     }
     printf("OK\n");
 
@@ -295,7 +295,9 @@ int main(void)
     /* libtropic related code END */
 
     /* Not strictly necessary, but we deinitialize RNG here to demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&hrng) != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = HAL_RNG_DeInit(&hrng);
+    if (hal_ret != HAL_OK) {
+        fprintf(stderr, "HAL_RNG_DeInit() failed, hal_ret=%u\n", hal_ret);
         Error_Handler();
     }
 
@@ -469,6 +471,8 @@ PUTCHAR_PROTOTYPE
 void Error_Handler(void)
 {
     __disable_irq();
+    fprintf(stderr, "Error_Handler() was called!\n");
+
     while (1) {
     }
 }

--- a/tests/functional/stm32/nucleo_f439zi/Src/main.c
+++ b/tests/functional/stm32/nucleo_f439zi/Src/main.c
@@ -164,7 +164,11 @@ int main(void)
     /* Initialize BSP Led for LED2 */
     BSP_LED_Init(LED2);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret;
+
+    hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        LT_LOG_ERROR("DBG_UART_Init() failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
 
@@ -172,7 +176,10 @@ int main(void)
         Do not forget to do this in your application, as the
         Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        LT_LOG_ERROR("HAL_RNG_Init() failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
 
@@ -187,13 +194,13 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         LT_LOG_ERROR("PSA Crypto initialization failed, status=%d (psa_status_t)", status);
-        return -1;
+        Error_Handler();
     }
 #elif LT_USE_WOLFCRYPT
     int ret = wolfCrypt_Init();
     if (ret != 0) {
         LT_LOG_ERROR("WolfCrypt initialization failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
-        return ret;
+        Error_Handler();
     }
 #endif
 
@@ -235,7 +242,7 @@ int main(void)
     ret = wolfCrypt_Cleanup();
     if (ret != 0) {
         LT_LOG_ERROR("WolfCrypt cleanup failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
-        return ret;
+        Error_Handler();
     }
 #endif
 
@@ -250,7 +257,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
         demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        LT_LOG_ERROR("HAL_RNG_DeInit failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
 
@@ -335,6 +344,8 @@ static void SystemClock_Config(void)
  */
 static void Error_Handler(void)
 {
+    LT_LOG_ERROR("Error_Handler() was called!");
+
     /* Turn LED2 on */
     BSP_LED_On(LED2);
     while (1) {

--- a/tests/functional/stm32/nucleo_l432kc/Src/main.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/main.c
@@ -202,7 +202,11 @@ int main(void)
     /* Configure LED3 */
     BSP_LED_Init(LED3);
 
-    if (DBG_UART_Init() != HAL_OK) {
+    HAL_StatusTypeDef hal_ret;
+
+    hal_ret = DBG_UART_Init();
+    if (hal_ret != HAL_OK) {
+        LT_LOG_ERROR("DBG_UART_Init() failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
 
@@ -210,10 +214,13 @@ int main(void)
        Do not forget to do this in your application, as the
        Libtropic HAL uses RNG for entropy source! */
     RNGHandle.Instance = RNG;
-    if (HAL_RNG_Init(&RNGHandle) != HAL_OK) {
+
+    hal_ret = HAL_RNG_Init(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        LT_LOG_ERROR("HAL_RNG_Init() failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
-
+    
     /* libtropic related code BEGIN */
     /* libtropic related code BEGIN */
     /* libtropic related code BEGIN */
@@ -225,13 +232,13 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         LT_LOG_ERROR("PSA Crypto initialization failed, status=%d (psa_status_t)", status);
-        return -1;
+        Error_Handler();
     }
 #elif LT_USE_WOLFCRYPT
     int ret = wolfCrypt_Init();
     if (ret != 0) {
         LT_LOG_ERROR("WolfCrypt initialization failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
-        return ret;
+        Error_Handler();
     }
 #endif
 
@@ -273,7 +280,7 @@ int main(void)
     ret = wolfCrypt_Cleanup();
     if (ret != 0) {
         LT_LOG_ERROR("WolfCrypt cleanup failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
-        return ret;
+        Error_Handler();
     }
 #endif
 
@@ -288,7 +295,9 @@ int main(void)
 
     /* Not strictly necessary, but we deinitialize RNG here to
        demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&RNGHandle) != HAL_OK) {
+    hal_ret = HAL_RNG_DeInit(&RNGHandle);
+    if (hal_ret != HAL_OK) {
+        LT_LOG_ERROR("HAL_RNG_DeInit failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
 
@@ -306,6 +315,8 @@ int main(void)
  */
 static void Error_Handler(void)
 {
+    LT_LOG_ERROR("Error_Handler() was called!");
+
     while (1) {
         /* Toggle LED3 for error */
         BSP_LED_Toggle(LED3);

--- a/tests/functional/stm32/nucleo_l432kc/Src/main.c
+++ b/tests/functional/stm32/nucleo_l432kc/Src/main.c
@@ -220,7 +220,7 @@ int main(void)
         LT_LOG_ERROR("HAL_RNG_Init() failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
-    
+
     /* libtropic related code BEGIN */
     /* libtropic related code BEGIN */
     /* libtropic related code BEGIN */

--- a/tests/functional/stm32/nucleo_u545re_q/Src/main.c
+++ b/tests/functional/stm32/nucleo_u545re_q/Src/main.c
@@ -109,13 +109,13 @@ int main(void)
     psa_status_t status = psa_crypto_init();
     if (status != PSA_SUCCESS) {
         LT_LOG_ERROR("PSA Crypto initialization failed, status=%d (psa_status_t)", status);
-        return -1;
+        Error_Handler();
     }
 #elif LT_USE_WOLFCRYPT
     int ret = wolfCrypt_Init();
     if (ret != 0) {
         LT_LOG_ERROR("WolfCrypt initialization failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
-        return ret;
+        Error_Handler();
     }
 #endif
 
@@ -154,7 +154,7 @@ int main(void)
     ret = wolfCrypt_Cleanup();
     if (ret != 0) {
         LT_LOG_ERROR("WolfCrypt cleanup failed, ret=%d (%s)", ret, wc_GetErrorString(ret));
-        return ret;
+        Error_Handler();
     }
 #endif
 
@@ -168,7 +168,9 @@ int main(void)
     /* libtropic related code END */
 
     /* Not strictly necessary, but we deinitialize RNG here to demonstrate proper usage. */
-    if (HAL_RNG_DeInit(&hrng) != HAL_OK) {
+    HAL_StatusTypeDef hal_ret = HAL_RNG_DeInit(&hrng);
+    if (hal_ret != HAL_OK) {
+        LT_LOG_ERROR("HAL_RNG_DeInit failed, hal_ret=%u", hal_ret);
         Error_Handler();
     }
 
@@ -341,6 +343,8 @@ PUTCHAR_PROTOTYPE
  */
 void Error_Handler(void)
 {
+    LT_LOG_ERROR("Error_Handler() was called!");
+
     __disable_irq();
     while (1) {
     }


### PR DESCRIPTION
## Description

Main function of STM32 projects (both examples and tests) contained `return` keywords. In this PR, I replace it with `Error_Handler()` call instead. Also, a message to `Error_Handler()` was added, so it's clear that an error occured.

---

## Type of Change

Select the type(s) that best describe your change:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---

## Optional Checks
You can enable optional CI jobs by checking following boxes. For example, coverage job is useful when modifying or implementing new tests.

- [ ] Measure Test Coverage