### PR TITLE
fix(tcp): receive fragmented responses correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - STM32 examples and tests: replace `return` in the `main()` function with `Error_Handler()`, enhanced error logging.
 - Added `const` to `struct lt_config_obj_desc_t cfg_desc_table` to save RAM space (it is never modified).
 - Marked `lt_ret_strs` pointer with `const`.
+- TCP HAL: correctly receive fragmented responses and reject response payload lengths that exceed the receive buffer.
 
 ### Removed
 

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -119,6 +119,12 @@ static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr,
         return LT_HAL_ERROR;
     }
 
+    if (dev->rx_buffer.len > LT_TCP_MAX_PAYLOAD_LEN) {
+        LT_LOG_ERROR("Received payload length %" PRIu16 " exceeds maximum %u.", dev->rx_buffer.len,
+                     LT_TCP_MAX_PAYLOAD_LEN);
+        return LT_HAL_ERROR;
+    }
+
     LT_LOG_DEBUG("Length field: %" PRIu16 ".", dev->rx_buffer.len);
     nb_bytes_to_receive += dev->rx_buffer.len;
     nb_bytes_received_total += nb_bytes_received;

--- a/hal/posix/tcp/libtropic_port_posix_tcp.c
+++ b/hal/posix/tcp/libtropic_port_posix_tcp.c
@@ -130,7 +130,8 @@ static lt_ret_t communicate(lt_dev_posix_tcp_t *dev, int *tx_payload_length_ptr,
 
         for (int i = 0; i < LT_TCP_RX_ATTEMPTS; i++) {
             LT_LOG_DEBUG("Attempting to receive remaining bytes: attempt #%d.", i);
-            nb_bytes_received = recv(dev->socket_fd, dev->rx_buffer.buff, LT_TCP_MAX_RECV_SIZE, 0);
+            nb_bytes_received = recv(dev->socket_fd, rx_ptr,
+                                     nb_bytes_to_receive - nb_bytes_received_total, 0);
 
             if (nb_bytes_received < 0) {
                 LT_LOG_ERROR("Receive failed, errno=%d (%s)", errno, strerror(errno));


### PR DESCRIPTION
## Description

Resolves #551 

The variable `rx_ptr` seems useless, but it should actually be used in `recv()`.

---

## Type of Change

Select the type(s) that best describe your change:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Build system or toolchain update
- [ ] 🔒 Security improvement
- [ ] Other (please describe):

---

## Checklist

Before submitting, please confirm that you have completed the following:

- [x] I opened the Pull Request to the **develop** branch
- [x] I followed the project's [**code guidelines**](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)  
- [x] I formatted the code using **clang-format** with the [recommended configuration](https://github.com/tropicsquare/libtropic/blob/develop/CONTRIBUTING.md)
- [x] I updated the [**changelog**](https://github.com/tropicsquare/libtropic/blob/develop/CHANGELOG.md), or this change does not require it (e.g., internal or non-functional update)  
- [x] The project **builds without errors or warnings**  
- [x] I have **verified the functionality against the hardware/model** as applicable  
- [x] I have ensured that public APIs remain backward compatible (if applicable)  
- [x] This PR is ready for review by maintainers (no WIP commits left) and marked as Ready for Review

---